### PR TITLE
Add /usr/local/etc as possible location for config files

### DIFF
--- a/theHarvester/discovery/dnssearch.py
+++ b/theHarvester/discovery/dnssearch.py
@@ -31,11 +31,15 @@ class DnsForce:
         # self.dnsserver = [dnsserver] if isinstance(dnsserver, str) else dnsserver
         self.dnsserver = list(map(str, dnsserver.split(','))) if isinstance(dnsserver, str) else dnsserver
         try:
-            with open('wordlists/dns-names.txt', 'r') as file:
+            with open('/etc/theHarvester/wordlists/dns-names.txt', 'r') as file:
                 self.list = file.readlines()
         except FileNotFoundError:
-            with open('/etc/theHarvester/dns-names.txt', 'r') as file:
-                self.list = file.readlines()
+            try:
+                with open('/usr/local/etc/theHarvester/wordlists/dns-names.txt', 'r') as file:
+                    self.list = file.readlines()
+            except FileNotFoundError:
+                with open('wordlists/dns-names.txt', 'r') as file:
+                    self.list = file.readlines()
         self.domain = domain.replace('www.', '')
         self.list = [f'{word.strip()}.{self.domain}' for word in self.list]
 

--- a/theHarvester/discovery/googlesearch.py
+++ b/theHarvester/discovery/googlesearch.py
@@ -102,10 +102,18 @@ class SearchGoogle:
     async def append_dorks(self):
         # Wrap in try-except incase filepaths are messed up.
         try:
-            with open('wordlists/dorks.txt', mode='r') as fp:
+            with open('/etc/theHarvester/wordlists/dorks.txt', 'r') as fp:
                 self.dorks = [dork.strip() for dork in fp]
-        except FileNotFoundError as error:
-            print(error)
+        except FileNotFoundError:
+            try:
+                with open('/usr/local/etc/theHarvester/wordlists/dorks.txt', 'r') as fp:
+                    self.dorks = [dork.strip() for dork in fp]
+            except FileNotFoundError:
+                try:
+                    with open('wordlists/dorks.txt', 'r') as fp:
+                        self.dorks = [dork.strip() for dork in fp]
+                except FileNotFoundError as error:
+                    print(error)
 
     async def construct_dorks(self):
         # Format is: site:targetwebsite.com + space + inurl:admindork

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -15,103 +15,54 @@ class Core:
         return '3.2.0'
 
     @staticmethod
-    def bing_key() -> str:
+    def api_keys() -> dict:
         try:
             with open('/etc/theHarvester/api-keys.yaml', 'r') as api_keys:
                 keys = yaml.safe_load(api_keys)
         except FileNotFoundError:
-            with open('api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-                return keys['apikeys']['bing']['key']
-        return keys['apikeys']['bing']['key']
+            try:
+                with open('/usr/local/etc/theHarvester/api-keys.yaml', 'r') as api_keys:
+                    keys = yaml.safe_load(api_keys)
+            except FileNotFoundError:
+                with open('api-keys.yaml', 'r') as api_keys:
+                    keys = yaml.safe_load(api_keys)
+        return keys['apikeys']
+
+    @staticmethod
+    def bing_key() -> str:
+        return Core.api_keys()['bing']['key']
 
     @staticmethod
     def github_key() -> str:
-        try:
-            with open('/etc/theHarvester/api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-        except FileNotFoundError:
-            with open('api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-                return keys['apikeys']['github']['key']
-        return keys['apikeys']['github']['key']
+        return Core.api_keys()['github']['key']
 
     @staticmethod
     def hunter_key() -> str:
-        try:
-            with open('/etc/theHarvester/api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-        except FileNotFoundError:
-            with open('api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-            return keys['apikeys']['hunter']['key']
-        return keys['apikeys']['hunter']['key']
+        return Core.api_keys()['hunter']['key']
 
     @staticmethod
     def intelx_key() -> str:
-        try:
-            with open('/etc/theHarvester/api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-        except FileNotFoundError:
-            with open('api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-                return keys['apikeys']['intelx']['key']
-        return keys['apikeys']['intelx']['key']
+        return Core.api_keys()['intelx']['key']
 
     @staticmethod
     def pentest_tools_key() -> str:
-        try:
-            with open('/etc/theHarvester/api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-        except FileNotFoundError:
-            with open('api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-                return keys['apikeys']['pentestTools']['key']
-        return keys['apikeys']['pentestTools']['key']
+        return Core.api_keys()['pentestTools']['key']
 
     @staticmethod
     def projectdiscovery_key() -> str:
-        try:
-            with open('/etc/theHarvester/api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-        except FileNotFoundError:
-            with open('api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-                return keys['apikeys']['projectDiscovery']['key']
-        return keys['apikeys']['projectDiscovery']['key']
+        return Core.api_keys()['projectDiscovery']['key']
 
     @staticmethod
     def security_trails_key() -> str:
-        try:
-            with open('/etc/theHarvester/api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-        except FileNotFoundError:
-            with open('api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-                return keys['apikeys']['securityTrails']['key']
-        return keys['apikeys']['securityTrails']['key']
+        return Core.api_keys()['securityTrails']['key']
 
     @staticmethod
     def shodan_key() -> str:
-        try:
-            with open('/etc/theHarvester/api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-        except FileNotFoundError:
-            with open('api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-                return keys['apikeys']['shodan']['key']
-        return keys['apikeys']['shodan']['key']
+        return Core.api_keys()['shodan']['key']
 
     @staticmethod
     def spyse_key() -> str:
-        try:
-            with open('/etc/theHarvester/api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-        except FileNotFoundError:
-            with open('api-keys.yaml', 'r') as api_keys:
-                keys = yaml.safe_load(api_keys)
-                return keys['apikeys']['spyse']['key']
-        return keys['apikeys']['spyse']['key']
+        return Core.api_keys()['spyse']['key']
 
     @staticmethod
     def proxy_list() -> List:
@@ -119,10 +70,12 @@ class Core:
             with open('/etc/theHarvester/proxies.yaml', 'r') as proxy_file:
                 keys = yaml.safe_load(proxy_file)
         except FileNotFoundError:
-            with open('proxies.yaml', 'r') as proxy_file:
-                keys = yaml.safe_load(proxy_file)
-                http_list = [f'http://{proxy}' for proxy in keys['http']] if keys['http'] is not None else []
-                return http_list
+            try:
+                with open('/usr/local/etc/theHarvester/proxies.yaml', 'r') as proxy_file:
+                    keys = yaml.safe_load(proxy_file)
+            except FileNotFoundError:
+                with open('proxies.yaml', 'r') as proxy_file:
+                    keys = yaml.safe_load(proxy_file)
         http_list = [f'http://{proxy}' for proxy in keys['http']] if keys['http'] is not None else []
         return http_list
 


### PR DESCRIPTION
The change make theHarvester search for `proxies.yaml` etc. in `/usr/local/etc/theHarvester/` directory in addition to `/etc/theHarvester` and the current directory. This allows system-wide configs to be installed without root privileges, e.g. via Homebrew. 

Additionally, I refactored the code in `core.py` at bit. Now there is one method to read the `api-keys.yaml` file and all service-specific methods just call this function and pass on the right key from the returned object.