### PR TITLE
Filename now strips after the last full stop, not the first one

### DIFF
--- a/theHarvester.py
+++ b/theHarvester.py
@@ -400,7 +400,7 @@ def start(argv):
             print e
             print "Error creating the file"
         try:
-            filename = filename.split(".")[0] + ".xml"
+            filename = filename.rsplit(".", 1)[0] + ".xml"
             file = open(filename, 'w')
             file.write('<?xml version="1.0" encoding="UTF-8"?><theHarvester>')
             for x in all_emails:


### PR DESCRIPTION
For the current implementation,  feeding a filename to save such as 

`-f /foo/website.com/results.extension`
results in the file being saved as 
`/foo/website.xml`

This quick fix changes that to have the expected result of saving it as:
`/foo/website.com/results.xml`.
Utilizing `x.rsplit`, instead of `x.split`.