### PR TITLE
Replace an inappropriate test expression that is always evaluating to true

### DIFF
--- a/theHarvester/discovery/rapiddns.py
+++ b/theHarvester/discovery/rapiddns.py
@@ -1,4 +1,3 @@
-# comment here
 from bs4 import BeautifulSoup
 
 from theHarvester.lib.core import AsyncFetcher, Core

--- a/theHarvester/discovery/rapiddns.py
+++ b/theHarvester/discovery/rapiddns.py
@@ -1,3 +1,4 @@
+# comment here
 from bs4 import BeautifulSoup
 
 from theHarvester.lib.core import AsyncFetcher, Core
@@ -26,7 +27,7 @@ class SearchRapidDns:
                 # Validation check
                 for row in rows:
                     cells = row.find_all("td")
-                    if len(cells) >= 0:
+                    if len(cells) > 0:
                         # sanity check
                         subdomain = str(cells[0].get_text())
                         if cells[-1].get_text() == "CNAME":


### PR DESCRIPTION
In file: rapiddns.py, the comparison of Collection length creates a logical short circuit; it will always evaluate to true. I suggested that the Collection length comparison should be done without creating a logical short circuit. The check is likely to be done only if the `cells` is of non-zero length. This is what I introduced.

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the Open Source Security Foundation (OpenSSF)(https://openssf.org/): Project Alpha-Omega(https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.