### PR TITLE
Added code to support Windows 10

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,5 +11,5 @@ retrying==1.3.3
 shodan==1.23.0
 texttable==1.6.2
 lxml==4.5.1
-uvloop==0.14.0
+uvloop==0.14.0; platform_system != "Windows"
 certifi==2020.4.5.1

--- a/theHarvester.py
+++ b/theHarvester.py
@@ -4,7 +4,6 @@
 from platform import python_version
 import sys
 import asyncio
-import uvloop
 
 if python_version()[0:3] < '3.7':
     print('\033[93m[!] Make sure you have Python 3.7+ installed, quitting.\n\n \033[0m')
@@ -12,5 +11,10 @@ if python_version()[0:3] < '3.7':
 
 from theHarvester import __main__
 
-uvloop.install()
+if sys.platform == 'win32':
+    asyncio.DefaultEventLoopPolicy = asyncio.WindowsSelectorEventLoopPolicy
+else:
+    import uvloop
+    uvloop.install()
+
 asyncio.run(__main__.entry_point())


### PR DESCRIPTION
Manually tested with Python 3.8.3 in Win10 and Python 3.7.3 on Raspbian/Debian. Using SelectorEventLoop for Windows because of issues with default ProactorEventLoop on that platform (e.g., missing add_reader implementation needed by aiodns). Made the uvloop install requirement conditional on the operating system (skipped on Windows platforms). This change doesn't allow setup.py to run on Windows (because of /etc/theHarvester reference), but supports running theHarvester.py directly from a cloned workspace.