### PR TITLE
Added ~/ expansion

### DIFF
--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -65,7 +65,9 @@ async def start(rest_args=None):
         await db.do_init()
     except Exception:
         pass
-
+    import os
+    if len(filename) > 2 and filename[:2] == "~/":
+        filename = os.path.expanduser(filename)
     all_emails: List = []
     all_hosts: List = []
     all_ip: List = []


### PR DESCRIPTION
`open()` function inside `theHarvester/__main__.py` at line 831 and 892 does not recognize the `~/` as user home folder, because `w+` in general can create a non-existent file but cannot create a non-existent directory, and for `open()` function the `~/` directory does not exist. It works only if the tilde is outside the "" otherwise it needs to be expanded. Here the applied solution expands the `~/` allowing to be used in all cases. Discussed in the following issue: https://github.com/laramies/theHarvester/issues/935