### PR TITLE
Update pgpsearch.py

### DIFF
--- a/discovery/pgpsearch.py
+++ b/discovery/pgpsearch.py
@@ -26,6 +26,7 @@ class search_pgp:
             returncode, returnmsg, headers = h.getreply()
             self.results = h.getfile().read()
         except Exception, e:
+            print "Unable to connect to PGP server: ",str(e)
             pass
 
     def get_emails(self):


### PR DESCRIPTION
I'm running a test with the standard example:
$ python2 theHarvester.py  -d microsoft.com -b pgp
However, the ```pgp.rediris.es``` server is dead.

This fix in this pull simply prints an error message to show the problem instead of returning 0 results. However, you might want to change the server to pgp.mit.edu as well (currently commented out).