### PR TITLE
Add --no-hosts result filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `--no-hosts` and the REST `no_hosts` query parameter to disable hostname retrieval, processing, storage, console output, and report export while preserving other result types.
+
 ## [4.11.1] - 2026-06-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ uv run ruff format
 
 To protect the optional `/additional/*` REST API routes, set `THEHARVESTER_API_KEY` and pass the same value in the `X-API-Key` header. Those routes return `503` when the key is not configured.
 
+## Filtering hostname results
+
+Use `--no-hosts` to keep non-host artifacts while disabling hostname retrieval, processing, storage, console output, and report export:
+
+```bash
+theHarvester -d example.com -b duckduckgo,hunter --no-hosts -f example-no-hosts
+```
+
+Directly returned emails, people, URLs, ASNs, and IP addresses remain available. Host-only sources are skipped. Some upstream services may return mixed data in a single response; in those cases, hostname artifacts are discarded locally.
+
+Because they require discovered hosts, `--no-hosts` cannot be combined with `--shodan`, `--dns-resolve`, `--dns-lookup`, `--dns-brute`, `--take-over`, or `--screenshot`. The REST `/query` endpoint exposes the same behavior with the `no_hosts` query parameter.
+
 Passive modules
 ---------------
 

--- a/tests/test_no_hosts.py
+++ b/tests/test_no_hosts.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from theHarvester import __main__
+from theHarvester.lib.host_collection import (
+    HostCollectionOptionError,
+    enabled_host_dependent_options,
+    should_collect_hosts,
+    validate_host_collection_options,
+)
+
+
+class FakeStashManager:
+    stored_types: list[str] = []
+
+    async def do_init(self) -> None:
+        return None
+
+    async def store_all(self, _domain: str, _values: list, result_type: str, _source: str) -> None:
+        self.stored_types.append(result_type)
+
+    async def store(self, _domain: str, _value: str, result_type: str, _source: str) -> None:
+        self.stored_types.append(result_type)
+
+
+class FakeDuckDuckGoSearch:
+    hostnames_requested = False
+    emails_requested = False
+
+    def __init__(self, _domain: str, _limit: int) -> None:
+        pass
+
+    async def process(self, _proxy: bool) -> None:
+        return None
+
+    async def get_hostnames(self) -> list[str]:
+        self.__class__.hostnames_requested = True
+        return ['portal.example.com']
+
+    async def get_emails(self) -> list[str]:
+        self.__class__.emails_requested = True
+        return ['security@example.com']
+
+
+class FakeDymoSearch:
+    process_called = False
+
+    def __init__(self, _domain: str) -> None:
+        pass
+
+    async def process(self, _proxy: bool) -> None:
+        self.__class__.process_called = True
+
+    async def get_hostnames(self) -> list[str]:
+        return ['portal.example.com']
+
+
+class FakeBufferOverSearch:
+    hostnames_requested = False
+    ips_requested = False
+
+    def __init__(self, _domain: str) -> None:
+        pass
+
+    async def process(self, _proxy: bool) -> None:
+        return None
+
+    async def get_hostnames(self) -> list[str]:
+        self.__class__.hostnames_requested = True
+        return ['portal.example.com']
+
+    async def get_ips(self) -> list[str]:
+        self.__class__.ips_requested = True
+        return ['203.0.113.10']
+
+
+def make_rest_args(**overrides) -> argparse.Namespace:
+    values = {
+        'api_scan': False,
+        'dns_brute': False,
+        'dns_lookup': False,
+        'dns_resolve': '',
+        'dns_server': '',
+        'domain': 'example.com',
+        'filename': '',
+        'limit': 10,
+        'no_hosts': True,
+        'proxies': False,
+        'quiet': True,
+        'screenshot': '',
+        'shodan': False,
+        'source': 'duckduckgo',
+        'start': 0,
+        'take_over': False,
+        'wordlist': '',
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def reset_fakes() -> None:
+    FakeStashManager.stored_types.clear()
+    FakeDuckDuckGoSearch.hostnames_requested = False
+    FakeDuckDuckGoSearch.emails_requested = False
+    FakeDymoSearch.process_called = False
+    FakeBufferOverSearch.hostnames_requested = False
+    FakeBufferOverSearch.ips_requested = False
+
+
+def test_should_collect_hosts_defaults_to_enabled() -> None:
+    assert should_collect_hosts(argparse.Namespace()) is True
+    assert should_collect_hosts(argparse.Namespace(no_hosts=False)) is True
+    assert should_collect_hosts(argparse.Namespace(no_hosts=True)) is False
+
+
+@pytest.mark.parametrize(
+    ('overrides', 'expected_option'),
+    [
+        ({'shodan': True}, '--shodan'),
+        ({'dns_lookup': True}, '--dns-lookup'),
+        ({'dns_brute': True}, '--dns-brute'),
+        ({'take_over': True}, '--take-over'),
+        ({'dns_resolve': None}, '--dns-resolve'),
+        ({'dns_resolve': '1.1.1.1'}, '--dns-resolve'),
+        ({'screenshot': 'screenshots'}, '--screenshot'),
+    ],
+)
+def test_enabled_host_dependent_options(overrides: dict[str, object], expected_option: str) -> None:
+    args = make_rest_args(**overrides)
+    assert expected_option in enabled_host_dependent_options(args)
+
+
+def test_validate_host_collection_options_lists_all_conflicts() -> None:
+    args = make_rest_args(shodan=True, dns_lookup=True, screenshot='screenshots')
+
+    with pytest.raises(HostCollectionOptionError) as error:
+        validate_host_collection_options(args)
+
+    message = str(error.value)
+    assert '--no-hosts cannot be combined with:' in message
+    assert '--shodan' in message
+    assert '--dns-lookup' in message
+    assert '--screenshot' in message
+
+
+@pytest.mark.asyncio
+async def test_no_hosts_keeps_emails_without_requesting_or_storing_hostnames(monkeypatch) -> None:
+    reset_fakes()
+    monkeypatch.setattr(__main__.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(__main__.duckduckgosearch, 'SearchDuckDuckGo', FakeDuckDuckGoSearch)
+
+    result = await __main__.start(make_rest_args())
+
+    assert result[-2] == ['security@example.com']
+    assert result[-1] == []
+    assert FakeDuckDuckGoSearch.emails_requested is True
+    assert FakeDuckDuckGoSearch.hostnames_requested is False
+    assert 'email' in FakeStashManager.stored_types
+    assert 'host' not in FakeStashManager.stored_types
+
+
+@pytest.mark.asyncio
+async def test_no_hosts_preserves_direct_ip_results(monkeypatch) -> None:
+    reset_fakes()
+    monkeypatch.setattr(__main__.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(__main__.bufferoverun, 'SearchBufferover', FakeBufferOverSearch)
+
+    result = await __main__.start(make_rest_args(source='bufferoverun'))
+
+    assert result[-3] == ['203.0.113.10']
+    assert result[-1] == []
+    assert FakeBufferOverSearch.ips_requested is True
+    assert FakeBufferOverSearch.hostnames_requested is False
+    assert 'ip' in FakeStashManager.stored_types
+    assert 'host' not in FakeStashManager.stored_types
+
+
+@pytest.mark.asyncio
+async def test_no_hosts_skips_host_only_sources(monkeypatch) -> None:
+    reset_fakes()
+    monkeypatch.setattr(__main__.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(__main__.dymosearch, 'SearchDymo', FakeDymoSearch)
+
+    result = await __main__.start(make_rest_args(source='dymo'))
+
+    assert result[-1] == []
+    assert FakeDymoSearch.process_called is False
+    assert 'host' not in FakeStashManager.stored_types
+
+
+@pytest.mark.asyncio
+async def test_no_hosts_omits_host_console_and_file_output(monkeypatch, tmp_path: Path, capsys) -> None:
+    reset_fakes()
+    monkeypatch.setattr(__main__.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(__main__.duckduckgosearch, 'SearchDuckDuckGo', FakeDuckDuckGoSearch)
+
+    output_base = tmp_path / 'no-hosts-results'
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'theHarvester',
+            '-d',
+            'example.com',
+            '-b',
+            'duckduckgo',
+            '--no-hosts',
+            '-f',
+            str(output_base),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await __main__.start()
+
+    assert exit_info.value.code == 0
+    console_output = capsys.readouterr().out
+    assert 'Hosts found' not in console_output
+    assert 'No hosts found' not in console_output
+
+    json_output = json.loads(output_base.with_suffix('.json').read_text(encoding='utf-8'))
+    xml_output = output_base.with_suffix('.xml').read_text(encoding='utf-8')
+
+    assert json_output['emails'] == ['security@example.com']
+    assert 'hosts' not in json_output
+    assert '<host>' not in xml_output
+    assert '<hostname>' not in xml_output
+    assert FakeDuckDuckGoSearch.hostnames_requested is False

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -77,6 +77,11 @@ from theHarvester.discovery import (
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib import hostchecker, stash
 from theHarvester.lib.core import DATA_DIR, Core, show_default_error_message
+from theHarvester.lib.host_collection import (
+    HostCollectionOptionError,
+    should_collect_hosts,
+    validate_host_collection_options,
+)
 from theHarvester.lib.output import print_linkedin_sections, print_section, sorted_unique
 from theHarvester.screenshot.screenshot import ScreenShotter
 
@@ -139,6 +144,12 @@ async def start(rest_args: argparse.Namespace | None = None):
         '-s',
         '--shodan',
         help='Use Shodan to query discovered hosts.',
+        default=False,
+        action='store_true',
+    )
+    parser.add_argument(
+        '--no-hosts',
+        help='Do not collect, process, display, or export discovered hostnames.',
         default=False,
         action='store_true',
     )
@@ -225,6 +236,14 @@ async def start(rest_args: argparse.Namespace | None = None):
         args = parser.parse_args()
         filename = args.filename
         dnsbrute = (args.dns_brute, False)
+    try:
+        validate_host_collection_options(args)
+    except HostCollectionOptionError as host_option_error:
+        if rest_args is not None:
+            raise
+        parser.error(str(host_option_error))
+
+    collect_hosts = should_collect_hosts(args)
     Core.quiet = getattr(args, 'quiet', False)
     try:
         db = stash.StashManager()
@@ -346,6 +365,21 @@ async def start(rest_args: argparse.Namespace | None = None):
         :param store_interestingurls: whether to store interesting urls
         :param store_asns: whether to store asns
         """
+        stores_non_host_results = any(
+            (
+                store_emails,
+                store_ip,
+                store_people,
+                store_links,
+                store_results,
+                store_interestingurls,
+                store_asns,
+            )
+        )
+        if store_host and not collect_hosts and not stores_non_host_results:
+            print(f'[*] Skipping {source[0].upper() + source[1:]} because host collection is disabled.')
+            return
+
         (
             await search_engine.process(use_proxy)
             if process_param is None
@@ -356,7 +390,7 @@ async def start(rest_args: argparse.Namespace | None = None):
         if source:
             print(f'[*] Searching {source[0].upper() + source[1:]}. ')
 
-        if store_host:
+        if store_host and collect_hosts:
             host_names = list({host for host in await search_engine.get_hostnames() if f'.{word}' in host})
             host_names = list(host_names)
             if source != 'hackertarget' and source != 'pentesttools' and source != 'rapiddns':
@@ -394,10 +428,11 @@ async def start(rest_args: argparse.Namespace | None = None):
         if store_results:
             email_list, host_names, urls = await search_engine.get_results()
             all_emails.extend(email_list)
-            host_names = list({host for host in host_names if f'.{word}' in host})
             all_urls.extend(urls)
-            all_hosts.extend(host_names)
-            await db.store_all(word, all_hosts, 'host', source)
+            if collect_hosts:
+                host_names = list({host for host in host_names if f'.{word}' in host})
+                all_hosts.extend(host_names)
+                await db.store_all(word, all_hosts, 'host', source)
             await db.store_all(word, all_emails, 'email', source)
 
         if store_people:
@@ -1484,9 +1519,9 @@ async def start(rest_args: argparse.Namespace | None = None):
         for person in all_people:
             print(person)
 
-    if len(all_hosts) == 0:
+    if collect_hosts and len(all_hosts) == 0:
         print('\n[*] No hosts found.\n\n')
-    else:
+    elif collect_hosts:
         db = stash.StashManager()
         if dnsresolve is None or len(final_dns_resolver_list) > 0:
             temp = set()
@@ -1525,7 +1560,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 print(host)
 
     # DNS brute force
-    if dnsbrute and dnsbrute[0] is True:
+    if collect_hosts and dnsbrute and dnsbrute[0] is True:
         print('\n[*] Starting DNS brute force.')
         dns_force = dnssearch.DnsForce(word, final_dns_resolver_list, verbose=True)
         resolved_pair, hosts, ips = await dns_force.run()
@@ -1562,7 +1597,7 @@ async def start(rest_args: argparse.Namespace | None = None):
 
     takeover_results = dict()
     # TakeOver Checking
-    if takeover_status:
+    if collect_hosts and takeover_status:
         print('\n[*] Performing subdomain takeover check')
         print('\n[*] Subdomain Takeover checking IS ACTIVE RECON')
         search_take = takeover.TakeOver(all_hosts)
@@ -1572,7 +1607,7 @@ async def start(rest_args: argparse.Namespace | None = None):
     # DNS reverse lookup
     dnsrev: list = []
     # print(f'DNSlookup: {dnslookup}')
-    if dnslookup is True:
+    if collect_hosts and dnslookup is True:
         print('\n[*] Starting active queries for DNSLookup.')
 
         # reverse each iprange in a separate task
@@ -1601,7 +1636,7 @@ async def start(rest_args: argparse.Namespace | None = None):
 
     # Screenshots
     screenshot_tups = []
-    if len(args.screenshot) > 0:
+    if collect_hosts and len(args.screenshot) > 0:
         screen_shotter = ScreenShotter(args.screenshot)
         path_exists = screen_shotter.verify_path()
         # Verify the path exists, if not create it or if user does not create it skips screenshot
@@ -1644,7 +1679,7 @@ async def start(rest_args: argparse.Namespace | None = None):
 
     # Shodan
     shodanres = []
-    if shodan is True:
+    if collect_hosts and shodan is True:
         print('[*] Searching Shodan. ')
         try:
             for ip in host_ip:
@@ -1693,22 +1728,24 @@ async def start(rest_args: argparse.Namespace | None = None):
                 await file.write('<cmd>' + ' '.join(sanitized_args) + '</cmd>')
                 for email in all_emails:
                     await file.write('<email>' + sanitize_for_xml(email) + '</email>')
-                for x in full:
-                    host, ip = x.split(':', 1) if ':' in x else (x, '')
-                    if ip and len(ip) > 3:
-                        await file.write(
-                            f'<host><ip>{sanitize_for_xml(ip)}</ip><hostname>{sanitize_for_xml(host)}</hostname></host>'
-                        )
-                    else:
-                        await file.write(f'<host>{sanitize_for_xml(host)}</host>')
-                for x in vhost:
-                    host, ip = x.split(':', 1) if ':' in x else (x, '')
-                    if ip and len(ip) > 3:
-                        await file.write(
-                            f'<vhost><ip>{sanitize_for_xml(ip)} </ip><hostname>{sanitize_for_xml(host)}</hostname></vhost>'
-                        )
-                    else:
-                        await file.write(f'<vhost>{sanitize_for_xml(host)}</vhost>')
+                if collect_hosts:
+                    for x in full:
+                        host, ip = x.split(':', 1) if ':' in x else (x, '')
+                        if ip and len(ip) > 3:
+                            await file.write(
+                                f'<host><ip>{sanitize_for_xml(ip)}</ip><hostname>{sanitize_for_xml(host)}</hostname></host>'
+                            )
+                        else:
+                            await file.write(f'<host>{sanitize_for_xml(host)}</host>')
+                if collect_hosts:
+                    for x in vhost:
+                        host, ip = x.split(':', 1) if ':' in x else (x, '')
+                        if ip and len(ip) > 3:
+                            await file.write(
+                                f'<vhost><ip>{sanitize_for_xml(ip)} </ip><hostname>{sanitize_for_xml(host)}</hostname></vhost>'
+                            )
+                        else:
+                            await file.write(f'<vhost>{sanitize_for_xml(host)}</vhost>')
                 # TODO add Shodan output into XML report
                 await file.write('</theHarvester>')
                 print('[*] XML File saved.')
@@ -1731,14 +1768,15 @@ async def start(rest_args: argparse.Namespace | None = None):
             if len(all_emails) > 0:
                 json_dict['emails'] = all_emails
 
-            if dnsresolve is None or (len(final_dns_resolver_list) > 0 and len(full) > 0):
-                json_dict['hosts'] = full
-            elif len(all_hosts) > 0:
-                json_dict['hosts'] = all_hosts
-            else:
-                json_dict['hosts'] = []
+            if collect_hosts:
+                if dnsresolve is None or (len(final_dns_resolver_list) > 0 and len(full) > 0):
+                    json_dict['hosts'] = full
+                elif len(all_hosts) > 0:
+                    json_dict['hosts'] = all_hosts
+                else:
+                    json_dict['hosts'] = []
 
-            if vhost and len(vhost) > 0:
+            if collect_hosts and vhost and len(vhost) > 0:
                 json_dict['vhosts'] = vhost
 
             if len(interesting_urls) > 0:
@@ -1885,7 +1923,7 @@ async def start(rest_args: argparse.Namespace | None = None):
             await securityscorecard_scanner.process(use_proxy)
 
             # Use the existing API to get results
-            hosts = await securityscorecard_scanner.get_hostnames()
+            hosts = await securityscorecard_scanner.get_hostnames() if collect_hosts else []
             if hosts:
                 print(f'\n[*] SecurityScorecard results: {len(hosts)} hosts found')
                 for host in hosts:
@@ -1909,7 +1947,7 @@ async def start(rest_args: argparse.Namespace | None = None):
             builtwith_scanner = builtwith.SearchBuiltWith(word)
             await builtwith_scanner.process(use_proxy)
 
-            hosts = await builtwith_scanner.get_hostnames()
+            hosts = await builtwith_scanner.get_hostnames() if collect_hosts else []
             if hosts:
                 print(f'\n[*] BuiltWith results: {len(hosts)} hosts found')
                 for host in hosts:

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -17,6 +17,7 @@ from starlette.staticfiles import StaticFiles
 
 from theHarvester import __main__
 from theHarvester.lib.api.additional_endpoints import router as additional_router
+from theHarvester.lib.host_collection import HostCollectionOptionError
 
 API_RATE_LIMIT = os.getenv('API_RATE_LIMIT', '5/minute')
 
@@ -299,6 +300,7 @@ async def query(
     filename: Annotated[str, Query(description='Save the results to an XML and JSON file')] = '',
     proxies: Annotated[bool, Query(description='Use proxies for requests')] = False,
     shodan: Annotated[bool, Query(description='Use Shodan to query discovered hosts')] = False,
+    no_hosts: Annotated[bool, Query(description='Do not collect, process, display, or export discovered hostnames')] = False,
     take_over: Annotated[bool, Query(description='Check for takeovers')] = False,
     wordlist: Annotated[str, Query(description='Specify a wordlist for API endpoint scanning')] = '',
     api_scan: Annotated[bool, Query(description='Scan for API endpoints')] = False,
@@ -352,6 +354,7 @@ async def query(
                 limit=limit,
                 proxies=proxies,
                 shodan=shodan,
+                no_hosts=no_hosts,
                 source=','.join(source),
                 start=start,
                 take_over=take_over,
@@ -380,6 +383,8 @@ async def query(
     except HTTPException as e:
         # Re-raise HTTP exceptions
         raise e
+    except HostCollectionOptionError as host_option_error:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(host_option_error)) from host_option_error
     except Exception as e:
         # Log the error and return a detailed error response
         error_traceback = traceback.format_exc()

--- a/theHarvester/lib/host_collection.py
+++ b/theHarvester/lib/host_collection.py
@@ -1,0 +1,45 @@
+from argparse import Namespace
+
+
+class HostCollectionOptionError(ValueError):
+    """Raised when host collection is disabled with a host-dependent option."""
+
+
+def should_collect_hosts(args: Namespace) -> bool:
+    """Return whether hostname artifacts should be collected and processed."""
+    return not bool(getattr(args, 'no_hosts', False))
+
+
+def enabled_host_dependent_options(args: Namespace) -> list[str]:
+    """Return host-dependent CLI options enabled in an argument namespace."""
+    enabled_options: list[str] = []
+
+    boolean_options = (
+        ('shodan', '--shodan'),
+        ('dns_lookup', '--dns-lookup'),
+        ('dns_brute', '--dns-brute'),
+        ('take_over', '--take-over'),
+    )
+    for attribute, option in boolean_options:
+        if bool(getattr(args, attribute, False)):
+            enabled_options.append(option)
+
+    dns_resolve = getattr(args, 'dns_resolve', '')
+    if dns_resolve is None or bool(dns_resolve):
+        enabled_options.append('--dns-resolve')
+
+    if bool(getattr(args, 'screenshot', '')):
+        enabled_options.append('--screenshot')
+
+    return enabled_options
+
+
+def validate_host_collection_options(args: Namespace) -> None:
+    """Reject host-dependent options when hostname collection is disabled."""
+    if should_collect_hosts(args):
+        return
+
+    incompatible_options = enabled_host_dependent_options(args)
+    if incompatible_options:
+        options = ', '.join(incompatible_options)
+        raise HostCollectionOptionError(f'--no-hosts cannot be combined with: {options}')


### PR DESCRIPTION
## Summary

Adds a global `--no-hosts` option that disables hostname retrieval,
processing, storage, display, enrichment, and report export while
preserving non-host result types.

Closes #2400

## Changes

- Adds the `--no-hosts` CLI argument.
- Adds `no_hosts=true` support to the REST `/query` endpoint.
- Prevents hostname retrieval when a source exposes hostname results
  separately.
- Filters hostname artifacts from mixed-result sources while retaining
  their non-host results.
- Skips host-only sources when hostname collection is disabled.
- Preserves emails, people, URLs, ASNs, interesting URLs, and IP
  addresses returned directly by a source.
- Omits hostname and virtual-host records from JSON and XML reports.
- Rejects incompatible DNS, Shodan, takeover, and screenshot options.
- Adds automated tests, README documentation, and a changelog entry.

## Validation

- Feature tests: `13 passed`
- Full test suite: `133 passed`
- Ruff linting: passed
- Ruff formatting: passed
- mypy: no issues found in 83 source files
- `git diff --check`: passed

The pytest run produced dependency deprecation warnings from Starlette
and aiosqlite, but no test failures.

## Notes

This option controls hostname collection and processing within
theHarvester. Some upstream services may include hostname data in amixed API response. In those cases, hostname results are discarded
before storage, enrichment, display, or report export.