### PR TITLE
Resolving plotly deprecation issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4>=4.7.1
 censys==0.0.8
-plotly>=3.10.0
+plotly==3.10.0
 pytest>=4.6.3
 PyYaml>=5.1.1
 requests>=2.22.0


### PR DESCRIPTION
In the old version of [requirements.txt](https://github.com/laramies/theHarvester/blob/master/requirements.txt) `plotly>=3.10.0` is being used which returns deprecation issue. It can be fixed by using `plotly==3.10.0` instead