### PR TITLE
Properly clean up apt footprint in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim-bookworm
 LABEL maintainer="@jay_townsend1 & @NotoriousRebel1"
-RUN apt update && apt install -y pipx git; apt clean; apt autoremove -y
+RUN apt update && apt install -y pipx git && rm -rf /var/lib/apt/lists/*
 RUN pipx install git+https://github.com/laramies/theHarvester.git
 RUN pipx ensurepath
 ENTRYPOINT ["/root/.local/bin/restfulHarvest", "-H", "0.0.0.0", "-p", "80"]


### PR DESCRIPTION
According to the official best practices guidelines outlined in the following document: https://docs.docker.com/develop/develop-images/instructions/#apt-get

The official Debian/Ubuntu images have been configured to do `apt-get` clean automatically. Consequently, performing `apt clean` is unnecessary. As no package has been removed, another `apt autoremove` is also unnecessary. Instead, it'll be helpful to clear the cache for the index file by executing this command: `rm -rf /var/lib/apt/lists/*`.