### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests=2.18.4
+requests==2.18.4


### PR DESCRIPTION
Installing with `pip install -r requirements.txt` fails currently because `=` is not a valid operator.