### PR TITLE
Update starlette version due to dependency conflict

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,6 +19,6 @@ setuptools==62.2.0
 shodan==1.27.0
 slowapi==0.1.5
 -e git+https://github.com/L1ghtn1ng/spyse-python@main#egg=spyse-python
-starlette==0.17.1
+starlette==0.19.1
 uvicorn==0.17.6
 uvloop==0.16.0; platform_system != "Windows"


### PR DESCRIPTION
Dependency Error in starlette package when installing dependencies. Upgrading starlette package to 0.19.1 fixes the issue. 

```
[TRUNCATED]
  Using cached aiodns-3.0.0-py3-none-any.whl (5.0 kB)
ERROR: Cannot install -r requirements/base.txt (line 10) and starlette==0.17.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested starlette==0.17.1
    fastapi 0.77.1 depends on starlette==0.19.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
[Truncated]
```