### PR TITLE
fix: create static directory when missing

### DIFF
--- a/.github/workflows/theHarvester.yml
+++ b/.github/workflows/theHarvester.yml
@@ -17,7 +17,7 @@ jobs:
       max-parallel: 8
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        python-version: [ 3.10.12, 3.11, 3.12 ]
+        python-version: [ '3.10', '3.11', '3.12' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.11-slim-bookworm
 LABEL maintainer="@jay_townsend1 & @NotoriousRebel1"
-RUN mkdir -p "~/.local/share/theHarvester/static/"
 RUN apt update && apt install -y pipx git; apt clean; apt autoremove -y
 RUN pipx install git+https://github.com/laramies/theHarvester.git
 RUN pipx ensurepath

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,6 @@ PyYAML==6.0.1
 python-dateutil==2.9.0.post0
 requests==2.31.0
 retrying==1.3.4
-setuptools==69.4.0
 shodan==1.31.0
 slowapi==0.1.9
 uvicorn==0.29.0

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -28,7 +28,7 @@ except RuntimeError:
         os.makedirs(static_path)
         app.mount(
             '/static',
-            StaticFiles(directory='~/.local/share/theHarvester/static/'),
+            StaticFiles(directory=static_path),
             name='static',
         )
 


### PR DESCRIPTION
:wave: I noticed the static directory isn't being created since `StaticFiles` doesn't expand `~`:

```console
$ docker build -t tmp . && docker run --rm tmp
# ...
  File "/root/.local/pipx/venvs/theharvester/lib/python3.11/site-packages/theHarvester/lib/api/api.py", line 31, in <module>
    StaticFiles(directory='~/.local/share/theHarvester/static/'),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/pipx/venvs/theharvester/lib/python3.11/site-packages/starlette/staticfiles.py", line 59, in __init__
    raise RuntimeError(f"Directory '{directory}' does not exist")
RuntimeError: Directory '~/.local/share/theHarvester/static/' does not exist
```

Also, I dropped `setuptools` from requirements.txt since it isn't a runtime dependency
