### PR TITLE
Fix HTTP 500 on REST /query with a filename; validate api_scan target

### DIFF
--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -216,6 +216,7 @@ async def start(rest_args: argparse.Namespace | None = None):
             dnsbrute = (rest_args.dns_brute, True)
         else:
             args = rest_args
+            dnsbrute = (args.dns_brute, False)
             # We need to make sure the filename is random as to not overwrite other files
             filename: str = args.filename
             alphabet = string.ascii_letters + string.digits
@@ -1931,6 +1932,19 @@ async def start(rest_args: argparse.Namespace | None = None):
                 else:
                     print(f'An exception has occurred in BuiltWith scanning: {e}')
 
+    if rest_args is not None:
+        all_hosts = sorted({host.replace('www.', '') for host in all_hosts})
+        return (
+            total_asns,
+            interesting_urls,
+            twitter_people_list_tracker,
+            linkedin_people_list_tracker,
+            linkedin_links_tracker,
+            all_urls,
+            all_ip,
+            all_emails,
+            all_hosts,
+        )
     sys.exit(0)
 
 

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -1,5 +1,8 @@
 import argparse
+import asyncio
+import ipaddress
 import os
+import socket
 import traceback
 from typing import Annotated, Any, cast
 
@@ -16,6 +19,19 @@ from theHarvester import __main__
 from theHarvester.lib.api.additional_endpoints import router as additional_router
 
 API_RATE_LIMIT = os.getenv('API_RATE_LIMIT', '5/minute')
+
+
+async def _is_public_target(domain: str) -> bool:
+    host = domain.split('/')[0].split(':')[0]
+    try:
+        infos = await asyncio.get_event_loop().getaddrinfo(host, None)
+    except socket.gaierror:
+        return True  # unresolvable: the scan cannot reach it
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified:
+            return False
+    return True
 
 
 # Define Pydantic models for request and response validation
@@ -308,6 +324,12 @@ async def query(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"Source '{s}' is not supported. Supported sources: {', '.join(supported_engines)}",
                 )
+
+        if api_scan and not await _is_public_target(domain):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail='api_scan target must be a publicly routable host',
+            )
 
         # Call the main function with the provided parameters
         (


### PR DESCRIPTION
# Fix HTTP 500 on REST `/query` with a filename; validate `api_scan` target

Normal public PR, not a security advisory — there is no exploitable SSRF in released code.

## What it fixes

Any REST `/query` request with a `filename` returns HTTP 500. Repro:
`curl -i 'http://127.0.0.1:5000/query?source=crtsh&domain=example.com&filename=test'`.

Two bugs on that path, both fixed in `__main__.py`:

1. **`dnsbrute` unassigned** on the REST normal-search branch in `start()`, so reading it (`if dnsbrute and dnsbrute[0] is True`, ~L1528) raises `UnboundLocalError`. Fix: initialise it as the CLI branch does.
2. With that fixed, the request reaches the final `sys.exit(0)` of `start()` (~L1935). Over the API that raises `SystemExit`, which the handler's `except Exception` can't catch (it's a `BaseException`) → 500. Fix: when called over REST (`rest_args is not None`), return the results tuple instead of exiting. CLI is unchanged.

## api_scan validation

Fixing the crash makes the `api_scan` path reachable over REST for the first time. It issues HTTP requests directly to `domain` (only length-validated; endpoint unauthenticated by default), so this validates `domain` when `api_scan` is set and rejects non-public targets (loopback / RFC1918 / link-local / `169.254.169.254`) with a 400.


## Verification 

- `…&domain=example.com&filename=test` → **200** (was 500).
- `api_scan=true` + `127.0.0.1:8099` / `169.254.169.254` → **400**; public hosts pass.
- No-filename path → 200 (unchanged); CLI still exits via `sys.exit(0)`.
- `ruff check` + `ruff format --check` pass

## Known separate issue (not fixed here)

With a `filename`, the report still isn't written: the save targets `theHarvester/app/static/`, which doesn't exist (the API serves static from `lib/api/static/`). The error is caught, so it no longer 500s, but no file appears. Pre-existing and independent — flagging rather than guessing the intended destination.


## Patch

`git apply theHarvester-query-fix.patch` 
