### PR TITLE
Respect --limit for VirusTotal results

### DIFF
--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -1241,7 +1241,7 @@ async def start(rest_args: argparse.Namespace | None = None):
 
                 elif engineitem == 'virustotal':
                     try:
-                        virustotal_search = virustotal.SearchVirustotal(word)
+                        virustotal_search = virustotal.SearchVirustotal(word, limit)
                         stor_lst.append(store(virustotal_search, engineitem, store_host=True))
                     except Exception as e:
                         if isinstance(e, MissingKey):

--- a/theHarvester/discovery/virustotal.py
+++ b/theHarvester/discovery/virustotal.py
@@ -5,11 +5,12 @@ from theHarvester.lib.core import AsyncFetcher, Core
 
 
 class SearchVirustotal:
-    def __init__(self, word) -> None:
+    def __init__(self, word, limit=500) -> None:
         self.key = Core.virustotal_key()
         if self.key is None:
             raise MissingKey('virustotal')
         self.word = word
+        self.limit = limit
         self.proxy = False
         self.hostnames: list = []
 
@@ -53,13 +54,15 @@ class SearchVirustotal:
                 data = jdata['data']
                 self.hostnames.extend(await self.parse_hostnames(data, self.word))
                 counter += 1
+                if len(set(self.hostnames)) >= self.limit:
+                    break
             await asyncio.sleep(16)
         self.hostnames = list(sorted(set(self.hostnames)))
         # verify domains such as x.x.com.multicdn.x.com are parsed properly
         self.hostnames = [
             host for host in self.hostnames if ((len(host.split('.')) >= 3) and host.split('.')[-2] == self.word.split('.')[-2])
         ]
-
+        self.hostnames = self.hostnames[:self.limit]
     async def get_hostnames(self) -> list:
         return self.hostnames
 


### PR DESCRIPTION
## Summary

This pull request fixes the VirusTotal backend so that it respects the user-supplied `--limit` (`-l`) option.

## Changes

- Pass the `limit` value from `__main__.py` to `SearchVirustotal`.
- Stop requesting additional VirusTotal pages once the requested number of unique hosts has been collected.
- Trim the final hostname list to the requested limit before returning it.

## Testing

Verified with:

```bash
theHarvester -d openai.com -b virustotal -l 5
```

The output now returns exactly 5 hosts, matching the requested limit.