### PR TITLE
Fix local variable 'full' referenced before assignment

### DIFF
--- a/theHarvester.py
+++ b/theHarvester.py
@@ -308,6 +308,7 @@ def start(argv):
     print "------------------------------------"
     if all_hosts == []:
         print "No hosts found"
+        full = []
     else:
         all_hosts=sorted(set(all_hosts))
         print "[-] Resolving hostnames IPs... "


### PR DESCRIPTION
Saving a file will fail if no hosts are found because it tries to loop through this 'full' variable that was never assigned