### PR TITLE
Fix: Container Running as Root User Instead of Safer Account in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+
+# Create non-root user for security
+RUN useradd -m -u 1000 -s /bin/bash theharvester
 FROM debian:trixie-slim
 
 LABEL maintainer="@jay_townsend1 & @NotoriousRebel1"
@@ -46,4 +49,11 @@ RUN pipx install --python python3.13 git+https://github.com/laramies/theHarveste
 RUN pipx ensurepath
 
 # Set the entrypoint
+
+# Change ownership of application files to non-root user
+RUN chown -R theharvester:theharvester /app
+
+# Switch to non-root user
+USER theharvester
+# Switch to non-root userUSER harvester
 ENTRYPOINT ["/root/.local/bin/restfulHarvest", "-H", "0.0.0.0", "-p", "80"]


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** By not specifying a USER, a program in the container may run as 'root'. This is a security hazard. If an attacker can control a process running as root, they may have control over the container. Ensure that the last USER in a Dockerfile is a USER other than 'root'.
- **Rule ID:** dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
- **Severity:** MEDIUM
- **File:** Dockerfile
- **Lines Affected:** 49 - 49

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `Dockerfile` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.