### PR TITLE
Fix yahoo

### DIFF
--- a/theHarvester/discovery/yahoosearch.py
+++ b/theHarvester/discovery/yahoosearch.py
@@ -22,7 +22,8 @@ class SearchYahoo:
         for response in responses:
             self.total_results += response
 
-    async def process(self) -> None:
+    async def process(self, proxy: bool = False) -> None:
+        self.proxy = proxy
         await self.do_search()
 
     async def get_emails(self):


### PR DESCRIPTION
The scan with yahoo was not going due to the process function signature not matching with the call at __main__.py line 121.