### PR TITLE
docs: add pipx installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ Run theHarvester:
    ```bash
    uv run theHarvester
    ```
+### Alternative installation with pipx
+
+If you prefer an isolated installation without cloning the repository:
+
+```bash
+pipx install theHarvester
+```
+
+If your system default Python is older than 3.12:
+
+```bash
+pipx install --python python3.12 theHarvester
+```
+
+Verify the installation:
+
+```bash
+theHarvester -h
+```
 
 ## Development
 


### PR DESCRIPTION
## Summary

Adds a short pipx installation section to the README.

This documents an alternative installation method for users who prefer
isolated environments and avoids requiring a repository clone for basic use.

## Tested

- Python 3.12
- pipx
- macOS

Verified:

pipx install theHarvester
theHarvester -h