### PR TITLE
Add Sherlockeye as an API-key source module

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Passive modules
 
 * securityTrails: Security Trails search engine, the world's largest repository of historical DNS data (https://securitytrails.com)
 
+* sherlockeye: Reverse Lookup & AI-Powered OSINT (https://sherlockeye.io)
+
 * -s, --shodan: Shodan search engine will search for ports and banners from discovered hosts (https://shodan.io)
 
 * subdomaincenter: A subdomain finder tool used to find subdomains of a given domain (https://www.subdomain.center)
@@ -192,6 +194,7 @@ Documentation to setup API keys can be found at - https://github.com/laramies/th
 * rocketreach - 100 email lookups/month $48, 250 email lookups/month $108
 * securityscorecard - requires a work email
 * securityTrails - 50 free queries/month. 20k queries/month $500
+* sherlockeye - Intermediate $46 month, Advanced $120 month. Enterprise available.
 * shodan - Freelancer $69 month, Small Business $359 month
 * tomba - 25 free searches/month. 1k searches/month $39, 5k searches/month $89
 * venacus - 1 free search/day. 10 searches/day $12, 30 searches/day $36

--- a/tests/discovery/test_sherlockeye.py
+++ b/tests/discovery/test_sherlockeye.py
@@ -1,0 +1,137 @@
+import sys
+import types
+
+import pytest
+
+if 'aiohttp_socks' not in sys.modules:
+    aiohttp_socks_stub = types.ModuleType('aiohttp_socks')
+
+    class _ProxyConnector:
+        @staticmethod
+        def from_url(*_args, **_kwargs):
+            return None
+
+    setattr(aiohttp_socks_stub, 'ProxyConnector', _ProxyConnector)
+    sys.modules['aiohttp_socks'] = aiohttp_socks_stub
+
+from theHarvester.discovery import sherlockeye
+from theHarvester.discovery.constants import MissingKey
+
+
+@pytest.mark.asyncio
+async def test_missing_key_raises(monkeypatch) -> None:
+    monkeypatch.setattr(sherlockeye.Core, 'sherlockeye_key', lambda: None)
+
+    with pytest.raises(MissingKey):
+        sherlockeye.SearchSherlockeye('example.com')
+
+
+@pytest.mark.asyncio
+async def test_process_extracts_domain_intelligence(monkeypatch) -> None:
+    monkeypatch.setattr(sherlockeye.Core, 'sherlockeye_key', lambda: 'dummy-key')
+
+    api_payload = {
+        'success': True,
+        'data': {
+            'searchId': 'search-1',
+            'type': 'domain',
+            'value': 'example.com',
+            'timeoutSeconds': 60,
+            'status': 'complete',
+            'progress': 100,
+            'results': [
+                {
+                    'id': 'result-1',
+                    'source': 'provider-a',
+                    'attributes': {
+                        'domain': 'sub.example.com',
+                        'email': 'user@example.com',
+                        'ip': '203.0.113.10',
+                        'link': 'https://www.example.com/path',
+                    },
+                },
+                {
+                    'id': 'result-2',
+                    'source': 'provider-b',
+                    'attributes': {
+                        'email': 'other@not-example.org',
+                        'link': 'https://api.example.com/docs',
+                    },
+                },
+            ],
+        },
+        'balance': {'credits': 10},
+    }
+
+    class _FakeResponse:
+        status = 200
+
+        async def json(self):
+            return api_payload
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            pass
+
+    class _FakeSession:
+        def __init__(self, **_kwargs):
+            pass
+
+        def post(self, *_args, **_kwargs):
+            return _FakeResponse()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            pass
+
+    monkeypatch.setattr(sherlockeye.aiohttp, 'ClientSession', _FakeSession)
+
+    search = sherlockeye.SearchSherlockeye('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == {'sub.example.com', 'example.com', 'api.example.com'}
+    assert await search.get_emails() == {'user@example.com'}
+    assert await search.get_ips() == {'203.0.113.10'}
+
+
+@pytest.mark.asyncio
+async def test_process_handles_api_error(monkeypatch) -> None:
+    monkeypatch.setattr(sherlockeye.Core, 'sherlockeye_key', lambda: 'dummy-key')
+
+    class _FakeResponse:
+        status = 401
+
+        async def text(self):
+            return '{"success":false,"errorCode":"UNAUTHORIZED","message":"Invalid bearer token"}'
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            pass
+
+    class _FakeSession:
+        def __init__(self, **_kwargs):
+            pass
+
+        def post(self, *_args, **_kwargs):
+            return _FakeResponse()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            pass
+
+    monkeypatch.setattr(sherlockeye.aiohttp, 'ClientSession', _FakeSession)
+
+    search = sherlockeye.SearchSherlockeye('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert await search.get_emails() == set()
+    assert await search.get_ips() == set()

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -56,6 +56,7 @@ from theHarvester.discovery import (
     searchhunterhow,
     securityscorecard,
     securitytrailssearch,
+    sherlockeye,
     shodan_internetdb,
     shodansearch,
     subdomaincenter,
@@ -200,7 +201,7 @@ async def start(rest_args: argparse.Namespace | None = None):
         help="""baidu, bevigil, bitbucket, brave, bufferoverun,
                             builtwith, censys, certspotter, chaos, commoncrawl, criminalip, crtsh, dehashed, dnsdumpster, duckduckgo, dymo, fofa, fullhunt, github-code,
                             gitlab, hackertarget, haveibeenpwned, hudsonrock, hunter, hunterhow, intelx, leakix, leaklookup, mojeek, netlas, onyphe, otx, pentesttools,
-                            projectdiscovery, rapiddns, robtex, rocketreach, securityscorecard, securityTrails, shodan, shodanInternetDB, subdomaincenter,
+                            projectdiscovery, rapiddns, robtex, rocketreach, securityscorecard, securityTrails, sherlockeye, shodan, shodanInternetDB, subdomaincenter,
                             subdomainfinderc99, thc, threatcrowd, tomba, urlscan, venacus, virustotal, waybackarchive, whoisxml, windvane, yahoo, zoomeye""",
     )
 
@@ -1035,6 +1036,25 @@ async def start(rest_args: argparse.Namespace | None = None):
                         if isinstance(e, MissingKey):
                             if not args.quiet:
                                 print(f'A Missing Key error occurred Security Trails: {e}')
+
+                elif engineitem == 'sherlockeye':
+                    try:
+                        sherlockeye_search = sherlockeye.SearchSherlockeye(word)
+                        stor_lst.append(
+                            store(
+                                sherlockeye_search,
+                                engineitem,
+                                store_host=True,
+                                store_ip=True,
+                                store_emails=True,
+                            )
+                        )
+                    except Exception as e:
+                        if isinstance(e, MissingKey):
+                            if not args.quiet:
+                                print(f'A Missing Key error occurred in sherlockeye: {e}')
+                        else:
+                            show_default_error_message(engineitem, word, e)
 
                 elif engineitem == 'shodan':
                     try:

--- a/theHarvester/data/api-keys.yaml
+++ b/theHarvester/data/api-keys.yaml
@@ -86,6 +86,9 @@ apikeys:
   securityTrails:
     key:
 
+  sherlockeye:
+    key:
+
   shodan:
     key:
 

--- a/theHarvester/discovery/sherlockeye.py
+++ b/theHarvester/discovery/sherlockeye.py
@@ -1,0 +1,154 @@
+import random
+from typing import Any
+from urllib.parse import urlparse
+
+import aiohttp
+
+from theHarvester.discovery.constants import MissingKey
+from theHarvester.lib.core import Core
+
+
+class SearchSherlockeye:
+    """Sherlockeye reverse search engine for OSINT investigations.
+
+    Uses the synchronous search endpoint to collect domain-related intelligence
+    such as subdomains, emails, and IP addresses from multiple providers.
+
+    API docs: https://docs.sherlockeye.io/
+    """
+
+    SYNC_SEARCH_URL = 'https://api.sherlockeye.io/v1/searches/sync'
+    DEFAULT_TIMEOUT_SECONDS = 60
+
+    def __init__(self, word: str) -> None:
+        self.word = word
+        self.key = Core.sherlockeye_key()
+        if self.key is None:
+            raise MissingKey('sherlockeye')
+        self.totalhosts: set[str] = set()
+        self.totalemails: set[str] = set()
+        self.totalips: set[str] = set()
+        self.results: list[dict[str, Any]] = []
+        self.proxy: bool | str = False
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            'User-Agent': Core.get_user_agent(),
+            'Authorization': f'Bearer {self.key}',
+            'Content-Type': 'application/json',
+        }
+
+    def _proxy_url(self) -> str | None:
+        if isinstance(self.proxy, str) and self.proxy:
+            return self.proxy
+        if isinstance(self.proxy, bool) and self.proxy:
+            try:
+                proxy_list = Core.proxy_list()
+                proxy_urls = [*proxy_list.get('http', []), *proxy_list.get('socks5', [])]
+                if proxy_urls:
+                    return random.choice(proxy_urls)
+            except Exception:
+                return None
+        return None
+
+    def _add_hostname(self, hostname: str) -> None:
+        hostname = hostname.strip().lower().removeprefix('www.')
+        if hostname.endswith(f'.{self.word}') or hostname == self.word:
+            self.totalhosts.add(hostname)
+
+    def _add_email(self, email: str) -> None:
+        email = email.strip().lower()
+        if '@' in email and self.word in email:
+            self.totalemails.add(email)
+
+    def _add_ip(self, ip_address: str) -> None:
+        ip_address = ip_address.strip()
+        if ip_address:
+            self.totalips.add(ip_address)
+
+    def _extract_from_link(self, link: str) -> None:
+        parsed = urlparse(link.strip())
+        if parsed.hostname:
+            self._add_hostname(parsed.hostname)
+
+    def _extract_result(self, result: dict[str, Any]) -> None:
+        attributes = result.get('attributes')
+        if not isinstance(attributes, dict):
+            return
+
+        domain = attributes.get('domain')
+        if isinstance(domain, str):
+            self._add_hostname(domain)
+
+        email = attributes.get('email')
+        if isinstance(email, str):
+            self._add_email(email)
+
+        ip_address = attributes.get('ip')
+        if isinstance(ip_address, str):
+            self._add_ip(ip_address)
+
+        link = attributes.get('link')
+        if isinstance(link, str):
+            self._extract_from_link(link)
+
+    def _extract_response(self, response: dict[str, Any]) -> None:
+        if response.get('success') is False:
+            message = response.get('message', 'Unknown Sherlockeye API error')
+            print(f'Sherlockeye API error: {message}')
+            return
+
+        data = response.get('data')
+        if not isinstance(data, dict):
+            return
+
+        search_results = data.get('results')
+        if not isinstance(search_results, list):
+            return
+
+        self.results = search_results
+        for result in search_results:
+            if isinstance(result, dict):
+                self._extract_result(result)
+
+    async def do_search(self) -> None:
+        payload = {
+            'type': 'domain',
+            'value': self.word,
+            'timeoutSeconds': self.DEFAULT_TIMEOUT_SECONDS,
+        }
+        timeout = aiohttp.ClientTimeout(total=self.DEFAULT_TIMEOUT_SECONDS + 30)
+
+        try:
+            async with aiohttp.ClientSession(headers=self._headers(), timeout=timeout) as session:
+                async with session.post(
+                    self.SYNC_SEARCH_URL,
+                    json=payload,
+                    proxy=self._proxy_url(),
+                ) as response:
+                    if response.status != 200:
+                        error_body = await response.text()
+                        print(f'Sherlockeye API error ({response.status}): {error_body[:200]}')
+                        return
+
+                    response_data = await response.json()
+                    if isinstance(response_data, dict):
+                        self._extract_response(response_data)
+        except Exception as error:
+            print(f'Sherlockeye API error: {error}')
+
+    async def get_hostnames(self) -> set[str]:
+        return self.totalhosts
+
+    async def get_emails(self) -> set[str]:
+        return self.totalemails
+
+    async def get_ips(self) -> set[str]:
+        return self.totalips
+
+    async def get_results(self) -> list[dict[str, Any]]:
+        return self.results
+
+    async def process(self, proxy: bool = False) -> None:
+        self.proxy = proxy
+        await self.do_search()

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -59,6 +59,7 @@ class Core:
         'rocketreach': ('key',),
         'securityscorecard': ('key',),
         'securityTrails': ('key',),
+        'sherlockeye': ('key',),
         'shodan': ('key',),
         'tomba': ('key', 'secret'),
         'venacus': ('key',),
@@ -212,6 +213,10 @@ class Core:
         return Core._api_key_value('securityTrails')
 
     @staticmethod
+    def sherlockeye_key() -> str:
+        return Core._api_key_value('sherlockeye')
+
+    @staticmethod
     def shodan_key() -> str:
         return Core._api_key_value('shodan')
 
@@ -315,6 +320,7 @@ class Core:
             'rocketreach',
             'securityscorecard',
             'securityTrails',
+            'sherlockeye',
             'shodan',
             'shodanInternetDB',
             'subdomaincenter',


### PR DESCRIPTION
## Summary

- Adds **Sherlockeye** (`-b sherlockeye`) as a new passive discovery module that requires an API key.
- Integrates the [Sherlockeye synchronous search API](https://docs.sherlockeye.io/) (`POST /v1/searches/sync`) for domain lookups, extracting hostnames, emails, and IPs from result attributes.
- Registers the provider in `api-keys.yaml`, `Core._API_KEY_FIELDS`, CLI engine list, and `README.md`.
- Uses `aiohttp` directly for the JSON POST body (same approach as `search_dehashed`, `builtwith`, etc.), since `AsyncFetcher.post_fetch` does not send JSON request bodies correctly.
- Accepts both `complete` and `partial` sync responses so partial results within the timeout window are not discarded.

## Test plan

- [ ] `uv run pytest tests/discovery/test_sherlockeye.py -v`
- [ ] `uv run pytest tests/lib/test_core.py::test_api_keys_yaml_is_in_sync_with_core_accessors -v`
- [ ] Configure `sherlockeye.key` in `~/.theHarvester/api-keys.yaml`
- [ ] `uv run theHarvester -d example.com -b sherlockeye`
- [ ] `uv run ruff check theHarvester/discovery/sherlockeye.py`

<img width="826" height="563" alt="integration" src="https://github.com/user-attachments/assets/6a1e3648-8b82-4f5f-b4b1-d7f82f5984b6" />