### PR TITLE
removed api_endpoints from lib/core.py

### DIFF
--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -198,7 +198,6 @@ class Core:
         Returns a list of supported search engines.
         """
         return [
-            'api_endpoints',
             'baidu',
             'bevigil',
             'bufferoverun',


### PR DESCRIPTION
theHarvester was scanning for API endpoints by default regardless of -a, --api-scan argument was provided. Removing api_endpoints from supported engines fixed the issue.