### PR TITLE
Modify linkedin people stuff

### DIFF
--- a/theHarvester/parsers/myparser.py
+++ b/theHarvester/parsers/myparser.py
@@ -93,15 +93,17 @@ class Parser:
         return resul
 
     async def people_linkedin(self):
-        reg_people = re.compile(r'">[a-zA-Z0-9._ -]* \| LinkedIn')
+        reg_people = re.compile(r'">[a-zA-Z0-9._ -]* -|\| LinkedIn')
         self.temp = reg_people.findall(self.results)
         resul = []
         for iteration in (self.temp):
             delete = iteration.replace(' | LinkedIn', '')
+            delete = delete.replace(' - LinkedIn', '')
             delete = delete.replace(' profiles ', '')
             delete = delete.replace('LinkedIn', '')
             delete = delete.replace('"', '')
             delete = delete.replace('>', '')
+            delete = delete.strip("-")
             if delete != " ":
                 resul.append(delete)
         return resul


### PR DESCRIPTION
Minor improvment to linkedin user research as linkedin also use "NAME - COMPANY **-** LinkedIn" in addition to "NAME - COMPANY **|** LinkedIn" (notice the - instead of |).

![example](https://user-images.githubusercontent.com/25591433/78647899-7ed00180-78bb-11ea-82e1-cd44018e1958.jpg)
