### PR TITLE
Remove deprecated gethostbyname in favor of getaddrinfo

### DIFF
--- a/theHarvester/lib/hostchecker.py
+++ b/theHarvester/lib/hostchecker.py
@@ -39,8 +39,8 @@ class Checker:
     async def resolve_host(host: str, resolver: aiodns.DNSResolver) -> str:
         try:
             # TODO add check for ipv6 addrs as well
-            result = await resolver.gethostbyname(host, socket.AF_INET)
-            addresses_list = result.addresses
+            result = await resolver.getaddrinfo(host, socket.AF_INET)
+            addresses_list: list[str] = [r.addr[0] for r in result.nodes]
             if addresses_list == [] or addresses_list is None or result is None:
                 return f'{host}:'
             else:


### PR DESCRIPTION
Revisiting this repo and being a maintainer of aiodns I found a function that was considered by our team as deprecated so I migrated the function away from gethostbyname in favor of getaddrinfo so that it doesn't need migrating to later.