### PR TITLE
Fix missing dependences

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ PyYaml>=3.13
 requests>=2.21.0
 shodan>=1.11.1
 texttable>=1.6.1
+decorator
+pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 beautifulsoup4>=4.7.1
 censys==0.0.8
+decorator
 plotly>=3.6.1
 pytest>=4.3.0
+pytz
 PyYaml>=3.13
 requests>=2.21.0
 shodan>=1.11.1
 texttable>=1.6.1
-decorator
-pytz


### PR DESCRIPTION
The `pytz` and `decorator` python libraries are misisng from deps-