### PR TITLE
Add workflow to publish to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  push:
+    tags: ["*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/theHarvester
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv build
+      - run: uv publish


### PR DESCRIPTION
Fixes #1501

This adds a simple workflow to publish to PyPI on any new git tag. You just need to register this workflow with PyPI [here](https://pypi.org/manage/account/publishing/) (as explained in [this python guide](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#configuring-trusted-publishing)).

Note [theHarvester already exists](https://pypi.org/project/theHarvester/) on PyPI, so hopefully you don't have any trouble gaining access
