### PR TITLE
Fix winloop dependency condition for Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "ujson==5.11.0",
     "uvicorn==0.38.0",
     "uvloop==0.22.1; platform_system != 'Windows'",
-    "winloop==0.4.0'Windows'",
+    "winloop==0.4.0; platform_system == 'Windows'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Fix invalid PEP508 dependency for `winloop` in `pyproject.toml`

This PR fixes an invalid dependency entry in `pyproject.toml` which breaks builds using setuptools, pip, uv, and downstream package managers (e.g., Arch Linux AUR).

## Problem

The following entry is invalid PEP 508 syntax:

```toml
"winloop==0.4.0'Windows'"
```

This produces an error:

```
configuration error: `project.dependencies[22]` must be pep508
```

Because the dependency string contains a stray `'Windows'` and is missing a valid environment marker.

## Fix

Replace the invalid entry with the correct PEP 508–compliant dependency:

```toml
"winloop==0.4.0; platform_system == 'Windows'",
```

## Full Diff

```diff
diff --git a/pyproject.toml b/pyproject.toml
index 1111111..2222222 100644
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "shodan==1.31.0",
     "slowapi==0.1.9",
     "ujson==5.11.0",
-    "uvicorn==0.38.0",
-    "uvloop==0.22.1; platform_system != 'Windows'",
-    "winloop==0.4.0'Windows'",
+    "uvicorn==0.38.0",
+    "uvloop==0.22.1; platform_system != 'Windows'",
+    "winloop==0.4.0; platform_system == 'Windows'",
 ]
```