### PR TITLE
remove url scheme in genericClean Parser method

### DIFF
--- a/theHarvester/parsers/myparser.py
+++ b/theHarvester/parsers/myparser.py
@@ -13,7 +13,7 @@ class Parser:
             .replace('%2f', '').replace('%3a', '').replace('<strong>', '').replace('</strong>', '')\
             .replace('<wbr>', '').replace('</wbr>', '')
 
-        for search in ('<', '>', 'https', 'http', ':', '=', ';', '&', '%3A', '%3D', '%3C', '/', '\\'):
+        for search in ('<', '>', 'https://', 'http://', ':', '=', ';', '&', '%3A', '%3D', '%3C', '/', '\\'):
             self.results = self.results.replace(search, ' ')
 
     def urlClean(self):

--- a/theHarvester/parsers/myparser.py
+++ b/theHarvester/parsers/myparser.py
@@ -13,7 +13,7 @@ class Parser:
             .replace('%2f', '').replace('%3a', '').replace('<strong>', '').replace('</strong>', '')\
             .replace('<wbr>', '').replace('</wbr>', '')
 
-        for search in ('<', '>', ':', '=', ';', '&', '%3A', '%3D', '%3C', '/', '\\'):
+        for search in ('<', '>', 'https', 'http', ':', '=', ';', '&', '%3A', '%3D', '%3C', '/', '\\'):
             self.results = self.results.replace(search, ' ')
 
     def urlClean(self):

--- a/theHarvester/parsers/myparser.py
+++ b/theHarvester/parsers/myparser.py
@@ -10,7 +10,7 @@ class Parser:
 
     def genericClean(self):
         self.results = self.results.replace('<em>', '').replace('<b>', '').replace('</b>', '').replace('</em>', '')\
-            .replace('%2f', '').replace('%3a', '').replace('<strong>', '').replace('</strong>', '')\
+            .replace('%3a', '').replace('<strong>', '').replace('</strong>', '')\
             .replace('<wbr>', '').replace('</wbr>', '')
 
         for search in ('<', '>', 'https://', 'http://', ':', '=', ';', '&', '%3A', '%3D', '%3C', '/', '\\'):
@@ -48,7 +48,6 @@ class Parser:
     def hostnames(self):
         self.genericClean()
         reg_hosts = re.compile(r'[a-zA-Z0-9.-]*\.' + self.word)
-        self.temp = reg_hosts.findall(self.results)
         hostnames = self.unique()
         reg_hosts = re.compile(r'[a-zA-Z0-9.-]*\.' + self.word.replace('www.', ''))
         self.temp = reg_hosts.findall(self.results)

--- a/theHarvester/parsers/myparser.py
+++ b/theHarvester/parsers/myparser.py
@@ -48,6 +48,7 @@ class Parser:
     def hostnames(self):
         self.genericClean()
         reg_hosts = re.compile(r'[a-zA-Z0-9.-]*\.' + self.word)
+        self.temp = reg_hosts.findall(self.results)
         hostnames = self.unique()
         reg_hosts = re.compile(r'[a-zA-Z0-9.-]*\.' + self.word.replace('www.', ''))
         self.temp = reg_hosts.findall(self.results)

--- a/theHarvester/parsers/myparser.py
+++ b/theHarvester/parsers/myparser.py
@@ -13,7 +13,7 @@ class Parser:
             .replace('%3a', '').replace('<strong>', '').replace('</strong>', '')\
             .replace('<wbr>', '').replace('</wbr>', '')
 
-        for search in ('<', '>', 'https://', 'http://', ':', '=', ';', '&', '%3A', '%3D', '%3C', '/', '\\'):
+        for search in ('<', '>', ':', '=', ';', '&', '%3A', '%3D', '%3C', '/', '\\'):
             self.results = self.results.replace(search, ' ')
 
     def urlClean(self):

--- a/theHarvester/parsers/myparser.py
+++ b/theHarvester/parsers/myparser.py
@@ -13,7 +13,7 @@ class Parser:
             .replace('%3a', '').replace('<strong>', '').replace('</strong>', '')\
             .replace('<wbr>', '').replace('</wbr>', '')
 
-        for search in ('<', '>', ':', '=', ';', '&', '%3A', '%3D', '%3C', '/', '\\'):
+        for search in ('<', '>', ':', '=', ';', '&', '%3A', '%3D', '%3C', '%2f', '/', '\\'):
             self.results = self.results.replace(search, ' ')
 
     def urlClean(self):


### PR DESCRIPTION
Hostnames output contains scheme without URL specific symbols like "://", so when the script is finished it's execution we get subdomains in wrong format, example: "httpsubdomain.test.com" or "httpssubdomain.test.com".

I fixed this error by passing possible url schemes in genericClean Parser method.