### PR TITLE
Dockerfile multiple fixes inspired by hadolint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:alpine3.11
 RUN mkdir /app
 WORKDIR /app
 COPY . /app
-RUN apk add --update build-base libffi-dev libxml2-dev libxslt-dev
-RUN pip3 install -r requirements.txt
-RUN chmod +x *.py
+RUN apk add --no-cache build-base libffi-dev libxml2-dev libxslt-dev
+RUN pip3 install --no-cache-dir -r requirements.txt
+RUN chmod +x ./*.py
 ENTRYPOINT ["/app/theHarvester.py"]


### PR DESCRIPTION
https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache
> This avoids the need to use --update-cache and remove /var/cache/apk/* when done installing packages.

https://github.com/hadolint/hadolint/wiki/DL3042#rationale
> Once a package is installed, it does not be installed and the Docker cache can be leveraged instead. Since the pip cache makes the images larger and is not needed, it's better to disable it.

> It's better to use `./*glob*` or -- `*glob*` so names with dashes won't become options.