### PR TITLE
Stop invalid Robtex reverse-IP requests

### DIFF
--- a/tests/discovery/test_robtex.py
+++ b/tests/discovery/test_robtex.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+import pytest
+
+from theHarvester.discovery import robtex
+
+
+@pytest.mark.asyncio
+async def test_robtex_does_not_send_domain_to_reverse_ip_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    requested_urls: list[str] = []
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: Any) -> list[str]:
+        requested_urls.extend(urls)
+        return ['{"rrname":"api.example.com","rrtype":"A","rrdata":"192.0.2.1"}']
+
+    monkeypatch.setattr(robtex.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = robtex.SearchRobtex('example.com')
+    await search.process()
+
+    assert requested_urls == ['https://freeapi.robtex.com/pdns/forward/example.com']
+    assert await search.get_hostnames() == {'api.example.com'}
+    assert await search.get_ips() == {'192.0.2.1'}

--- a/theHarvester/discovery/robtex.py
+++ b/theHarvester/discovery/robtex.py
@@ -89,21 +89,6 @@ class SearchRobtex:
                         except (ValueError, TypeError):
                             pass
 
-            # Also try reverse DNS lookup for additional data
-            reverse_url = f'{self.hostname}/pdns/reverse/{self.word}'
-            reverse_response = await AsyncFetcher.fetch_all([reverse_url], headers=headers, proxy=self.proxy)
-
-            if reverse_response and isinstance(reverse_response, list) and reverse_response[0]:
-                try:
-                    reverse_data = self._safe_parse_json_lines(reverse_response[0])
-                    for record in reverse_data:
-                        if isinstance(record, dict):
-                            rrdata = record.get('rrdata', '')
-                            if rrdata and (rrdata.endswith(self.word) or f'.{self.word}' in rrdata):
-                                self.totalhosts.add(rrdata.rstrip('.'))
-                except (TypeError, ValueError) as e:
-                    logger.info(f'Failed to parse reverse DNS data from Robtex: {e}')
-
         except (aiohttp.ClientError, TimeoutError, OSError, TypeError, ValueError) as e:
             logger.info(f'Robtex API error: {e}')
 


### PR DESCRIPTION
## Summary

- keep the Robtex forward passive-DNS request and existing hostname/IP extraction
- stop sending domain names to the IP-only reverse passive-DNS endpoint
- add an offline regression test for the exact request and public getters

## Why

The reverse endpoint expects an IP address, but the adapter supplied the target domain. The request could not produce valid reverse evidence and added unnecessary provider traffic.

Ported as a clean, focused change from NotoriousRebel/theHarvester#110.

## Verification

- focused pytest: 1 passed
- Ruff check and format: passed
- mypy for changed files: passed
- full local suite: 153 passed, 4 skipped; two pre-existing live-provider tests failed before the offline harness in #2411 is merged

No live provider requests were used for this change.