### PR TITLE
Add Command Line Arguments to Exported File

### DIFF
--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -1202,6 +1202,7 @@ async def start(rest_args: argparse.Namespace | None = None):
             # XML REPORT SECTION
             with open(filename, 'w+') as file:
                 file.write('<?xml version="1.0" encoding="UTF-8"?><theHarvester>')
+                file.write('<cmd>' + ' '.join(['"{}"'.format(arg) if ' ' in arg else arg for arg in sys.argv[1:]]) + '</cmd>')
                 for x in all_emails:
                     file.write('<email>' + x + '</email>')
                 for x in full:
@@ -1227,6 +1228,8 @@ async def start(rest_args: argparse.Namespace | None = None):
             filename = filename.rsplit('.', 1)[0] + '.json'
             # create dict with values for json output
             json_dict: dict = dict()
+            # start by adding the command line arguments
+            json_dict["cmd"] = ' '.join(['"{}"'.format(arg) if ' ' in arg else arg for arg in sys.argv[1:]])
             # determine if a variable exists
             # it should but just a validation check
             if 'ip_list' in locals():


### PR DESCRIPTION
Hello,

This pull request enhances the exported file by including the command line arguments of the executed command.
This may provides users with clear visibility into the specific command that generated the raw output. User will be able to make sure an output file has been generated with, for example  `-l 5` and not `-l 1`.

`'"{}"'.format(arg) if ' ' in arg else arg ` is added in order to keep `" "` in the outputted string.

File export with command line arguments:
json:
```json
{
  "cmd": "-d example.com -s -f ../example.com -l 1 -b all",
  "hosts": [
    ".example.com",
   ]
}
```

xml:
```xml
<?xml version="1.0" encoding="UTF-8"?>
   <theHarvester>
      <cmd>-d example.com -s -f ../example.com -l 1 -b all</cmd>
      <email>email@example.com</email>
      ...
   </theHarvester>
```