### PR TITLE
fix: Type hinting change to support Python 3.9

### DIFF
--- a/tests/lib/test_core.py
+++ b/tests/lib/test_core.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, Union
 from unittest import mock
 
 import pytest
@@ -15,7 +15,7 @@ def mock_environ(monkeypatch, tmp_path: Path):
     monkeypatch.setenv("HOME", str(tmp_path))
 
 
-def mock_read_text(mocked: dict[Path, str | Exception]):
+def mock_read_text(mocked: Dict[Path, Union[str, Exception]]):
     read_text = Path.read_text
 
     def _read_text(self: Path, *args, **kwargs):

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -7,7 +7,7 @@ import secrets
 import string
 import sys
 import time
-from typing import Any
+from typing import Any, Optional
 
 import netaddr
 import ujson
@@ -60,7 +60,7 @@ from theHarvester.lib.core import Core
 from theHarvester.screenshot.screenshot import ScreenShotter
 
 
-async def start(rest_args: argparse.Namespace | None = None):
+async def start(rest_args: Optional[argparse.Namespace] = None):
     """Main program function"""
     parser = argparse.ArgumentParser(
         description='theHarvester is used to gather open source intelligence (OSINT) on a company or domain.'

--- a/theHarvester/discovery/bingsearch.py
+++ b/theHarvester/discovery/bingsearch.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, List
 
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib.core import AsyncFetcher, Core
@@ -8,7 +8,7 @@ from theHarvester.parsers import myparser
 class SearchBing:
     def __init__(self, word, limit, start) -> None:
         self.word = word.replace(' ', '%20')
-        self.results: list[Any] = []
+        self.results: List[Any] = []
         self.total_results = ''
         self.server = 'www.bing.com'
         self.apiserver = 'api.search.live.net'

--- a/theHarvester/discovery/constants.py
+++ b/theHarvester/discovery/constants.py
@@ -1,7 +1,7 @@
 import random
 
 from theHarvester.lib.core import AsyncFetcher, Core
-
+from typing import Union, Optional
 
 async def splitter(links):
     """
@@ -68,7 +68,7 @@ async def search(text: str) -> bool:
     return False
 
 
-async def google_workaround(visit_url: str) -> bool | str:
+async def google_workaround(visit_url: str) -> Union[bool,str]:
     """
     Function that makes a request on our behalf if Google starts to block us
     :param visit_url: Url to scrape
@@ -113,7 +113,7 @@ class MissingKey(Exception):
     :raise: When there is a module that has not been provided its API key
     """
 
-    def __init__(self, source: str | None) -> None:
+    def __init__(self, source: Optional[str]) -> None:
         if source:
             self.message = f'\n\033[93m[!] Missing API key for {source}. \033[0m'
         else:

--- a/theHarvester/discovery/dnssearch.py
+++ b/theHarvester/discovery/dnssearch.py
@@ -11,6 +11,7 @@ import re
 import sys
 from collections.abc import Callable
 from ipaddress import IPv4Network
+from typing import List, Optional
 
 from aiodns import DNSResolver
 
@@ -127,7 +128,7 @@ async def reverse_single_ip(ip: str, resolver: DNSResolver) -> str:
         return ''
 
 
-async def reverse_all_ips_in_range(iprange: str, callback: Callable, nameservers: list[str] | None = None) -> None:
+async def reverse_all_ips_in_range(iprange: str, callback: Callable, nameservers: Optional[List[str]] = None) -> None:
     """
     Reverse all the IPs stored in a network range.
     All the queries are made concurrently.
@@ -196,7 +197,7 @@ def log_result(host: str) -> None:
         print(host)
 
 
-def generate_postprocessing_callback(target: str, **allhosts: list[str]) -> Callable:
+def generate_postprocessing_callback(target: str, **allhosts: List[str]) -> Callable:
     """
     Postprocess the query results asynchronously too, instead of waiting for
     the querying stage to be completely finished.

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+from typing import Dict, List
 
 from fastapi import FastAPI, Header, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, Response, UJSONResponse
@@ -67,7 +68,7 @@ async def root(*, user_agent: str = Header(None)) -> Response:
 
 
 @app.get('/nicebot')
-async def bot() -> dict[str, str]:
+async def bot() -> Dict[str, str]:
     # nice bot
     string = {'bot': 'These are not the droids you are looking for'}
     return string
@@ -131,7 +132,7 @@ async def query(
     shodan: bool = Query(False),
     take_over: bool = Query(False),
     virtual_host: bool = Query(False),
-    source: list[str] = Query(..., description='Data sources to query comma separated with no space'),
+    source: List[str] = Query(..., description='Data sources to query comma separated with no space'),
     limit: int = Query(500),
     start: int = Query(0),
     domain: str = Query(..., description='Domain to be harvested'),

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -5,7 +5,7 @@ import contextlib
 import random
 import ssl
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union, Dict, List, Tuple
 
 import aiohttp
 import certifi
@@ -47,7 +47,7 @@ class Core:
         return default
 
     @staticmethod
-    def api_keys() -> dict:
+    def api_keys() -> Dict:
         keys = yaml.safe_load(Core._read_config('api-keys.yaml'))
         return keys['apikeys']
 
@@ -68,7 +68,7 @@ class Core:
         return Core.api_keys()['bufferoverun']['key']
 
     @staticmethod
-    def censys_key() -> tuple:
+    def censys_key() -> Tuple:
         return Core.api_keys()['censys']['id'], Core.api_keys()['censys']['secret']
 
     @staticmethod
@@ -136,7 +136,7 @@ class Core:
         return Core.api_keys()['virustotal']['key']
 
     @staticmethod
-    def proxy_list() -> list:
+    def proxy_list() -> List:
         keys = yaml.safe_load(Core._read_config('proxies.yaml'))
         http_list = [f'http://{proxy}' for proxy in keys['http']] if keys['http'] is not None else []
         return http_list
@@ -158,7 +158,7 @@ class Core:
         print('*******************************************************************')
 
     @staticmethod
-    def get_supportedengines() -> list[str | Any]:
+    def get_supportedengines() -> List[str | Any]:
         supportedengines = [
             'anubis',
             'baidu',
@@ -270,7 +270,7 @@ class AsyncFetcher:
         cls,
         url,
         headers=None,
-        data: str | dict[str, str] = '',
+        data: Union[str, Dict[str, str]] = '',
         params: str = '',
         json: bool = False,
         proxy: bool = False,

--- a/theHarvester/lib/hostchecker.py
+++ b/theHarvester/lib/hostchecker.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import socket
-from typing import Any
+from typing import Any, List
 
 import aiodns
 
@@ -55,7 +55,7 @@ class Checker:
         for i in range(0, len(lst), n):
             yield lst[i : i + n]
 
-    async def query_all(self, resolver, hosts) -> list[Any]:
+    async def query_all(self, resolver, hosts) -> List[Any]:
         # TODO chunk list into 50 pieces regardless of IPs and subnets
         results = await asyncio.gather(*[asyncio.create_task(self.resolve_host(host, resolver)) for host in hosts])
         return results

--- a/theHarvester/lib/stash.py
+++ b/theHarvester/lib/stash.py
@@ -2,6 +2,7 @@ import datetime
 import os
 from collections.abc import Iterable
 from sqlite3.dbapi2 import Row
+from typing import Optional, Union
 
 import aiosqlite
 
@@ -151,7 +152,7 @@ class StashManager:
         except Exception as e:
             print(e)
 
-    async def getlatestscanresults(self, domain, previousday: bool = False) -> Iterable[Row | str] | None:
+    async def getlatestscanresults(self, domain, previousday: bool = False) -> Optional[Iterable[Union[Row, str]]]:
         try:
             async with aiosqlite.connect(self.db, timeout=30) as conn:
                 if previousday:
@@ -290,7 +291,7 @@ class StashManager:
         except Exception as e:
             print(e)
 
-    async def getpluginscanstatistics(self) -> Iterable[Row] | None:
+    async def getpluginscanstatistics(self) -> Optional[Iterable[Row]]:
         try:
             async with aiosqlite.connect(self.db, timeout=30) as conn:
                 cursor = await conn.execute(


### PR DESCRIPTION
Fix for #1749.
This changes all typing to the old syntax, with types imported from typing, rather than the newer (and nicer) syntax introduced in python 3.10.
This is with the purpose of making theHarvaster compatible with python 3.9 as is still stated in the README.

Alternative to this PR is changing stated supported Python version to 3.10+