### PR TITLE
Use project requirements file to resolve dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6-alpine3.7
 RUN mkdir /app
-RUN pip3 install requests beautifulsoup4 texttable plotly shodan
 WORKDIR /app
 COPY . /app
+RUN pip3 install -r requirements.txt
 RUN chmod +x *.py
 ENTRYPOINT ["/app/theHarvester.py"]


### PR DESCRIPTION
The original `Dockerfile` installation was missing the `pyyaml` dependency in the `pip3 install` phase. Updating the container build to simply use the projects `requirements.txt` file both solves this issue as well as any future potential dependency changes.