### PR TITLE
Add Shodan InternetDB data source module

### DIFF
--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -55,6 +55,7 @@ from theHarvester.discovery import (
     searchhunterhow,
     securityscorecard,
     securitytrailssearch,
+    shodan_internetdb,
     shodansearch,
     subdomaincenter,
     subdomainfinderc99,
@@ -198,7 +199,7 @@ async def start(rest_args: argparse.Namespace | None = None):
         help="""baidu, bevigil, bitbucket, brave, bufferoverun,
                             builtwith, censys, certspotter, chaos, commoncrawl, criminalip, crtsh, dehashed, dnsdumpster, duckduckgo, fofa, fullhunt, github-code,
                             gitlab, hackertarget, haveibeenpwned, hudsonrock, hunter, hunterhow, intelx, leakix, leaklookup, mojeek, netlas, onyphe, otx, pentesttools,
-                            projectdiscovery, rapiddns, robtex, rocketreach, securityscorecard, securityTrails, shodan, subdomaincenter,
+                            projectdiscovery, rapiddns, robtex, rocketreach, securityscorecard, securityTrails, shodan, shodanInternetDB, subdomaincenter,
                             subdomainfinderc99, thc, threatcrowd, tomba, urlscan, venacus, virustotal, waybackarchive, whoisxml, windvane, yahoo, zoomeye""",
     )
 
@@ -1067,6 +1068,27 @@ async def start(rest_args: argparse.Namespace | None = None):
                                 print(f'A Missing Key error occurred in Shodan search: {e}')
                         else:
                             print(f'An exception has occurred in Shodan search: {e}')
+
+                elif engineitem == 'shodanInternetDB':
+                    try:
+                        shodanidb_search = shodan_internetdb.SearchShodanInternetDB(word)
+                        stor_lst.append(
+                            store(
+                                shodanidb_search,
+                                engineitem,
+                                store_host=True,
+                                store_ip=True,
+                            )
+                        )
+                    except ConnectionError as ce:
+                        if not args.quiet:
+                            print(f'Network connection error while accessing Shodan InternetDB: {ce}')
+                    except TimeoutError as te:
+                        if not args.quiet:
+                            print(f'Request to Shodan InternetDB timed out: {te}')
+                    except Exception as e:
+                        if not args.quiet:
+                            print(f'Unexpected error occurred in Shodan InternetDB module: {e}')
 
                 elif engineitem == 'subdomaincenter':
                     try:

--- a/theHarvester/discovery/shodan_internetdb.py
+++ b/theHarvester/discovery/shodan_internetdb.py
@@ -1,0 +1,111 @@
+import asyncio
+import socket
+
+from theHarvester.lib.core import AsyncFetcher
+
+
+class SearchShodanInternetDB:
+    """Search Shodan InternetDB for IP intelligence data.
+
+    Shodan InternetDB (https://internetdb.shodan.io/) is a free API that
+    provides basic information about IP addresses including open ports,
+    hostnames, vulnerabilities (CVEs), tags, and CPEs. No API key is required.
+
+    This module first resolves the target domain to its IP addresses, then
+    queries InternetDB for each IP to gather associated hostnames and other
+    intelligence.
+    """
+
+    def __init__(self, word) -> None:
+        self.word = word
+        self.totalhosts: set = set()
+        self.totalips: set = set()
+        self.ports: set = set()
+        self.vulns: set = set()
+        self.tags: set = set()
+        self.cpes: set = set()
+        self.proxy = False
+
+    async def do_search(self) -> None:
+        # Resolve the domain to IP addresses first
+        try:
+            addr_infos = await asyncio.to_thread(socket.getaddrinfo, self.word, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+        except socket.gaierror:
+            print(f'Shodan InternetDB: Could not resolve domain {self.word}')
+            return
+
+        # Deduplicate IPs from the resolution results
+        resolved_ips: set[str] = set()
+        for family, _type, _proto, _canonname, sockaddr in addr_infos:
+            ip = sockaddr[0]
+            resolved_ips.add(ip)
+
+        if not resolved_ips:
+            print(f'Shodan InternetDB: No IPs resolved for {self.word}')
+            return
+
+        # Query InternetDB for each resolved IP
+        urls = [f'https://internetdb.shodan.io/{ip}' for ip in resolved_ips]
+        responses = await AsyncFetcher.fetch_all(urls, json=True, proxy=self.proxy)
+
+        for response in responses:
+            if not isinstance(response, dict):
+                continue
+
+            # InternetDB returns a 404 as an empty JSON object or with a "detail" key
+            # when no data is found for an IP. Skip those.
+            if 'detail' in response:
+                continue
+
+            # Collect hostnames that match our target domain
+            for hostname in response.get('hostnames', []):
+                if isinstance(hostname, str) and (hostname == self.word or hostname.endswith('.' + self.word)):
+                    self.totalhosts.add(hostname)
+
+            # Collect ports
+            for port in response.get('ports', []):
+                if isinstance(port, int):
+                    self.ports.add(port)
+
+            # Collect CVEs / vulnerabilities
+            for vuln in response.get('vulns', []):
+                if isinstance(vuln, str):
+                    self.vulns.add(vuln)
+
+            # Collect tags
+            for tag in response.get('tags', []):
+                if isinstance(tag, str):
+                    self.tags.add(tag)
+
+            # Collect CPEs
+            for cpe in response.get('cpes', []):
+                if isinstance(cpe, str):
+                    self.cpes.add(cpe)
+
+            # Add the IP if there was any data
+            if response.get('hostnames') or response.get('ports') or response.get('vulns') or response.get('tags') or response.get('cpes'):
+                ip_str = response.get('ip', '')
+                if ip_str:
+                    self.totalips.add(str(ip_str))
+
+    async def get_hostnames(self) -> set:
+        return self.totalhosts
+
+    async def get_ips(self) -> set:
+        return self.totalips
+
+    async def get_ports(self) -> set:
+        return self.ports
+
+    async def get_vulns(self) -> set:
+        return self.vulns
+
+    async def get_tags(self) -> set:
+        return self.tags
+
+    async def get_cpes(self) -> set:
+        return self.cpes
+
+    async def process(self, proxy: bool = False) -> None:
+        self.proxy = proxy
+        await self.do_search()

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -313,6 +313,7 @@ class Core:
             'securityscorecard',
             'securityTrails',
             'shodan',
+            'shodanInternetDB',
             'subdomaincenter',
             'subdomainfinderc99',
             'sublist3r',


### PR DESCRIPTION
Adds a new OSINT data source: Shodan InternetDB (internetdb.shodan.io).

## What is Shodan InternetDB?

Shodan InternetDB is a **free, no-API-key-required** service that provides basic intelligence about IP addresses including open ports, associated hostnames, known vulnerabilities (CVEs), tags, and CPEs.

This is distinct from the existing `shodan` source which requires a paid API key. Shodan InternetDB is free and provides complementary data, making it accessible to all users.

## Usage

```bash
theHarvester -d example.com -b shodanInternetDB
```

## Changes

- **New module**: `theHarvester/discovery/shodan_internetdb.py` - Resolves the target domain to IPs, queries InternetDB for each IP, and collects hostnames, ports, vulns, tags, and CPEs
- **Registered in `__main__.py`**: Import + engine handler with proper exception handling (ConnectionError, TimeoutError)
- **Added to supported engines**: `core.py` - `get_supportedengines()` now includes `shodanInternetDB`
- **Added to CLI help**: `--source` option lists the new source

## API Details

- Endpoint: `https://internetdb.shodan.io/{ip}`
- No authentication required
- Rate limiting: Reasonable use (no documented hard limits)
- Returns: JSON with hostnames, ports, vulns, tags, cpes fields

## Testing

The module follows the same pattern as existing modules like `urlscan` and `criminalip`. It uses `AsyncFetcher.fetch_all` for HTTP requests and `asyncio.to_thread` for DNS resolution to avoid blocking the event loop.