### PR TITLE
Externalise code repetition to method

### DIFF
--- a/tests/test_theHarvester.py
+++ b/tests/test_theHarvester.py
@@ -8,18 +8,18 @@ domain = 'metasploit.com'
 sys.argv = args = [os.path.curdir + 'theHarvester.py', '-d', domain, '-b', 'domain']
 
 
-@patch('theHarvester.discovery.baidusearch.SearchBaidu')
+@patch('theHarvester.discovery.certspottersearch.SearchCertspoter')
 @patch('theHarvester.lib.stash.stash_manager')
-def test_baidu(stash, search_engine):
+def test_certspotter(stash, search_engine):
     mock_stash = stash()
-    args[-1] = 'baidu'
+    args[-1] = 'certspotter'
     theHarvester.start()
-    assert mock_stash.store_all.call_count == 2
+    assert mock_stash.store_all.call_count == 1
 
 
 @patch('theHarvester.discovery.crtsh.SearchCrtsh')
 @patch('theHarvester.lib.stash.stash_manager')
-def test_certsh(stash, search_engine):
+def test_crtsh(stash, search_engine):
     mock_stash = stash()
     args[-1] = 'crtsh'
     theHarvester.start()
@@ -37,8 +37,125 @@ def test_dnsdumpster(stash, search_engine):
 
 @patch('theHarvester.discovery.dogpilesearch.SearchDogpile')
 @patch('theHarvester.lib.stash.stash_manager')
-def test_dogpilesearch(stash, search_engine):
+def test_dogpile(stash, search_engine):
     mock_stash = stash()
     args[-1] = 'dogpile'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 2
+
+
+@patch('theHarvester.discovery.duckduckgosearch.SearchDuckDuckGo')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_duckduckgo(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'duckduckgo'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 2
+
+
+@patch('theHarvester.discovery.exaleadsearch.SearchExalead')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_exalead(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'exalead'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 2
+
+
+@patch('theHarvester.discovery.googlesearch.SearchGoogle')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_google(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'google'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 2
+
+
+@patch('theHarvester.discovery.linkedinsearch.SearchLinkedin')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_linkedin(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'linkedin'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 1
+
+
+@patch('theHarvester.discovery.linkedinsearch.SearchLinkedin')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_linkedin_links(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'linkedin_links'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 1
+
+
+@patch('theHarvester.discovery.netcraft.SearchNetcraft')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_netcraft(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'netcraft'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 1
+
+
+@patch('theHarvester.discovery.otxsearch.SearchOtx')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_otx(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'otx'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 2
+
+
+@patch('theHarvester.discovery.securitytrailssearch.SearchSecuritytrail')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_security_trails(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'securityTrails'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 2
+
+
+@patch('theHarvester.discovery.suip.SearchSuip')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_suip(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'suip'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 1
+
+
+@patch('theHarvester.discovery.threatcrowd.SearchThreatcrowd')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_threatcrowd(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'threatcrowd'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 1
+
+
+@patch('theHarvester.discovery.twittersearch.SearchTwitter')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_twitter(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'twitter'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 1
+
+
+@patch('theHarvester.discovery.virustotal.SearchVirustotal')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_virustotal(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'virustotal'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 1
+
+
+@patch('theHarvester.discovery.yahoosearch.SearchYahoo')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_yahoo(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'yahoo'
     theHarvester.start()
     assert mock_stash.store_all.call_count == 2

--- a/tests/test_theHarvester.py
+++ b/tests/test_theHarvester.py
@@ -1,0 +1,44 @@
+import os
+import sys
+from unittest.mock import patch
+
+import theHarvester.__main__ as theHarvester
+
+domain = 'metasploit.com'
+sys.argv = args = [os.path.curdir + 'theHarvester.py', '-d', domain, '-b', 'domain']
+
+
+@patch('theHarvester.discovery.baidusearch.SearchBaidu')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_baidu(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'baidu'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 2
+
+
+@patch('theHarvester.discovery.crtsh.SearchCrtsh')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_certsh(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'crtsh'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 1
+
+
+@patch('theHarvester.discovery.dnsdumpster.SearchDnsDumpster')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_dnsdumpster(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'dnsdumpster'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 1
+
+
+@patch('theHarvester.discovery.dogpilesearch.SearchDogpile')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_dogpilesearch(stash, search_engine):
+    mock_stash = stash()
+    args[-1] = 'dogpile'
+    theHarvester.start()
+    assert mock_stash.store_all.call_count == 2

--- a/tests/test_theHarvester.py
+++ b/tests/test_theHarvester.py
@@ -1,161 +1,195 @@
 import os
 import sys
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
-import theHarvester.__main__ as theHarvester
+import theHarvester.__main__ as harvester
 
 domain = 'metasploit.com'
 sys.argv = args = [os.path.curdir + 'theHarvester.py', '-d', domain, '-b', 'domain']
 
 
+@patch('theHarvester.discovery.baidusearch.SearchBaidu')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_baidu(stash, search_engine):
+    args[-1] = 'baidu'
+    harvester.start()
+    assert stash().store_all.call_count == 2
+
+
+@patch('theHarvester.discovery.bingsearch.SearchBing')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_bing(stash, search_engine):
+    args[-1] = 'bing'
+    harvester.start()
+    args[-1] = 'bingapi'
+    harvester.start()
+    assert stash().store_all.call_count == 4
+
+
 @patch('theHarvester.discovery.certspottersearch.SearchCertspoter')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_certspotter(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'certspotter'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 1
+    harvester.start()
+    assert stash().store_all.call_count == 1
 
 
 @patch('theHarvester.discovery.crtsh.SearchCrtsh')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_crtsh(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'crtsh'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 1
+    harvester.start()
+    assert stash().store_all.call_count == 1
 
 
 @patch('theHarvester.discovery.dnsdumpster.SearchDnsDumpster')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_dnsdumpster(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'dnsdumpster'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 1
+    harvester.start()
+    assert stash().store_all.call_count == 1
 
 
 @patch('theHarvester.discovery.dogpilesearch.SearchDogpile')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_dogpile(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'dogpile'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 2
+    harvester.start()
+    assert stash().store_all.call_count == 2
 
 
 @patch('theHarvester.discovery.duckduckgosearch.SearchDuckDuckGo')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_duckduckgo(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'duckduckgo'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 2
+    harvester.start()
+    assert stash().store_all.call_count == 2
+
+
+@patch('theHarvester.discovery.githubcode.SearchGithubCode')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_github(stash, search_engine):
+    args[-1] = 'github-code'
+    harvester.start()
+    assert stash().store_all.call_count == 2
 
 
 @patch('theHarvester.discovery.exaleadsearch.SearchExalead')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_exalead(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'exalead'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 2
+    harvester.start()
+    assert stash().store_all.call_count == 2
 
 
 @patch('theHarvester.discovery.googlesearch.SearchGoogle')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_google(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'google'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 2
+    harvester.start()
+    assert stash().store_all.call_count == 2
+
+
+@patch('theHarvester.discovery.huntersearch.SearchHunter')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_hunter(stash, search_engine):
+    args[-1] = 'hunter'
+    harvester.start()
+    assert stash().store_all.call_count == 2
+
+
+@patch('theHarvester.discovery.intelxsearch.SearchIntelx')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_intelx(stash, search_engine):
+    args[-1] = 'intelx'
+    harvester.start()
+    assert stash().store_all.call_count == 2
 
 
 @patch('theHarvester.discovery.linkedinsearch.SearchLinkedin')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_linkedin(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'linkedin'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 1
+    harvester.start()
+    assert stash().store_all.call_count == 1
 
 
 @patch('theHarvester.discovery.linkedinsearch.SearchLinkedin')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_linkedin_links(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'linkedin_links'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 1
+    harvester.start()
+    assert stash().store_all.call_count == 1
 
 
 @patch('theHarvester.discovery.netcraft.SearchNetcraft')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_netcraft(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'netcraft'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 1
+    harvester.start()
+    assert stash().store_all.call_count == 1
 
 
 @patch('theHarvester.discovery.otxsearch.SearchOtx')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_otx(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'otx'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 2
+    harvester.start()
+    assert stash().store_all.call_count == 2
 
 
 @patch('theHarvester.discovery.securitytrailssearch.SearchSecuritytrail')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_security_trails(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'securityTrails'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 2
+    harvester.start()
+    assert stash().store_all.call_count == 2
 
 
 @patch('theHarvester.discovery.suip.SearchSuip')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_suip(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'suip'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 1
+    harvester.start()
+    assert stash().store_all.call_count == 1
 
 
 @patch('theHarvester.discovery.threatcrowd.SearchThreatcrowd')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_threatcrowd(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'threatcrowd'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 1
+    harvester.start()
+    assert stash().store_all.call_count == 1
+
+
+@patch('theHarvester.discovery.trello.SearchTrello')
+@patch('theHarvester.lib.stash.stash_manager')
+def test_trello(stash, search_engine):
+    search_engine().get_results = MagicMock(return_value=('user@trello.com', 'trello', 'trello.com'))
+    args[-1] = 'trello'
+    harvester.start()
+    assert stash().store_all.call_count == 3
 
 
 @patch('theHarvester.discovery.twittersearch.SearchTwitter')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_twitter(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'twitter'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 1
+    harvester.start()
+    assert stash().store_all.call_count == 1
 
 
 @patch('theHarvester.discovery.virustotal.SearchVirustotal')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_virustotal(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'virustotal'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 1
+    harvester.start()
+    assert stash().store_all.call_count == 1
 
 
 @patch('theHarvester.discovery.yahoosearch.SearchYahoo')
 @patch('theHarvester.lib.stash.stash_manager')
 def test_yahoo(stash, search_engine):
-    mock_stash = stash()
     args[-1] = 'yahoo'
-    theHarvester.start()
-    assert mock_stash.store_all.call_count == 2
+    harvester.start()
+    assert stash().store_all.call_count == 2

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -64,7 +64,7 @@ def start():
     shodan = args.shodan
     start = args.start  # type: int
     takeover_check = False
-    trello_urls = []
+    all_urls = []
     vhost = []
     virtual = args.virtual_host
     word = args.domain  # type: str
@@ -110,7 +110,7 @@ def start():
             email_list, host_names, urls = search_engine.get_results()
             all_emails.extend(email_list)
             host_names = filter(host_names)
-            trello_urls.extend(filter(urls))
+            all_urls.extend(filter(urls))
             all_hosts.extend(host_names)
             db.store_all(word, all_hosts, 'host', source)
             db.store_all(word, all_emails, 'email', source)
@@ -408,7 +408,7 @@ def start():
             print(host)
         host_ip = [netaddr_ip.format() for netaddr_ip in sorted([netaddr.IPAddress(ip) for ip in ips])]
         db.store_all(word, host_ip, 'ip', 'DNS-resolver')
-    length_urls = len(trello_urls)
+    length_urls = len(all_urls)
     if length_urls == 0:
         if len(engines) >= 1 and 'trello' in engines:
             print('\n[*] No Trello URLs found.')
@@ -416,7 +416,7 @@ def start():
         total = length_urls
         print('\n[*] Trello URLs found: ' + str(total))
         print('--------------------')
-        for url in sorted(trello_urls):
+        for url in sorted(all_urls):
             print(url)
 
     # DNS brute force

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -126,9 +126,9 @@ def start():
                     print(usr)
         if store_links:
             links = search_engine.get_links()
-            db.store_all(word, links, 'name', 'linkedin')
+            db.store_all(word, links, 'name', engineitem)
             if len(links) == 0:
-                print('\n[*] No links found Linkedin.\n\n')
+                print('\n[*] No links found.\n\n')
             else:
                 print(f'\n[*] Links found: {len(links)}')
                 print('---------------------')
@@ -176,12 +176,7 @@ def start():
                     from theHarvester.discovery import certspottersearch
                     try:
                         certspotter_search = certspottersearch.SearchCertspoter(word)
-                        certspotter_search.process()
-                        hosts = filter(certspotter_search.get_hostnames())
-                        all_hosts.extend(list(hosts))
-                        all_hosts.extend(hosts)
-                        db = stash.stash_manager()
-                        db.store_all(word, all_hosts, 'host', 'certspotter')
+                        store(certspotter_search, engineitem, None, store_host=True)
                     except Exception as e:
                         print(e)
 

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -101,7 +101,7 @@ def start():
         if store_ip:
             ips_list = search_engine.get_ips()
             all_ip.extend(ips_list)
-            db_stash.store_all(word, ips, 'ip', source)
+            db_stash.store_all(word, all_ip, 'ip', source)
         if store_data:
             data = filter(search_engine.get_data())
             all_hosts.extend(data)
@@ -295,7 +295,7 @@ def start():
                     from theHarvester.discovery import securitytrailssearch
                     try:
                         securitytrails_search = securitytrailssearch.SearchSecuritytrail(word)
-                        store(securitytrails_search, engineitem, )
+                        store(securitytrails_search, engineitem, store_host=True, store_ip=True)
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             print(e)

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -69,8 +69,9 @@ def start():
     virtual = args.virtual_host
     word = args.domain  # type: str
 
-    def store(search_engine, source, process_param=None, store_host=False, store_emails=False, store_ip=False, store_people=False,
-              store_data=False, store_links=False, store_results=False):
+    def store(search_engine: Any, source: str, process_param: Any = None, store_host: bool = False,
+              store_emails: bool = False, store_ip: bool = False, store_people: bool = False,
+              store_data: bool = False, store_links: bool = False, store_results: bool = False) -> None:
         search_engine.process() if process_param is None else search_engine.process(process_param)
         db_stash = stash.stash_manager()
 

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -103,7 +103,7 @@ def start():
             all_ip.extend(ips_list)
             db_stash.store_all(word, ips, 'ip', source)
         if store_data:
-            data = filter(crtsh_search.get_data())
+            data = filter(search_engine.get_data())
             all_hosts.extend(data)
             db.store_all(word, all_hosts, 'host', source)
         if store_results:
@@ -125,7 +125,7 @@ def start():
                 for usr in sorted(list(set(people_list))):
                     print(usr)
         if store_links:
-            links = linkedin_links_search.get_links()
+            links = search_engine.get_links()
             db.store_all(word, links, 'name', 'linkedin')
             if len(links) == 0:
                 print('\n[*] No links found Linkedin.\n\n')

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -69,9 +69,9 @@ def start():
     virtual = args.virtual_host
     word = args.domain  # type: str
 
-    def store(search_engine, source, store_host=False, store_emails=False, store_ip=False, store_people=False,
+    def store(search_engine, source, process_param=None, store_host=False, store_emails=False, store_ip=False, store_people=False,
               store_data=False, store_links=False, store_results=False):
-        search_engine.process()
+        search_engine.process() if process_param is None else search_engine.process(process_param)
         db_stash = stash.stash_manager()
 
         if store_host:
@@ -148,7 +148,7 @@ def start():
                             bingapi += 'yes'
                         else:
                             bingapi += 'no'
-                        store(bing_search, 'bing', store_host=True, store_emails=True)
+                        store(bing_search, 'bing', process_param=bingapi, store_host=True, store_emails=True)
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             print(e)
@@ -224,7 +224,7 @@ def start():
                     print('\033[94m[*] Searching Google. \033[0m')
                     from theHarvester.discovery import googlesearch
                     google_search = googlesearch.SearchGoogle(word, limit, start)
-                    store(google_search, engineitem, store_host=True, store_emails=True)
+                    store(google_search, engineitem, process_param=google_dorking, store_host=True, store_emails=True)
 
                 elif engineitem == 'hunter':
                     print('\033[94m[*] Searching Hunter. \033[0m')

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -69,6 +69,56 @@ def start():
     virtual = args.virtual_host
     word = args.domain  # type: str
 
+    def store(search_engine, source, store_host=False, store_emails=False, store_ip=False, store_people=False,
+              store_data=False, store_links=False, store_results=False):
+        search_engine.process()
+        db_stash = stash.stash_manager()
+
+        if store_host:
+            host_names = filter(search_engine.get_hostnames())
+            all_hosts.extend(host_names)
+            db_stash.store_all(word, all_hosts, 'host', source)
+        if store_emails:
+            email_list = filter(search_engine.get_emails())
+            db_stash.store_all(word, email_list, 'email', source)
+        if store_ip:
+            ips_list = search_engine.get_ips()
+            all_ip.extend(ips_list)
+            db_stash.store_all(word, ips, 'ip', source)
+        if store_data:
+            data = filter(crtsh_search.get_data())
+            all_hosts.extend(data)
+            db.store_all(word, all_hosts, 'host', source)
+        if store_results:
+            emails, hosts, urls = search_engine.get_results()
+            all_emails.extend(emails)
+            hosts = filter(hosts)
+            global trello_urls
+            trello_urls = filter(urls)
+            all_hosts.extend(hosts)
+            db.store_all(word, hosts, 'host', source)
+            db.store_all(word, emails, 'email', source)
+        if store_people:
+            people_list = search_engine.get_people()
+            db_stash.store_all(word, people_list, 'people', source)
+            if len(people_list) == 0:
+                print('\n[*] No users found.\n\n')
+            else:
+                print('\n[*] Users found: ' + str(len(people_list)))
+                print('---------------------')
+                for usr in sorted(list(set(people_list))):
+                    print(usr)
+        if store_links:
+            links = linkedin_links_search.get_links()
+            db.store_all(word, links, 'name', 'linkedin')
+            if len(links) == 0:
+                print('\n[*] No links found Linkedin.\n\n')
+            else:
+                print(f'\n[*] Links found: {len(links)}')
+                print('---------------------')
+                for link in sorted(list(set(links))):
+                    print(link)
+
     if args.source is not None:
         if args.source.lower() != 'all':
             engines = sorted(set(map(str.strip, args.source.split(','))))
@@ -84,13 +134,7 @@ def start():
                     from theHarvester.discovery import baidusearch
                     try:
                         baidu_search = baidusearch.SearchBaidu(word, limit)
-                        baidu_search.process()
-                        all_emails = filter(baidu_search.get_emails())
-                        hosts = filter(baidu_search.get_hostnames())
-                        all_hosts.extend(hosts)
-                        db = stash.stash_manager()
-                        db.store_all(word, all_hosts, 'host', 'baidu')
-                        db.store_all(word, all_emails, 'email', 'baidu')
+                        store(baidu_search, engineitem, store_host=True, store_emails=True)
                     except Exception:
                         pass
 
@@ -104,13 +148,7 @@ def start():
                             bingapi += 'yes'
                         else:
                             bingapi += 'no'
-                        bing_search.process(bingapi)
-                        all_emails = filter(bing_search.get_emails())
-                        hosts = filter(bing_search.get_hostnames())
-                        all_hosts.extend(hosts)
-                        db = stash.stash_manager()
-                        db.store_all(word, all_hosts, 'email', 'bing')
-                        db.store_all(word, all_hosts, 'host', 'bing')
+                        store(bing_search, 'bing', store_host=True, store_emails=True)
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             print(e)
@@ -136,25 +174,17 @@ def start():
                         print('\033[94m[*] Searching CRT.sh. \033[0m')
                         from theHarvester.discovery import crtsh
                         crtsh_search = crtsh.SearchCrtsh(word)
-                        crtsh_search.process()
-                        hosts = filter(crtsh_search.get_data())
-                        all_hosts.extend(hosts)
-                        db = stash.stash_manager()
-                        db.store_all(word, all_hosts, 'host', 'CRTsh')
+                        store(crtsh_search, 'CRTsh', store_data=True)
 
                     except Exception:
-                        print(f'\033[93m[!] An timeout occurred with crtsh, cannot find {args.domain}\033[0m')
+                        print(f'\033[93m[!] A timeout occurred with crtsh, cannot find {args.domain}\033[0m')
 
                 elif engineitem == 'dnsdumpster':
                     try:
                         print('\033[94m[*] Searching DNSdumpster. \033[0m')
                         from theHarvester.discovery import dnsdumpster
                         dns_dumpster_search = dnsdumpster.SearchDnsDumpster(word)
-                        dns_dumpster_search.process()
-                        hosts = filter(dns_dumpster_search.get_hostnames())
-                        all_hosts.extend(hosts)
-                        db = stash.stash_manager()
-                        db.store_all(word, all_hosts, 'host', 'dnsdumpster')
+                        store(dns_dumpster_search, engineitem, store_host=True)
                     except Exception as e:
                         print(f'\033[93m[!] An error occurred with dnsdumpster: {e} \033[0m')
 
@@ -163,14 +193,7 @@ def start():
                         print('\033[94m[*] Searching Dogpile. \033[0m')
                         from theHarvester.discovery import dogpilesearch
                         dogpile_search = dogpilesearch.SearchDogpile(word, limit)
-                        dogpile_search.process()
-                        emails = filter(dogpile_search.get_emails())
-                        hosts = filter(dogpile_search.get_hostnames())
-                        all_hosts.extend(hosts)
-                        all_emails.extend(emails)
-                        db = stash.stash_manager()
-                        db.store_all(word, all_hosts, 'email', 'dogpile')
-                        db.store_all(word, all_hosts, 'host', 'dogpile')
+                        store(dogpile_search, engineitem, store_host=True, store_emails=True)
                     except Exception as e:
                         print(f'\033[93m[!] An error occurred with Dogpile: {e} \033[0m')
 
@@ -178,28 +201,14 @@ def start():
                     print('\033[94m[*] Searching DuckDuckGo. \033[0m')
                     from theHarvester.discovery import duckduckgosearch
                     duckduckgo_search = duckduckgosearch.SearchDuckDuckGo(word, limit)
-                    duckduckgo_search.process()
-                    emails = filter(duckduckgo_search.get_emails())
-                    hosts = filter(duckduckgo_search.get_hostnames())
-                    all_hosts.extend(hosts)
-                    all_emails.extend(emails)
-                    db = stash.stash_manager()
-                    db.store_all(word, all_hosts, 'email', 'duckduckgo')
-                    db.store_all(word, all_hosts, 'host', 'duckduckgo')
+                    store(duckduckgo_search, engineitem, store_host=True, store_emails=True)
 
                 elif engineitem == 'github-code':
                     print('\033[94m[*] Searching Github (code). \033[0m')
                     try:
                         from theHarvester.discovery import githubcode
                         github_search = githubcode.SearchGithubCode(word, limit)
-                        github_search.process()
-                        emails = filter(github_search.get_emails())
-                        all_emails.extend(emails)
-                        hosts = filter(github_search.get_hostnames())
-                        all_hosts.extend(hosts)
-                        db = stash.stash_manager()
-                        db.store_all(word, all_hosts, 'host', 'github-code')
-                        db.store_all(word, all_emails, 'email', 'github-code')
+                        store(github_search, engineitem, store_host=True, store_emails=True)
                     except MissingKey as ex:
                         print(ex)
                     else:
@@ -209,27 +218,13 @@ def start():
                     print('\033[94m[*] Searching Exalead \033[0m')
                     from theHarvester.discovery import exaleadsearch
                     exalead_search = exaleadsearch.SearchExalead(word, limit, start)
-                    exalead_search.process()
-                    emails = filter(exalead_search.get_emails())
-                    all_emails.extend(emails)
-                    hosts = filter(exalead_search.get_hostnames())
-                    all_hosts.extend(hosts)
-                    db = stash.stash_manager()
-                    db.store_all(word, all_hosts, 'host', 'exalead')
-                    db.store_all(word, all_emails, 'email', 'exalead')
+                    store(exalead_search, engineitem, store_host=True, store_emails=True)
 
                 elif engineitem == 'google':
                     print('\033[94m[*] Searching Google. \033[0m')
                     from theHarvester.discovery import googlesearch
                     google_search = googlesearch.SearchGoogle(word, limit, start)
-                    google_search.process(google_dorking)
-                    emails = filter(google_search.get_emails())
-                    all_emails.extend(emails)
-                    hosts = filter(google_search.get_hostnames())
-                    all_hosts.extend(hosts)
-                    db = stash.stash_manager()
-                    db.store_all(word, all_hosts, 'host', 'google')
-                    db.store_all(word, all_emails, 'email', 'google')
+                    store(google_search, engineitem, store_host=True, store_emails=True)
 
                 elif engineitem == 'hunter':
                     print('\033[94m[*] Searching Hunter. \033[0m')
@@ -237,14 +232,7 @@ def start():
                     # Import locally or won't work.
                     try:
                         hunter_search = huntersearch.SearchHunter(word, limit, start)
-                        hunter_search.process()
-                        emails = filter(hunter_search.get_emails())
-                        all_emails.extend(emails)
-                        hosts = filter(hunter_search.get_hostnames())
-                        all_hosts.extend(hosts)
-                        db = stash.stash_manager()
-                        db.store_all(word, all_hosts, 'host', 'hunter')
-                        db.store_all(word, all_emails, 'email', 'hunter')
+                        store(hunter_search, engineitem, store_host=True, store_emails=True)
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             print(e)
@@ -257,14 +245,7 @@ def start():
                     # Import locally or won't work.
                     try:
                         intelx_search = intelxsearch.SearchIntelx(word, limit)
-                        intelx_search.process()
-                        emails = filter(intelx_search.get_emails())
-                        all_emails.extend(emails)
-                        hosts = filter(intelx_search.get_hostnames())
-                        all_hosts.extend(hosts)
-                        db = stash.stash_manager()
-                        db.store_all(word, all_hosts, 'host', 'intelx')
-                        db.store_all(word, all_emails, 'email', 'intelx')
+                        store(intelx_search, engineitem, store_host=True, store_emails=True)
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             print(e)
@@ -275,60 +256,26 @@ def start():
                     print('\033[94m[*] Searching Linkedin. \033[0m')
                     from theHarvester.discovery import linkedinsearch
                     linkedin_search = linkedinsearch.SearchLinkedin(word, limit)
-                    linkedin_search.process()
-                    people = linkedin_search.get_people()
-                    db = stash.stash_manager()
-                    db.store_all(word, people, 'name', 'linkedin')
-
-                    if len(people) == 0:
-                        print('\n[*] No users found Linkedin.\n\n')
-                    else:
-                        print(f'\n[*] Users found: {len(people)}')
-                        print('---------------------')
-                        for user in sorted(list(set(people))):
-                            print(user)
+                    store(linkedin_search, engineitem, store_people=True)
 
                 elif engineitem == 'linkedin_links':
                     print('\033[94m[*] Searching Linkedin. \033[0m')
                     from theHarvester.discovery import linkedinsearch
                     linkedin_links_search = linkedinsearch.SearchLinkedin(word, limit)
-                    linkedin_links_search.process()
-                    people = linkedin_links_search.get_links()
-                    db = stash.stash_manager()
-                    db.store_all(word, people, 'name', 'linkedin')
-
-                    if len(people) == 0:
-                        print('\n[*] No links found Linkedin.\n\n')
-                    else:
-                        print(f'\n[*] Links found: {len(people)}')
-                        print('---------------------')
-                        for user in sorted(list(set(people))):
-                            print(user)
+                    store(linkedin_links_search, 'linkedin', store_links=True)
 
                 elif engineitem == 'netcraft':
                     print('\033[94m[*] Searching Netcraft. \033[0m')
                     from theHarvester.discovery import netcraft
                     netcraft_search = netcraft.SearchNetcraft(word)
-                    netcraft_search.process()
-                    hosts = filter(netcraft_search.get_hostnames())
-                    all_hosts.extend(hosts)
-                    db = stash.stash_manager()
-                    db.store_all(word, all_hosts, 'host', 'netcraft')
+                    store(netcraft_search, engineitem, store_host=True)
 
                 elif engineitem == 'otx':
                     print('\033[94m[*] Searching AlienVault OTX. \033[0m')
                     from theHarvester.discovery import otxsearch
                     try:
                         otxsearch_search = otxsearch.SearchOtx(word)
-                        otxsearch_search.process()
-                        hosts = filter(otxsearch_search.get_hostnames())
-                        all_hosts.extend(list(hosts))
-                        ips = filter(otxsearch_search.get_ips())
-                        all_ip.extend(list(ips))
-                        all_hosts.extend(hosts)
-                        db = stash.stash_manager()
-                        db.store_all(word, all_hosts, 'host', 'otx')
-                        db.store_all(word, all_ip, 'ip', 'otx')
+                        store(otxsearch_search, engineitem, store_host=True, store_ip=True)
                     except Exception as e:
                         print(e)
 
@@ -337,15 +284,7 @@ def start():
                     from theHarvester.discovery import securitytrailssearch
                     try:
                         securitytrails_search = securitytrailssearch.SearchSecuritytrail(word)
-                        securitytrails_search.process()
-                        hosts = filter(securitytrails_search.get_hostnames())
-                        all_hosts.extend(hosts)
-                        db = stash.stash_manager()
-                        db.store_all(word, hosts, 'host', 'securityTrails')
-                        ips = securitytrails_search.get_ips()
-                        all_ip.extend(ips)
-                        db = stash.stash_manager()
-                        db.store_all(word, ips, 'ip', 'securityTrails')
+                        store(securitytrails_search, engineitem, )
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             print(e)
@@ -357,11 +296,7 @@ def start():
                     from theHarvester.discovery import suip
                     try:
                         suip_search = suip.SearchSuip(word)
-                        suip_search.process()
-                        hosts = filter(suip_search.get_hostnames())
-                        all_hosts.extend(hosts)
-                        db = stash.stash_manager()
-                        db.store_all(word, all_hosts, 'host', 'suip')
+                        store(suip_search, engineitem, store_host=True)
                     except Exception as e:
                         print(e)
 
@@ -387,11 +322,7 @@ def start():
                     from theHarvester.discovery import threatcrowd
                     try:
                         threatcrowd_search = threatcrowd.SearchThreatcrowd(word)
-                        threatcrowd_search.process()
-                        hosts = filter(threatcrowd_search.get_hostnames())
-                        all_hosts.extend(hosts)
-                        db = stash.stash_manager()
-                        db.store_all(word, all_hosts, 'host', 'threatcrowd')
+                        store(threatcrowd_search, engineitem, store_host=True)
                     except Exception as e:
                         print(e)
 
@@ -400,55 +331,25 @@ def start():
                     from theHarvester.discovery import trello
                     # Import locally or won't work.
                     trello_search = trello.SearchTrello(word)
-                    trello_search.process()
-                    emails, hosts, urls = trello_search.get_results()
-                    all_emails.extend(emails)
-                    hosts = filter(hosts)
-                    trello_urls = filter(urls)
-                    all_hosts.extend(hosts)
-                    db = stash.stash_manager()
-                    db.store_all(word, hosts, 'host', 'trello')
-                    db.store_all(word, emails, 'email', 'trello')
+                    store(trello_search, engineitem, store_results=True)
 
                 elif engineitem == 'twitter':
                     print('\033[94m[*] Searching Twitter usernames using Google. \033[0m')
                     from theHarvester.discovery import twittersearch
                     twitter_search = twittersearch.SearchTwitter(word, limit)
-                    twitter_search.process()
-                    people = twitter_search.get_people()
-                    db = stash.stash_manager()
-                    db.store_all(word, people, 'name', 'twitter')
-
-                    if len(people) == 0:
-                        print('\n[*] No users found.\n\n')
-                    else:
-                        print('\n[*] Users found: ' + str(len(people)))
-                        print('---------------------')
-                        for user in sorted(list(set(people))):
-                            print(user)
+                    store(twitter_search, engineitem, store_people=True)
 
                 elif engineitem == 'virustotal':
                     print('\033[94m[*] Searching VirusTotal. \033[0m')
                     from theHarvester.discovery import virustotal
                     virustotal_search = virustotal.SearchVirustotal(word)
-                    virustotal_search.process()
-                    hosts = filter(virustotal_search.get_hostnames())
-                    all_hosts.extend(hosts)
-                    db = stash.stash_manager()
-                    db.store_all(word, all_hosts, 'host', 'virustotal')
+                    store(virustotal_search, engineitem, store_host=True)
 
                 elif engineitem == 'yahoo':
                     print('\033[94m[*] Searching Yahoo. \033[0m')
                     from theHarvester.discovery import yahoosearch
                     yahoo_search = yahoosearch.SearchYahoo(word, limit)
-                    yahoo_search.process()
-                    hosts = yahoo_search.get_hostnames()
-                    emails = yahoo_search.get_emails()
-                    all_hosts.extend(filter(hosts))
-                    all_emails.extend(filter(emails))
-                    db = stash.stash_manager()
-                    db.store_all(word, all_hosts, 'host', 'yahoo')
-                    db.store_all(word, all_emails, 'email', 'yahoo')
+                    store(yahoo_search, engineitem, store_host=True, store_emails=True)
         else:
             print('\033[93m[!] Invalid source.\n\n \033[0m')
             sys.exit(1)
@@ -713,10 +614,10 @@ def start():
                     file.write('<banner><!--' + res[1] + '--></banner>')
                     reg_server = re.compile('Server:.*')
                     temp = reg_server.findall(res[1])
-                    if temp != []:
+                    if temp:
                         shodanalysis.append(res[0] + ':' + temp[0])
                     file.write('</shodan>')
-                if shodanalysis != []:
+                if shodanalysis:
                     shodanalysis = sorted(set(shodanalysis))
                     file.write('<servers>')
                     for x in shodanalysis:

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -72,6 +72,22 @@ def start():
     def store(search_engine: Any, source: str, process_param: Any = None, store_host: bool = False,
               store_emails: bool = False, store_ip: bool = False, store_people: bool = False,
               store_data: bool = False, store_links: bool = False, store_results: bool = False) -> None:
+        """
+        Persist details into the database.
+        The details to be stored is controlled by the parameters passed to the method.
+
+        :param search_engine: search engine to fetch details from
+        :param source: source against which the details (corresponding to the search engine) need to be persisted
+        :param process_param: any parameters to be passed to the search engine
+                              eg: Google needs google_dorking
+        :param store_host: whether to store hosts
+        :param store_emails: whether to store emails
+        :param store_ip: whether to store IP address
+        :param store_people: whether to store user details
+        :param store_data: whether to fetch host from method get_data() and persist
+        :param store_links: whether to store links
+        :param store_results: whether to fetch details from get_results() and persist
+        """
         search_engine.process() if process_param is None else search_engine.process(process_param)
         db_stash = stash.stash_manager()
 

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -90,14 +90,13 @@ def start():
             all_hosts.extend(data)
             db.store_all(word, all_hosts, 'host', source)
         if store_results:
-            emails, hosts, urls = search_engine.get_results()
-            all_emails.extend(emails)
-            hosts = filter(hosts)
-            global trello_urls
-            trello_urls = filter(urls)
-            all_hosts.extend(hosts)
-            db.store_all(word, hosts, 'host', source)
-            db.store_all(word, emails, 'email', source)
+            email_list, host_names, urls = search_engine.get_results()
+            all_emails.extend(email_list)
+            host_names = filter(host_names)
+            trello_urls.extend(filter(urls))
+            all_hosts.extend(host_names)
+            db.store_all(word, all_hosts, 'host', source)
+            db.store_all(word, all_emails, 'email', source)
         if store_people:
             people_list = search_engine.get_people()
             db_stash.store_all(word, people_list, 'people', source)


### PR DESCRIPTION
Fixes #317 

This PR only touches the logic inside search engines, externalising the logic to store hosts, emails, ips to a nested method.