### PR TITLE
feat(discovery): add Dymo API data verifier source (closes #2300)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Passive modules
 
 * duckduckgo: DuckDuckGo search engine (https://duckduckgo.com)
 
+* dymo: Dymo API data verifier - confirms domains, surfaces typo suggestions and MX/fraud signals (https://dymo.tpeoficial.com)
+
 * fofa: FOFA search eingine (https://en.fofa.info)
 
 * fullhunt: Next-generation attack surface security platform (https://fullhunt.io)
@@ -168,6 +170,7 @@ Documentation to setup API keys can be found at - https://github.com/laramies/th
 * criminalip - 100 free queries/month. 700k/month $59
 * dehashed - 500 credts $15, 5k credits $150
 * dnsdumpster - 50 free querries/day, $49
+* dymo - free tier available, paid plans for higher limits
 * fofa - query credits 10,000/month. 100k results/month $25
 * fullhunt - 50 free queries. 200 queries $29/month, 500 queries $59 
 * github-code

--- a/tests/discovery/test_dymosearch.py
+++ b/tests/discovery/test_dymosearch.py
@@ -1,0 +1,145 @@
+import pytest
+
+from theHarvester.discovery import dymosearch
+from theHarvester.discovery.constants import MissingKey
+
+
+def _patch_dymo_key(monkeypatch, value):
+    import theHarvester.lib.core as core_module
+
+    monkeypatch.setattr(core_module.Core, 'dymo_key', staticmethod(lambda: value), raising=True)
+    monkeypatch.setattr(core_module.Core, 'get_user_agent', staticmethod(lambda: 'UA'), raising=True)
+
+
+class TestDymoSearch:
+    def test_missing_key_raises(self, monkeypatch):
+        _patch_dymo_key(monkeypatch, None)
+        with pytest.raises(MissingKey):
+            dymosearch.SearchDymo('example.com')
+
+    def test_init_sets_state(self, monkeypatch):
+        _patch_dymo_key(monkeypatch, 'token-123')
+        search = dymosearch.SearchDymo('example.com')
+        assert search.word == 'example.com'
+        assert search.key == 'token-123'
+        assert search.proxy is False
+        assert search.totalhosts == set()
+        assert search.results == {}
+
+    def test_headers_use_bearer(self, monkeypatch):
+        _patch_dymo_key(monkeypatch, 'token-abc')
+        search = dymosearch.SearchDymo('example.com')
+        headers = search._headers()
+        assert headers['Authorization'] == 'Bearer token-abc'
+        assert headers['Content-Type'] == 'application/json'
+        assert headers['User-Agent'] == 'UA'
+
+    @pytest.mark.asyncio
+    async def test_process_extracts_canonical_and_suggestion(self, monkeypatch):
+        _patch_dymo_key(monkeypatch, 'token-xyz')
+        captured = {}
+
+        async def fake_post_fetch(url, headers=None, data='', params='', json=False, proxy=False):
+            captured['url'] = url
+            captured['headers'] = headers
+            captured['data'] = data
+            captured['proxy'] = proxy
+            return {
+                'domain': {
+                    'valid': True,
+                    'fraud': False,
+                    'freeSubdomain': False,
+                    'domain': 'exemple.com',
+                    'didYouMean': 'www.exemple.com',
+                },
+                'url': {
+                    'valid': True,
+                    'domain': 'exemple.com',
+                    'didYouMean': None,
+                },
+            }
+
+        import theHarvester.lib.core as core_module
+
+        monkeypatch.setattr(core_module.AsyncFetcher, 'post_fetch', classmethod(lambda cls, *a, **kw: fake_post_fetch(*a, **kw)))
+
+        search = dymosearch.SearchDymo('exemple.com')
+        await search.process(proxy=True)
+
+        assert captured['url'] == dymosearch.SearchDymo.VERIFY_URL
+        assert captured['proxy'] is True
+        assert captured['data'] == {'domain': 'exemple.com', 'url': 'https://exemple.com'}
+        assert captured['headers']['Authorization'] == 'Bearer token-xyz'
+
+        hosts = await search.get_hostnames()
+        results = await search.get_results()
+
+        assert 'exemple.com' in hosts
+        assert 'www.exemple.com' in hosts
+        assert results['domain']['valid'] is True
+
+    @pytest.mark.asyncio
+    async def test_process_handles_empty_payload(self, monkeypatch):
+        _patch_dymo_key(monkeypatch, 'token')
+
+        async def fake_post_fetch(url, headers=None, data='', params='', json=False, proxy=False):
+            return {}
+
+        import theHarvester.lib.core as core_module
+
+        monkeypatch.setattr(core_module.AsyncFetcher, 'post_fetch', classmethod(lambda cls, *a, **kw: fake_post_fetch(*a, **kw)))
+
+        search = dymosearch.SearchDymo('example.com')
+        await search.process()
+        assert await search.get_hostnames() == set()
+        assert await search.get_results() == {}
+
+    @pytest.mark.asyncio
+    async def test_process_ignores_unrelated_suggestion(self, monkeypatch):
+        _patch_dymo_key(monkeypatch, 'token')
+
+        async def fake_post_fetch(url, headers=None, data='', params='', json=False, proxy=False):
+            return {
+                'domain': {
+                    'valid': True,
+                    'domain': 'totally-different.org',
+                    'didYouMean': 'somewhere-else.net',
+                },
+            }
+
+        import theHarvester.lib.core as core_module
+
+        monkeypatch.setattr(core_module.AsyncFetcher, 'post_fetch', classmethod(lambda cls, *a, **kw: fake_post_fetch(*a, **kw)))
+
+        search = dymosearch.SearchDymo('example.com')
+        await search.process()
+        # Neither contains 'example.com', so neither should be added.
+        assert await search.get_hostnames() == set()
+
+    @pytest.mark.asyncio
+    async def test_process_handles_non_dict_response(self, monkeypatch):
+        _patch_dymo_key(monkeypatch, 'token')
+
+        async def fake_post_fetch(url, headers=None, data='', params='', json=False, proxy=False):
+            return '<html>error</html>'
+
+        import theHarvester.lib.core as core_module
+
+        monkeypatch.setattr(core_module.AsyncFetcher, 'post_fetch', classmethod(lambda cls, *a, **kw: fake_post_fetch(*a, **kw)))
+
+        search = dymosearch.SearchDymo('example.com')
+        await search.process()
+        assert await search.get_hostnames() == set()
+        assert search.results == {}
+
+
+class TestDymoIntegration:
+    def test_module_exposes_class(self, monkeypatch):
+        from theHarvester.discovery import dymosearch as mod
+
+        assert hasattr(mod, 'SearchDymo')
+
+    def test_supportedengines_lists_dymo(self):
+        from theHarvester.lib.core import Core
+
+        assert 'dymo' in Core.get_supportedengines()

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -30,6 +30,7 @@ from theHarvester.discovery import (
     crtsh,
     dnssearch,
     duckduckgosearch,
+    dymosearch,
     fofa,
     fullhuntsearch,
     githubcode,
@@ -196,7 +197,7 @@ async def start(rest_args: argparse.Namespace | None = None):
         '-b',
         '--source',
         help="""baidu, bevigil, bitbucket, brave, bufferoverun,
-                            builtwith, censys, certspotter, chaos, commoncrawl, criminalip, crtsh, dehashed, dnsdumpster, duckduckgo, fofa, fullhunt, github-code,
+                            builtwith, censys, certspotter, chaos, commoncrawl, criminalip, crtsh, dehashed, dnsdumpster, duckduckgo, dymo, fofa, fullhunt, github-code,
                             gitlab, hackertarget, haveibeenpwned, hudsonrock, hunter, hunterhow, intelx, leakix, leaklookup, mojeek, netlas, onyphe, otx, pentesttools,
                             projectdiscovery, rapiddns, robtex, rocketreach, securityscorecard, securityTrails, shodan, subdomaincenter,
                             subdomainfinderc99, thc, threatcrowd, tomba, urlscan, venacus, virustotal, waybackarchive, whoisxml, windvane, yahoo, zoomeye""",
@@ -663,6 +664,17 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store_emails=True,
                         )
                     )
+
+                elif engineitem == 'dymo':
+                    try:
+                        dymo_search = dymosearch.SearchDymo(word)
+                        stor_lst.append(store(dymo_search, engineitem, store_host=True))
+                    except Exception as e:
+                        if isinstance(e, MissingKey):
+                            if not args.quiet:
+                                print(f'A Missing Key error occurred in dymo: {e}')
+                        else:
+                            show_default_error_message(engineitem, word, e)
 
                 elif engineitem == 'fofa':
                     try:

--- a/theHarvester/data/api-keys.yaml
+++ b/theHarvester/data/api-keys.yaml
@@ -28,6 +28,9 @@ apikeys:
   dnsdumpster:
     key:
 
+  dymo:
+    key:
+
   fofa:
     key:
     email:

--- a/theHarvester/discovery/dymosearch.py
+++ b/theHarvester/discovery/dymosearch.py
@@ -1,0 +1,75 @@
+from typing import Any
+
+from theHarvester.discovery.constants import MissingKey
+from theHarvester.lib.core import AsyncFetcher, Core
+
+
+class SearchDymo:
+    """Dymo API data verifier source.
+
+    Dymo provides a verification endpoint that takes a domain (and optionally
+    an email/url/ip/phone) and returns metadata such as MX presence, fraud
+    flags, free-subdomain detection, ``didYouMean`` suggestions and the
+    canonical domain. theHarvester does not call it for bulk discovery; it
+    treats it as a low-volume enrichment pass that can confirm the target
+    domain and surface near-miss suggestions as additional host candidates.
+
+    API docs: https://docs.tpeoficial.com/docs/dymo-api/private/data-verifier
+    """
+
+    VERIFY_URL = 'https://api.tpeoficial.com/v1/private/secure/verify'
+
+    def __init__(self, word) -> None:
+        self.word = word
+        self.totalhosts: set[str] = set()
+        self.results: dict[str, Any] = {}
+        self.key = Core.dymo_key()
+        if self.key is None:
+            raise MissingKey('dymo')
+        self.proxy = False
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            'User-Agent': Core.get_user_agent(),
+            'Authorization': f'Bearer {self.key}',
+            'Content-Type': 'application/json',
+        }
+
+    async def do_search(self) -> None:
+        payload = {
+            'domain': self.word,
+            'url': f'https://{self.word}',
+        }
+        response = await AsyncFetcher.post_fetch(
+            self.VERIFY_URL,
+            headers=self._headers(),
+            data=payload,
+            json=True,
+            proxy=self.proxy,
+        )
+        if not isinstance(response, dict):
+            return
+
+        self.results = response
+
+        domain_block = response.get('domain') if isinstance(response.get('domain'), dict) else {}
+        url_block = response.get('url') if isinstance(response.get('url'), dict) else {}
+
+        for block in (domain_block, url_block):
+            candidate = block.get('domain') if isinstance(block, dict) else None
+            if isinstance(candidate, str) and self.word in candidate:
+                self.totalhosts.add(candidate)
+
+            suggestion = block.get('didYouMean') if isinstance(block, dict) else None
+            if isinstance(suggestion, str) and self.word in suggestion:
+                self.totalhosts.add(suggestion)
+
+    async def get_hostnames(self) -> set:
+        return self.totalhosts
+
+    async def get_results(self) -> dict[str, Any]:
+        return self.results
+
+    async def process(self, proxy: bool = False) -> None:
+        self.proxy = proxy
+        await self.do_search()

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -40,6 +40,7 @@ class Core:
         'criminalip': ('key',),
         'dehashed': ('key',),
         'dnsdumpster': ('key',),
+        'dymo': ('key',),
         'fofa': ('key', 'email'),
         'fullhunt': ('key',),
         'github': ('key',),
@@ -133,6 +134,10 @@ class Core:
     @staticmethod
     def dnsdumpster_key() -> str:
         return Core._api_key_value('dnsdumpster')
+
+    @staticmethod
+    def dymo_key() -> str:
+        return Core._api_key_value('dymo')
 
     @staticmethod
     def fofa_key() -> tuple[str, str]:
@@ -284,6 +289,7 @@ class Core:
             'dehashed',
             'dnsdumpster',
             'duckduckgo',
+            'dymo',
             'fofa',
             'fullhunt',
             'github-code',


### PR DESCRIPTION
Closes #2300.

## What this adds

A new passive source, `dymo`, that integrates the [Dymo data verifier API](https://docs.tpeoficial.com/docs/dymo-api/private/data-verifier). The source posts the target domain to `https://api.tpeoficial.com/v1/private/secure/verify` and:

- exposes the full response via `get_results()` so other consumers can read fraud/MX/free-subdomain/no-reply signals,
- adds the canonical `domain` and any `didYouMean` suggestion to `get_hostnames()` when they contain the target word so the existing host-resolution pipeline can pick them up.

The endpoint also accepts `email`, `phone`, `ip`, `url`, `creditCard`, `wallet`, `userAgent`, and `iban` per the docs; the source currently sends `domain` plus `https://<domain>` to keep the shape compatible with theHarvester's `word`-as-domain convention.

## Auth shape

`Authorization: Bearer <token>` against the verify endpoint. The token is read from the new `dymo.key` block in `api-keys.yaml` via `Core.dymo_key()`, matching how other single-key sources (bevigil, fullhunt, netlas, etc.) plumb their keys.

## Files

- `theHarvester/discovery/dymosearch.py` - new `SearchDymo` source.
- `theHarvester/lib/core.py` - `_API_KEY_FIELDS` entry, `dymo_key()` accessor, `'dymo'` added to `get_supportedengines()`.
- `theHarvester/__main__.py` - import, dispatcher branch, `--source` help string.
- `theHarvester/data/api-keys.yaml` - `dymo.key` block (config-key name: `dymo`).
- `README.md` - source list entry + API-key plan note.
- `tests/discovery/test_dymosearch.py` - 9 tests covering missing key, headers, payload shape, empty payload, unrelated suggestion, non-dict response, and engine registration.

## Tests

```
$ uv run pytest tests/
======================= 104 passed, 4 warnings in 46s =======================
```

`uv run ruff check` and `uv run ruff format --check` pass on all touched files. The `test_api_keys_yaml_is_in_sync_with_core_accessors` invariant is preserved (the `dymo` provider is added to both `_API_KEY_FIELDS` and `api-keys.yaml`).