### PR TITLE
company_domain seems more in line with the intention of -d

### DIFF
--- a/theHarvester/discovery/rocketreach.py
+++ b/theHarvester/discovery/rocketreach.py
@@ -26,7 +26,7 @@ class SearchRocketReach:
             }
 
             for page in range(1, self.limit):
-                data = f'{{"query":{{"company_website_url": ["{self.word}"]}}, "start": {page}}}'
+                data = f'{{"query":{{"company_domain": ["{self.word}"]}}, "start": {page}}}'
                 result = await AsyncFetcher.post_fetch(self.baseurl, headers=headers, data=data, json=True)
                 if 'detail' in result.keys() and 'error' in result.keys() and 'Subscribe to a plan to access' in result['detail']:
                     # No more results can be fetched


### PR DESCRIPTION
According to the rocketreach API documentation, `company_website_url`, which is the search term currently being used, requires the entire URL, including scheme etc. This will give back zero results with a search like "company.com". Alternatively, `company_domain` seems to give much nicer results in line with the way other discovery modules query for data.

https://rocketreach.co/api?section=api_section_ws_search