### PR TITLE
fix incorrect file closing

### DIFF
--- a/theHarvester.py
+++ b/theHarvester.py
@@ -430,7 +430,8 @@ def start(argv):
             for x in vhost:
                 file.write('<vhost>' + x + '</vhost>')
             file.write('</theHarvester>')
-            file.close
+            file.flush()
+            file.close()
             print "Files saved!"
         except Exception as er:
             print "Error saving XML file: " + er


### PR DESCRIPTION
After writing to save emails, hosts, and vhosts to a file, the `file` object never properly calls `.close()` (but invoke as an attribute `.close`). This will always trigger `Exception` thereby never exporting the contents in the first place.