### PR TITLE
fix(worker): surface the underlying exception when a work item fails (#2227)

### DIFF
--- a/tests/discovery/test_shodan_engine.py
+++ b/tests/discovery/test_shodan_engine.py
@@ -39,6 +39,6 @@ class TestShodanEngine:
         assert excinfo.value.code == 0
 
         out = capsys.readouterr().out
-        assert 'A error occurred while processing a "work item"' not in out
+        assert 'An error occurred while processing a "work item"' not in out
         assert "a.example.com" in out
         assert "b.example.com" in out

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -1301,8 +1301,8 @@ async def start(rest_args: argparse.Namespace | None = None):
                 await stor
                 queue.task_done()
                 # Notify the queue that the "work item" has been processed.
-            except Exception:
-                print('\n A error occurred while processing a "work item".\n')
+            except Exception as work_item_error:
+                print(f'\n An error occurred while processing a "work item": {type(work_item_error).__name__}: {work_item_error}\n')
                 queue.task_done()
 
     async def handler(lst):


### PR DESCRIPTION
Closes #2227.

## Background

The async worker draining the engine queue catches `Exception` with no `as` binding and prints:

```
 A error occurred while processing a "work item".
```

Two problems:

1. **The actual error class + message is swallowed.** That's why the issue thread runs through "Bug error running shodan search" → maintainer applies a fix → "I have same for censys module" — every per-engine bug surfaces with the same opaque print, and the only way to debug is to add a `traceback.print_exc()` locally. (See @sulaimanzai's same-message-different-engine repro in the latest comment.)
2. The article reads `A error` instead of the grammatical `An error`.

## Change

Bind the exception, print its type and message:

```python
except Exception as work_item_error:
    print(f'\n An error occurred while processing a "work item": '
          f'{type(work_item_error).__name__}: {work_item_error}\n')
    queue.task_done()
```

That keeps the existing `try: await stor` / `task_done()` flow intact (so a single failing engine never wedges the queue) but operators now see e.g. `AttributeError: 'ShodanWrapper' object has no attribute 'do_search'` and can act on the report directly.

## Test update

`tests/discovery/test_shodan_engine.py:42` already asserts the message is not present on the happy path. I updated the assertion's substring to match the new "An error" form so the test still pins the same condition.

```diff
-        assert 'A error occurred while processing a "work item"' not in out
+        assert 'An error occurred while processing a "work item"' not in out
```

## Verification

Diff is `+3 / -3` lines across two files. The change is purely error-reporting; the engine queue's success path is untouched, and existing per-engine error handling (the `except` clauses around each `engineitem == ...` branch) continues to suppress engine-specific cases the same way it does today.

## Note

I scoped this PR to the worker-level surfacing — that alone makes #2227 actionable for the next reporter. If you'd rather inline a `logger.exception(...)` (so the full traceback lands in the log) I'm happy to follow up.
