### PR TITLE
fix import error in virtual host option

### DIFF
--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -661,6 +661,7 @@ async def start(rest_args: Optional[argparse.Namespace] = None):
         print('\n[*] Virtual hosts:')
         print('------------------')
         for data in host_ip:
+            from theHarvester.discovery import bingsearch
             basic_search = bingsearch.SearchBing(data, limit, start)
             await basic_search.process_vhost()
             results = await basic_search.get_allhostnames()


### PR DESCRIPTION
I found a simple import error when using virtual host option(-v).

```
brwook@ubuntu:~/origin/theHarvester$ ./theHarvester.py -d google.com -b otx -v
*******************************************************************
*  _   _                                            _             *
* | |_| |__   ___    /\  /\__ _ _ ____   _____  ___| |_ ___ _ __  *
* | __|  _ \ / _ \  / /_/ / _` | '__\ \ / / _ \/ __| __/ _ \ '__| *
* | |_| | | |  __/ / __  / (_| | |   \ V /  __/\__ \ ||  __/ |    *
*  \__|_| |_|\___| \/ /_/ \__,_|_|    \_/ \___||___/\__\___|_|    *
*                                                                 *
* theHarvester 4.3.0-dev                                          *
* Coded by Christian Martorella                                   *
* Edge-Security Research                                          *
* cmartorella@edge-security.com                                   *
*                                                                 *
*******************************************************************

[*] Target: google.com 
...

[*] Virtual hosts:
------------------
local variable 'bingsearch' referenced before assignment
```

I added a line about importing `bingsearch`, and It works well.