### PR TITLE
Reverse dns lookup

### DIFF
--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -477,11 +477,11 @@ def start():
                 analyzed_ranges.append(ip_range)
             else:
                 continue
-            for entries in res:
-                if entries.count(word):
-                    dnsrev.append(entries)
-                    if entries not in full:
-                        full.append(entries)
+            for entry in res:
+                if word in entry:
+                    dnsrev.append(entry)
+                    if entry not in full:
+                        full.append(entry)
         print('[*] Hosts found after reverse lookup (in target domain):')
         print('--------------------------------------------------------')
         for xh in dnsrev:

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -472,7 +472,6 @@ def start():
             if not analyzed_ranges.count(ip_range):
                 print('[*] Performing reverse lookup in ' + ip_range)
                 a = dnssearch.DnsReverse(ip_range, True)
-                a.list()
                 res = a.process()
                 analyzed_ranges.append(ip_range)
             else:

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -477,11 +477,11 @@ def start():
                 analyzed_ranges.append(ip_range)
             else:
                 continue
-            for entry in res:
-                if word in entry:
-                    dnsrev.append(entry)
-                    if entry not in full:
-                        full.append(entry)
+            for cname in res:
+                if word in cname:
+                    dnsrev.append(cname)
+                    if cname not in full:
+                        full.append(cname)
         print('[*] Hosts found after reverse lookup (in target domain):')
         print('--------------------------------------------------------')
         for xh in dnsrev:

--- a/theHarvester/discovery/dnssearch.py
+++ b/theHarvester/discovery/dnssearch.py
@@ -117,7 +117,7 @@ class DnsReverse:
             return str(a_record_answer.canonical_name)
 
         except Exception:
-            pass
+            return ''
 
     def process(
             self) -> List[str]:
@@ -135,7 +135,7 @@ class DnsReverse:
         results = []
         for entry in self._list_ips_in_range():
             host = self.run(entry)
-            if host is not None:
+            if host is not None and host:
                 # print(' : ' + host.split(':')[1])
                 results.append(host)
         return results

--- a/theHarvester/discovery/dnssearch.py
+++ b/theHarvester/discovery/dnssearch.py
@@ -47,6 +47,11 @@ class DnsReverse:
         self.iprange = iprange
         self.verbose = verbose
 
+    def list(self):
+        prefix = '.'.join(
+            self.iprange.split('.')[:-1])
+        self.list = [prefix + '.' + str(i) for i in range(256)]
+
     def run(self, ip):
         if self.verbose:
             esc = chr(27)

--- a/theHarvester/discovery/dnssearch.py
+++ b/theHarvester/discovery/dnssearch.py
@@ -1,5 +1,6 @@
 import sys
 import dns.resolver
+import dns.reversename
 
 # TODO: need big focus on performance and results parsing, now does the basic.
 
@@ -59,9 +60,11 @@ class DnsReverse:
             sys.stdout.write('\r' + ip + ' - ')
             sys.stdout.flush()
         try:
-            answer = dns.resolver.query(ip, 'A')
-            print(answer.canonical_name)
-            return answer.canonical_name  # TODO: need rework all this results
+            dns_record_from_ip_answer = dns.reversename.from_address(ip)
+            ptr_record_answer = dns.resolver.query(dns_record_from_ip_answer, 'PTR')
+            a_record_answer = dns.resolver.query(ptr_record_answer[0].to_text(), 'A')
+            print(a_record_answer.canonical_name)
+            return a_record_answer.canonical_name
 
         except Exception:
             pass

--- a/theHarvester/discovery/dnssearch.py
+++ b/theHarvester/discovery/dnssearch.py
@@ -64,7 +64,7 @@ class DnsReverse:
             ptr_record_answer = dns.resolver.query(dns_record_from_ip_answer, 'PTR')
             a_record_answer = dns.resolver.query(ptr_record_answer[0].to_text(), 'A')
             print(a_record_answer.canonical_name)
-            return a_record_answer.canonical_name
+            return str(a_record_answer.canonical_name)
 
         except Exception:
             pass

--- a/theHarvester/discovery/dnssearch.py
+++ b/theHarvester/discovery/dnssearch.py
@@ -2,6 +2,8 @@ import sys
 import dns.resolver
 import dns.reversename
 
+from typing import List
+
 # TODO: need big focus on performance and results parsing, now does the basic.
 
 
@@ -69,22 +71,22 @@ class DnsReverse:
         self.iprange = iprange
         self.verbose = verbose
 
-    def list(
-            self) -> list:
+    def _list_ips_in_range(
+            self) -> List[str]:
         """
         List all the IPs in the range.
-        They are stored in self.list.
 
         Parameters
         ----------
 
         Returns
         -------
-        out: None.
+        out: list.
+            The list of IPs in the range.
         """
         prefix = '.'.join(
             self.iprange.split('.')[:-1])
-        self.list = [prefix + '.' + str(i) for i in range(256)]
+        return [prefix + '.' + str(i) for i in range(256)]
 
     def run(
             self,
@@ -118,7 +120,7 @@ class DnsReverse:
             pass
 
     def process(
-            self) -> list:
+            self) -> List[str]:
         """
         Reverse all the IPs stored in 'self.list'.
 
@@ -131,7 +133,7 @@ class DnsReverse:
             The list of all the found CNAME records.
         """
         results = []
-        for entry in self.list:
+        for entry in self._list_ips_in_range():
             host = self.run(entry)
             if host is not None:
                 # print(' : ' + host.split(':')[1])

--- a/theHarvester/discovery/dnssearch.py
+++ b/theHarvester/discovery/dnssearch.py
@@ -44,16 +44,44 @@ class DnsForce:
 
 
 class DnsReverse:
+    """
+    Find all the IPs in a range associated with a CNAME. 
+    """
 
     def __init__(
             self,
             iprange: str,
             verbose: bool = False) -> None:
+        """
+        Initialize.
+
+        Parameters
+        ----------
+        iprange: str.
+            An IPv4 range formated as 'x.x.x.x/y'
+        verbose: bool.
+            Print the progress or not.
+
+        Returns
+        -------
+        out: None.
+        """
         self.iprange = iprange
         self.verbose = verbose
 
     def list(
             self) -> list:
+        """
+        List all the IPs in the range.
+        They are stored in self.list.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        out: None.
+        """
         prefix = '.'.join(
             self.iprange.split('.')[:-1])
         self.list = [prefix + '.' + str(i) for i in range(256)]
@@ -61,6 +89,19 @@ class DnsReverse:
     def run(
             self,
             ip: str) -> str:
+        """
+        Reverse a single IP and output the linked CNAME, if it exists.
+
+        Parameters
+        ----------
+        ip: str.
+            The IP to reverse.
+
+        Returns
+        -------
+        out: str.
+            The corresponding CNAME or None.
+        """
         if self.verbose:
             esc = chr(27)
             sys.stdout.write(esc + '[2K' + esc + '[G')
@@ -78,6 +119,17 @@ class DnsReverse:
 
     def process(
             self) -> list:
+        """
+        Reverse all the IPs stored in 'self.list'.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        out: list.
+            The list of all the found CNAME records.
+        """
         results = []
         for entry in self.list:
             host = self.run(entry)

--- a/theHarvester/discovery/dnssearch.py
+++ b/theHarvester/discovery/dnssearch.py
@@ -45,7 +45,7 @@ class DnsForce:
 
 class DnsReverse:
     """
-    Find all the IPs in a range associated with a CNAME. 
+    Find all the IPs in a range associated with a CNAME.
     """
 
     def __init__(

--- a/theHarvester/discovery/dnssearch.py
+++ b/theHarvester/discovery/dnssearch.py
@@ -40,3 +40,32 @@ class DnsForce:
                 # print(' : ' + host.split(':')[1])
                 results.append(host)
         return results
+
+class DnsReverse:
+
+    def __init__(self, iprange, verbose=False):
+        self.iprange = iprange
+        self.verbose = verbose
+
+    def run(self, ip):
+        if self.verbose:
+            esc = chr(27)
+            sys.stdout.write(esc + '[2K' + esc + '[G')
+            sys.stdout.write('\r' + ip + ' - ')
+            sys.stdout.flush()
+        try:
+            answer = dns.resolver.query(ip, 'A')
+            print(answer.canonical_name)
+            return answer.canonical_name  # TODO: need rework all this results
+
+        except Exception:
+            pass
+
+    def process(self):
+        results = []
+        for entry in self.list:
+            host = self.run(entry)
+            if host is not None:
+                # print(' : ' + host.split(':')[1])
+                results.append(host)
+        return results

--- a/theHarvester/discovery/dnssearch.py
+++ b/theHarvester/discovery/dnssearch.py
@@ -42,18 +42,25 @@ class DnsForce:
                 results.append(host)
         return results
 
+
 class DnsReverse:
 
-    def __init__(self, iprange, verbose=False):
+    def __init__(
+            self,
+            iprange: str,
+            verbose: bool = False) -> None:
         self.iprange = iprange
         self.verbose = verbose
 
-    def list(self):
+    def list(
+            self) -> list:
         prefix = '.'.join(
             self.iprange.split('.')[:-1])
         self.list = [prefix + '.' + str(i) for i in range(256)]
 
-    def run(self, ip):
+    def run(
+            self,
+            ip: str) -> str:
         if self.verbose:
             esc = chr(27)
             sys.stdout.write(esc + '[2K' + esc + '[G')
@@ -69,7 +76,8 @@ class DnsReverse:
         except Exception:
             pass
 
-    def process(self):
+    def process(
+            self) -> list:
         results = []
         for entry in self.list:
             host = self.run(entry)


### PR DESCRIPTION
A simple reverse DNS lookup.
Can be called with the '-n' option.

*Note*
The `__main__.py` hasn't been modified.
IE the functionality is here but the results are *not* added to the report.
As is `__main__.py` only prints the results (l 460-488).