### PR TITLE
Multiple data sources support

### DIFF
--- a/theHarvester.py
+++ b/theHarvester.py
@@ -81,7 +81,7 @@ def start():
     word = args.domain
 
     if args.source is not None:
-        engines = set(args.source.split(','))
+        engines = set(map(str.strip, args.source.split(',')))
         if set(engines).issubset(Core.get_supportedengines()):
             print(f'\033[94m[*] Target: {word} \n \033[0m')
             for engineitem in engines:


### PR DESCRIPTION
Hello.
Adds support for multiple data sources with simple syntax:
`theharvester -d microsoft.com -b 'pgp, virustotal'`
theharvester was confused to me when I tried to pass '-b' arguments with space and without quotes.