### PR TITLE
Fix a bug about string splicing

### DIFF
--- a/theHarvester/discovery/bevigil.py
+++ b/theHarvester/discovery/bevigil.py
@@ -11,14 +11,13 @@ class SearchBeVigil:
         self.interestingurls: Set = set()
         self.key = Core.bevigil_key()
         if self.key is None:
+            self.key = ""
             raise MissingKey('bevigil')
         self.proxy = False
 
     async def do_search(self) -> None:
         subdomain_endpoint = f"https://osint.bevigil.com/api/{self.word}/subdomains/"
         url_endpoint = f"https://osint.bevigil.com/api/{self.word}/urls/"
-        if self.key is None:
-            self.key = ""
         headers = {'X-Access-Token': self.key}
 
         responses = await AsyncFetcher.fetch_all([subdomain_endpoint], json=True, proxy=self.proxy, headers=headers)

--- a/theHarvester/discovery/bevigil.py
+++ b/theHarvester/discovery/bevigil.py
@@ -17,6 +17,8 @@ class SearchBeVigil:
     async def do_search(self) -> None:
         subdomain_endpoint = f"https://osint.bevigil.com/api/{self.word}/subdomains/"
         url_endpoint = f"https://osint.bevigil.com/api/{self.word}/urls/"
+        if self.key is None:
+            self.key = ""
         headers = {'X-Access-Token': self.key}
 
         responses = await AsyncFetcher.fetch_all([subdomain_endpoint], json=True, proxy=self.proxy, headers=headers)


### PR DESCRIPTION
Fix the error "An exception has occurred: can only concatenate str (not "NoneType") to str" when the bevigil api lacks the key
