### PR TITLE
Fix incorrect usage example

### DIFF
--- a/theHarvester.py
+++ b/theHarvester.py
@@ -308,6 +308,7 @@ def start(argv):
     print "------------------------------------"
     if all_hosts == []:
         print "No hosts found"
+        full = []
     else:
         all_hosts=sorted(set(all_hosts))
         print "[-] Resolving hostnames IPs... "

--- a/theHarvester.py
+++ b/theHarvester.py
@@ -55,7 +55,7 @@ def usage():
     print "            google 100 to 100, and pgp doesn't use this option)"
     print "       -h: use SHODAN database to query discovered hosts"
     print "\nExamples:"
-    print "        " + comm + " -d microsoft.com -l 500 -b google -h myresults.html"
+    print "        " + comm + " -d microsoft.com -l 500 -b google -f myresults.html"
     print "        " + comm + " -d microsoft.com -b pgp"
     print "        " + comm + " -d microsoft -l 200 -b linkedin"
     print "        " + comm + " -d apple.com -b googleCSE -l 500 -s 300\n"


### PR DESCRIPTION
Branched from my pull request #68. 

Current usage example uses -h instead of -f to generate output files. This fixes issue #62.