### PR TITLE
Fix imports for module

### DIFF
--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 
-from .discovery import *
-from .discovery.constants import *
-from .lib import hostchecker
-from .lib import htmlExport
-from .lib import reportgraph
-from .lib import stash
-from .lib import statichtmlgenerator
-from .lib.core import *
+from theHarvester.discovery import *
+from theHarvester.discovery.constants import *
+from theHarvester.lib import hostchecker
+from theHarvester.lib import htmlExport
+from theHarvester.lib import reportgraph
+from theHarvester.lib import stash
+from theHarvester.lib import statichtmlgenerator
+from theHarvester.lib.core import *
 from platform import python_version
 import argparse
 import datetime

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 
-from theHarvester.discovery import *
-from theHarvester.discovery.constants import *
-from theHarvester.lib import hostchecker
-from theHarvester.lib import htmlExport
-from theHarvester.lib import reportgraph
-from theHarvester.lib import stash
-from theHarvester.lib import statichtmlgenerator
-from theHarvester.lib.core import *
+from .discovery import *
+from .discovery.constants import *
+from .lib import hostchecker
+from .lib import htmlExport
+from .lib import reportgraph
+from .lib import stash
+from .lib import statichtmlgenerator
+from .lib.core import *
 from platform import python_version
 import argparse
 import datetime

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -153,7 +153,7 @@ def start():
 
                 elif engineitem == 'cymon':
                     print('\033[94m[*] Searching Cymon. \033[0m')
-                    from discovery import cymon
+                    from theHarvester.discovery import cymon
                     # Import locally or won't work.
                     search = cymon.search_cymon(word)
                     search.process()
@@ -164,7 +164,7 @@ def start():
                 elif engineitem == 'dnsdumpster':
                     try:
                         print('\033[94m[*] Searching DNSdumpster. \033[0m')
-                        from discovery import dnsdumpster
+                        from theHarvester.discovery import dnsdumpster
                         search = dnsdumpster.search_dnsdumpster(word)
                         search.process()
                         hosts = filter(search.get_hostnames())
@@ -191,7 +191,7 @@ def start():
 
                 elif engineitem == 'duckduckgo':
                     print('\033[94m[*] Searching DuckDuckGo. \033[0m')
-                    from discovery import duckduckgosearch
+                    from theHarvester.discovery import duckduckgosearch
                     search = duckduckgosearch.SearchDuckDuckGo(word, limit)
                     search.process()
                     emails = filter(search.get_emails())
@@ -225,7 +225,7 @@ def start():
 
                 elif engineitem == 'hunter':
                     print('\033[94m[*] Searching Hunter. \033[0m')
-                    from discovery import huntersearch
+                    from theHarvester.discovery import huntersearch
                     # Import locally or won't work.
                     try:
                         search = huntersearch.SearchHunter(word, limit, start)
@@ -245,7 +245,7 @@ def start():
 
                 elif engineitem == 'intelx':
                     print('\033[94m[*] Searching Intelx. \033[0m')
-                    from discovery import intelxsearch
+                    from theHarvester.discovery import intelxsearch
                     # Import locally or won't work.
                     try:
                         search = intelxsearch.SearchIntelx(word, limit)
@@ -291,7 +291,7 @@ def start():
 
                 elif engineitem == 'securityTrails':
                     print('\033[94m[*] Searching SecurityTrails. \033[0m')
-                    from discovery import securitytrailssearch
+                    from theHarvester.discovery import securitytrailssearch
                     try:
                         search = securitytrailssearch.search_securitytrail(word)
                         search.process()
@@ -323,7 +323,7 @@ def start():
 
                 elif engineitem == 'trello':
                     print('\033[94m[*] Searching Trello. \033[0m')
-                    from discovery import trello
+                    from theHarvester.discovery import trello
                     # Import locally or won't work.
                     search = trello.search_trello(word, limit)
                     search.process()
@@ -407,7 +407,7 @@ def start():
                         pass
 
                     print('\033[94m[*] Searching Censys. \033[0m')
-                    from discovery import censys
+                    from theHarvester.discovery import censys
                     search = censys.SearchCensys(word, limit)
                     search.process()
                     ips = search.get_ipaddresses()
@@ -431,7 +431,7 @@ def start():
                     db.store_all(word, all_hosts, 'host', 'CRTsh')
 
                     print('\033[94m[*] Searching Cymon. \033[0m')
-                    from discovery import cymon
+                    from theHarvester.discovery import cymon
                     # Import locally or won't work.
                     search = cymon.search_cymon(word)
                     search.process()
@@ -441,7 +441,7 @@ def start():
 
                     try:
                         print('\033[94m[*] Searching DNSdumpster. \033[0m')
-                        from discovery import dnsdumpster
+                        from theHarvester.discovery import dnsdumpster
                         search = dnsdumpster.search_dnsdumpster(word)
                         search.process()
                         hosts = filter(search.get_hostnames())
@@ -466,7 +466,7 @@ def start():
                         print(f'An exception has occurred in Dogpile: {e}')
 
                     print('\033[94m[*] Searching DuckDuckGo. \033[0m')
-                    from discovery import duckduckgosearch
+                    from theHarvester.discovery import duckduckgosearch
                     search = duckduckgosearch.SearchDuckDuckGo(word, limit)
                     search.process()
                     emails = filter(search.get_emails())
@@ -498,7 +498,7 @@ def start():
                     db.store_all(word, all_hosts, 'host', 'google-certificates')
 
                     print('\033[94m[*] Searching Hunter. \033[0m')
-                    from discovery import huntersearch
+                    from theHarvester.discovery import huntersearch
                     # Import locally.
                     try:
                         search = huntersearch.SearchHunter(word, limit, start)
@@ -518,7 +518,7 @@ def start():
                             pass
 
                     print('\033[94m[*] Searching Intelx. \033[0m')
-                    from discovery import intelxsearch
+                    from theHarvester.discovery import intelxsearch
                     # Import locally or won't work.
                     try:
                         search = intelxsearch.SearchIntelx(word, limit)
@@ -560,7 +560,7 @@ def start():
                     db.store_all(word, all_hosts, 'host', 'netcraft')
 
                     print('\033[94m[*] Searching SecurityTrails. \033[0m')
-                    from discovery import securitytrailssearch
+                    from theHarvester.discovery import securitytrailssearch
                     try:
                         search = securitytrailssearch.search_securitytrail(word)
                         search.process()
@@ -590,7 +590,7 @@ def start():
                         pass
 
                     print('\033[94m[*] Searching Trello. \033[0m')
-                    from discovery import trello
+                    from theHarvester.discovery import trello
                     # Import locally or won't work.
                     search = trello.search_trello(word, limit)
                     search.process()

--- a/theHarvester/discovery/DNS/Base.py
+++ b/theHarvester/discovery/DNS/Base.py
@@ -12,7 +12,7 @@ This code is covered by the standard Python License.
 import socket
 import time
 
-from theHarvester.discovery.DNS import Type, Class, Opcode
+from . import Type, Class, Opcode
 import asyncore
 
 class DNSError(Exception):

--- a/theHarvester/discovery/DNS/Base.py
+++ b/theHarvester/discovery/DNS/Base.py
@@ -12,7 +12,7 @@ This code is covered by the standard Python License.
 import socket
 import time
 
-from . import Type, Class, Opcode
+from theHarvester.discovery.DNS import Type, Class, Opcode
 import asyncore
 
 class DNSError(Exception):


### PR DESCRIPTION
This is to fix the errors you receive when you try to use the app after installing as a module
```
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.7/site-packages/theHarvester-3.0.6-py3.7.egg/theHarvester/__main__.py", line 965, in entry_point
    start()
  File "/home/user/.local/lib/python3.7/site-packages/theHarvester-3.0.6-py3.7.egg/theHarvester/__main__.py", line 294, in start
    from discovery import securitytrailssearch
ModuleNotFoundError: No module named 'discovery'
None
```