### PR TITLE
Solve issue #259

### DIFF
--- a/theHarvester.py
+++ b/theHarvester.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 
 # Note: This script runs theHarvester
+from platform import python_version
+import sys
+if python_version()[0:3] < '3.6':
+    print('\033[93m[!] Make sure you have Python 3.6+ installed, quitting.\n\n \033[0m')
+    sys.exit(1)
 
 from theHarvester import __main__
 __main__.entry_point()

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -8,7 +8,6 @@ from theHarvester.lib import reportgraph
 from theHarvester.lib import stash
 from theHarvester.lib import statichtmlgenerator
 from theHarvester.lib.core import *
-from platform import python_version
 import argparse
 import datetime
 import ipaddress
@@ -940,9 +939,6 @@ def start():
 
 
 def entry_point():
-    if python_version()[0:3] < '3.6':
-        print('\033[93m[!] Make sure you have Python 3.6+ installed, quitting.\n\n \033[0m')
-        sys.exit(1)
     try:
         start()
     except KeyboardInterrupt:


### PR DESCRIPTION
 This is a way to solve #259 

Delay importing the main to avoid the SyntaxError. 

$ ./theHarvester.py
Traceback (most recent call last):
  File "./theHarvester.py", line 5, in <module>
    from theHarvester import __main__
  File
"theHarvester/__main__.py",
line 96
    print(f'\033[94m[*] Target: {word} \n \033[0m')
                                                 ^
SyntaxError: invalid syntax