### PR TITLE
Update usage example to show how to save output to a file

### DIFF
--- a/theHarvester.py
+++ b/theHarvester.py
@@ -55,7 +55,7 @@ def usage():
     print "            google 100 to 100, and pgp doesn't use this option)"
     print "       -h: use SHODAN database to query discovered hosts"
     print "\nExamples:"
-    print "        " + comm + " -d microsoft.com -l 500 -b google -h myresults.html"
+    print "        " + comm + " -d microsoft.com -l 500 -b google -f myresults.html"
     print "        " + comm + " -d microsoft.com -b pgp"
     print "        " + comm + " -d microsoft -l 200 -b linkedin"
     print "        " + comm + " -d apple.com -b googleCSE -l 500 -s 300\n"


### PR DESCRIPTION
Previously, a filename was specified, but the -f option was missing.