### PR TITLE
Dockerfile fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.6-alpine3.7
 RUN mkdir /app
 WORKDIR /app
 COPY . /app
+RUN apk add build-base
 RUN pip3 install -r requirements.txt
 RUN chmod +x *.py
 ENTRYPOINT ["/app/theHarvester.py"]


### PR DESCRIPTION
This PR allows to run:
```
docker built -t the/harvester .
```

Otherwise, `pip` complains that `gcc` is not installed.