### PR TITLE
100x improvement in rocketreach API calls via pagination tweaks

### DIFF
--- a/theHarvester/discovery/rocketreach.py
+++ b/theHarvester/discovery/rocketreach.py
@@ -25,8 +25,9 @@ class SearchRocketReach:
                 'User-Agent': Core.get_user_agent()
             }
 
-            for page in range(1, self.limit):
-                data = f'{{"query":{{"company_domain": ["{self.word}"]}}, "start": {page}}}'
+            next_page = 1 # track pagniation
+            for count in range(1, self.limit):
+                data = f'{{"query":{{"company_domain": ["{self.word}"]}}, "start": {next_page}, "page_size": 100}'
                 result = await AsyncFetcher.post_fetch(self.baseurl, headers=headers, data=data, json=True)
                 if 'detail' in result.keys() and 'error' in result.keys() and 'Subscribe to a plan to access' in result['detail']:
                     # No more results can be fetched
@@ -42,6 +43,10 @@ class SearchRocketReach:
                     for profile in result['profiles']:
                         if 'linkedin_url' in dict(profile).keys():
                             self.links.add(profile['linkedin_url'])
+                if 'pagination' in dict(result).keys():
+                    next_page = int(result['pagination']['next'])
+                    if next_page > int(result['pagination']['total']):
+                        break
 
             await asyncio.sleep(get_delay() + 2)
 

--- a/theHarvester/discovery/rocketreach.py
+++ b/theHarvester/discovery/rocketreach.py
@@ -27,7 +27,7 @@ class SearchRocketReach:
 
             next_page = 1 # track pagniation
             for count in range(1, self.limit):
-                data = f'{{"query":{{"company_domain": ["{self.word}"]}}, "start": {next_page}, "page_size": 100}'
+                data = f'{{"query":{{"company_domain": ["{self.word}"]}}, "start": {next_page}, "page_size": 100}}'
                 result = await AsyncFetcher.post_fetch(self.baseurl, headers=headers, data=data, json=True)
                 if 'detail' in result.keys() and 'error' in result.keys() and 'Subscribe to a plan to access' in result['detail']:
                     # No more results can be fetched

--- a/theHarvester/discovery/rocketreach.py
+++ b/theHarvester/discovery/rocketreach.py
@@ -25,7 +25,7 @@ class SearchRocketReach:
                 'User-Agent': Core.get_user_agent()
             }
 
-            next_page = 1 # track pagniation
+            next_page = 1  # track pagniation
             for count in range(1, self.limit):
                 data = f'{{"query":{{"company_domain": ["{self.word}"]}}, "start": {next_page}, "page_size": 100}}'
                 result = await AsyncFetcher.post_fetch(self.baseurl, headers=headers, data=data, json=True)


### PR DESCRIPTION
Pagination was previously broken, requesting pages of 10, but incrementing the start value by 1 at each call. This change follows pagination suggestions as returned by the `pagination` field that gets returned.

The default page size is also set to 10 for some reason, and can be set up to 100, so by doing that there's also another 10x reduction in API calls which comes back faster and counts less against your daily rocketreach limit.