### PR TITLE
bug fix of baidusearch

### DIFF
--- a/theHarvester/discovery/baidusearch.py
+++ b/theHarvester/discovery/baidusearch.py
@@ -17,7 +17,7 @@ class SearchBaidu:
             'Host': self.hostname,
             'User-agent': Core.get_user_agent()
         }
-        base_url = f'https://{self.server}/s?wd=%40{self.word}&pnxx&oq={self.word}'
+        base_url = f'https://{self.server}/s?wd=%40{self.word}&pn=xx&oq={self.word}'
         urls = [base_url.replace("xx", str(num)) for num in range(0, self.limit, 10) if num <= self.limit]
         responses = await AsyncFetcher.fetch_all(urls, headers=headers, proxy=self.proxy)
         for response in responses:


### PR DESCRIPTION
```python
# wrong
base_url = f'https://{self.server}/s?wd=%40{self.word}&pnxx&oq={self.word}'

# should be
base_url = f'https://{self.server}/s?wd=%40{self.word}&pn=xx&oq={self.word}'
```