### PR TITLE
Package incompatible

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,8 @@ netaddr==0.8.0
 ujson==5.1.0
 pyppeteer==0.2.6
 PyYAML==6.0
-requests==2.27.1
+requests==2.26.0
+urllib3==1.25.10
 retrying==1.3.3
 setuptools==60.2.0
 shodan==1.25.0


### PR DESCRIPTION
Package incompatible requirements/base.txt
ERROR: spyse-python 2.2.3 has requirement requests~=2.26.0, but you'll have requests 2.27.1 which is incompatible.
ERROR: responses 0.13.4 has requirement urllib3>=1.25.10, but you'll have urllib3 1.25.8 which is incompatible.