### PR TITLE
No need to exit the whole program when BING API key is not there

### DIFF
--- a/discovery/bingsearch.py
+++ b/discovery/bingsearch.py
@@ -69,7 +69,8 @@ class search_bing:
 		if api=="yes":
 				if self.bingApi=="":
 					print "Please insert your API key in the discovery/bingsearch.py"
-					sys.exit()
+					#sys.exit()
+					return
 		while (self.counter < self.limit):
 			if api=="yes":
 				self.do_search_api()

--- a/theHarvester.py
+++ b/theHarvester.py
@@ -160,6 +160,13 @@ def start(argv):
 	else:
 		for emails in all_emails:
 			print emails 
+	print "\n[+] Possible hosts found"
+	print " -----------"
+	if all_hosts == []:
+		print "No hosts found"
+	else:
+		for h in all_hosts:
+			print h
 	print "\n[+] Hosts found"
 	print " -----------"
 	if all_hosts == []:


### PR DESCRIPTION
Thanks for theHarvester, it's a nice idea. Here is a very small (trivial) patch important for first time users i believe.

No need to exit the whole program when the BING API key is not there.

theHarvester discards all the previously fetched information when doing so, thus wasting some time.

a return is enough.

Example of the problem:

```
$ ./theHarvester.py -l 100 -b all -d mytarget.com

*************************************
*TheHarvester Ver. 2.0 (reborn)     *
*Coded by Christian Martorella      *
*Edge-Security Research             *
*cmartorella@edge-security.com      *
*************************************


Full harvest..
[-] Searching in Google..
    Searching 100 results...
    Searching 200 results...
[-] Searching in PGP Key server..
[-] Searching in Bing..
Please insert your API key in the discovery/bingsearch.py
$
```

Here it returned directly (due to the exit()) and did not display what it had gathered so far.
