### PR TITLE
Normalize the IntelX result contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ A checkmark means the current CLI can add that result type to its consolidated r
 | `hudsonrock` | ✓ | ✓ | ✓ | — | — | — | — | — |
 | `hunter` | ✓ | ✓ | — | — | — | — | — | ✓ |
 | `hunterhow` | ✓ | — | — | — | — | — | — | ✓ |
-| `intelx` | — | ✓ | — | — | ✓ | — | — | ✓ |
+| `intelx` | ✓ | ✓ | — | — | ✓ | — | — | ✓ |
 | `leakix` | ✓ | ✓ | — | — | — | — | — | Optional |
 | `leaklookup` | — | ✓ | — | — | — | — | `POST /additional/leaks` response | ✓ |
 | `mojeek` | ✓ | ✓ | — | — | — | — | — | Optional |

--- a/tests/discovery/test_intelxsearch.py
+++ b/tests/discovery/test_intelxsearch.py
@@ -1,0 +1,109 @@
+import pytest
+
+from theHarvester.discovery import intelxsearch
+from theHarvester.discovery.constants import MissingKey
+
+
+class _Response:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args) -> None:
+        return None
+
+    async def json(self) -> object:
+        return self.payload
+
+
+class _Session:
+    def __init__(self, result: object, search_result: object | None = None) -> None:
+        self.result = result
+        self.search_result = {'success': True, 'id': 'search-id'} if search_result is None else search_result
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args) -> None:
+        return None
+
+    def post(self, *_args, **_kwargs) -> _Response:
+        return _Response(self.search_result)
+
+    def get(self, *_args, **_kwargs) -> _Response:
+        return _Response(self.result)
+
+
+def test_blank_key_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(intelxsearch.Core, 'intelx_key', staticmethod(lambda: '  '))
+
+    with pytest.raises(MissingKey):
+        intelxsearch.SearchIntelx('example.com')
+
+
+@pytest.mark.asyncio
+async def test_process_exposes_flat_normalized_in_scope_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = {
+        'selectors': [
+            {'selectorvalue': 'ADMIN@Example.COM'},
+            {'selectorvalue': 'outsider@notexample.com'},
+            {'selectorvalue': 'not@an@email@example.com'},
+            {'selectorvalue': 'https://portal.example.com/path'},
+            {'selectorvalue': 'api.example.com.'},
+            {'selectorvalue': 'foo.example.com.evil'},
+            {'selectorvalue': 'http://['},
+            {'selectorvalue': None},
+            None,
+        ]
+    }
+    session = _Session(result)
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(intelxsearch.Core, 'intelx_key', staticmethod(lambda: 'test-key'))
+    monkeypatch.setattr(intelxsearch.aiohttp, 'ClientSession', lambda: session)
+    monkeypatch.setattr(intelxsearch.asyncio, 'sleep', no_sleep)
+
+    search = intelxsearch.SearchIntelx('example.com')
+    await search.process()
+
+    assert await search.get_emails() == ['admin@example.com']
+    assert await search.get_hostnames() == ['api.example.com', 'portal.example.com']
+    assert await search.get_interestingurls() == [
+        'api.example.com.',
+        'foo.example.com.evil',
+        'https://portal.example.com/path',
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('search_result', 'result'),
+    [
+        ({'success': False, 'message': 'denied'}, {}),
+        ({}, {}),
+        ({'success': True, 'id': 'search-id'}, None),
+        ({'success': True, 'id': 'search-id'}, {'selectors': 'invalid'}),
+    ],
+)
+async def test_process_treats_denied_and_malformed_responses_as_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    search_result: object,
+    result: object,
+) -> None:
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(intelxsearch.Core, 'intelx_key', staticmethod(lambda: 'test-key'))
+    monkeypatch.setattr(intelxsearch.aiohttp, 'ClientSession', lambda: _Session(result, search_result))
+    monkeypatch.setattr(intelxsearch.asyncio, 'sleep', no_sleep)
+
+    search = intelxsearch.SearchIntelx('example.com')
+    await search.process()
+
+    assert await search.get_emails() == []
+    assert await search.get_hostnames() == []
+    assert await search.get_interestingurls() == []

--- a/tests/discovery/test_intelxsearch.py
+++ b/tests/discovery/test_intelxsearch.py
@@ -1,5 +1,8 @@
+from argparse import Namespace
+
 import pytest
 
+from theHarvester import __main__ as theharvester_main
 from theHarvester.discovery import intelxsearch
 from theHarvester.discovery.constants import MissingKey
 
@@ -48,6 +51,8 @@ async def test_process_exposes_flat_normalized_in_scope_results(monkeypatch: pyt
     result = {
         'selectors': [
             {'selectorvalue': 'ADMIN@Example.COM'},
+            {'selectorvalue': 'bad local@example.com'},
+            {'selectorvalue': '<>@example.com'},
             {'selectorvalue': 'outsider@notexample.com'},
             {'selectorvalue': 'not@an@email@example.com'},
             {'selectorvalue': 'https://portal.example.com/path'},
@@ -107,3 +112,56 @@ async def test_process_treats_denied_and_malformed_responses_as_empty(
     assert await search.get_emails() == []
     assert await search.get_hostnames() == []
     assert await search.get_interestingurls() == []
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_stores_intelx_hostnames(monkeypatch: pytest.MonkeyPatch) -> None:
+    stored_hosts: list[set[str]] = []
+
+    class _Stash:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, _domain: str, values: list[str], result_type: str, _source: str) -> None:
+            if result_type == 'host':
+                stored_hosts.append(set(values))
+
+    class _Intelx:
+        def __init__(self, _domain: str) -> None:
+            pass
+
+        async def process(self, _proxy: bool) -> None:
+            return None
+
+        async def get_hostnames(self) -> list[str]:
+            return ['example.com', 'api.example.com']
+
+        async def get_emails(self) -> list[str]:
+            return []
+
+        async def get_interestingurls(self) -> list[str]:
+            return []
+
+    monkeypatch.setattr(theharvester_main.stash, 'StashManager', _Stash)
+    monkeypatch.setattr(intelxsearch, 'SearchIntelx', _Intelx)
+
+    results = await theharvester_main.start(
+        Namespace(
+            source='intelx',
+            dns_brute=False,
+            filename='',
+            quiet=True,
+            dns_lookup=False,
+            dns_server=None,
+            dns_resolve='',
+            limit=500,
+            shodan=False,
+            start=0,
+            domain='Example.COM',
+            take_over=False,
+            proxies=False,
+        )
+    )
+
+    assert results[-1] == ['api.example.com', 'example.com']
+    assert stored_hosts == [{'api.example.com', 'example.com'}]

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -369,7 +369,14 @@ async def start(rest_args: argparse.Namespace | None = None):
             output_logger.info(f'[*] Searching {source[0].upper() + source[1:]}. ')
 
         if store_host:
-            host_names = list({host for host in await search_engine.get_hostnames() if f'.{word}' in host})
+            normalized_word = word.lower().rstrip('.')
+            host_names = list(
+                {
+                    host
+                    for host in await search_engine.get_hostnames()
+                    if host.lower().rstrip('.') == normalized_word or f'.{normalized_word}' in host.lower()
+                }
+            )
             host_names = list(host_names)
             if source != 'hackertarget' and source != 'pentesttools' and source != 'rapiddns':
                 # If a source is inside this conditional, it means the hosts returned must be resolved to obtain ip

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -369,14 +369,11 @@ async def start(rest_args: argparse.Namespace | None = None):
             output_logger.info(f'[*] Searching {source[0].upper() + source[1:]}. ')
 
         if store_host:
-            normalized_word = word.lower().rstrip('.')
-            host_names = list(
-                {
-                    host
-                    for host in await search_engine.get_hostnames()
-                    if host.lower().rstrip('.') == normalized_word or f'.{normalized_word}' in host.lower()
-                }
-            )
+            discovered_hosts = await search_engine.get_hostnames()
+            if source == 'intelx':
+                host_names = list(discovered_hosts)
+            else:
+                host_names = list({host for host in discovered_hosts if f'.{word}' in host})
             host_names = list(host_names)
             if source != 'hackertarget' and source != 'pentesttools' and source != 'rapiddns':
                 # If a source is inside this conditional, it means the hosts returned must be resolved to obtain ip

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -820,6 +820,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 intelx_search,
                                 engineitem,
+                                store_host=True,
                                 store_interestingurls=True,
                                 store_emails=True,
                             )

--- a/theHarvester/discovery/intelxsearch.py
+++ b/theHarvester/discovery/intelxsearch.py
@@ -1,5 +1,7 @@
 import asyncio
 import logging
+from email.errors import HeaderParseError
+from email.headerregistry import Address
 from typing import Any
 from urllib.parse import urlparse
 
@@ -35,7 +37,9 @@ class SearchIntelx:
             raise MissingKey('Intelx')
         self.database = 'https://2.intelx.io'
         self.results: dict[str, Any] = {}
-        self.info: tuple[list[str], list[str], list[str]] = ([], [], [])
+        self.emails: list[str] = []
+        self.hostnames: list[str] = []
+        self.interesting_urls: list[str] = []
         self.limit: int = 10000
         self.proxy = False
         self.offset = 0
@@ -91,9 +95,12 @@ class SearchIntelx:
         for email in raw_emails:
             if email.count('@') != 1:
                 continue
-            local_part, domain = email.lower().rsplit('@', maxsplit=1)
-            if local_part and (normalized_domain := _normalize_scoped_hostname(domain, self.word)):
-                emails.add(f'{local_part}@{normalized_domain}')
+            try:
+                address = Address(addr_spec=email.strip().lower())
+            except (HeaderParseError, ValueError):
+                continue
+            if address.username and (normalized_domain := _normalize_scoped_hostname(address.domain, self.word)):
+                emails.add(f'{address.username}@{normalized_domain}')
 
         for selector in raw_selectors:
             try:
@@ -104,13 +111,15 @@ class SearchIntelx:
             if normalized_hostname := _normalize_scoped_hostname(parsed.hostname, self.word):
                 hostnames.add(normalized_hostname)
 
-        self.info = sorted(emails), sorted(interesting_urls), sorted(hostnames)
+        self.emails = sorted(emails)
+        self.interesting_urls = sorted(interesting_urls)
+        self.hostnames = sorted(hostnames)
 
     async def get_emails(self) -> list[str]:
-        return self.info[0]
+        return self.emails
 
     async def get_hostnames(self) -> list[str]:
-        return self.info[2]
+        return self.hostnames
 
     async def get_interestingurls(self) -> list[str]:
-        return self.info[1]
+        return self.interesting_urls

--- a/theHarvester/discovery/intelxsearch.py
+++ b/theHarvester/discovery/intelxsearch.py
@@ -12,11 +12,26 @@ from theHarvester.parsers import intelxparser
 logger = logging.getLogger(__name__)
 
 
+def _normalize_scoped_hostname(value: object, target: str) -> str | None:
+    if not isinstance(value, str):
+        return None
+    hostname = value.strip().lower().rstrip('.')
+    normalized_target = target.strip().lower().rstrip('.')
+    if hostname == normalized_target or hostname.endswith(f'.{normalized_target}'):
+        return hostname
+    return None
+
+
 class SearchIntelx:
+    """Search the Intelligence X Phonebook API.
+
+    API documentation: https://github.com/IntelligenceX/SDK
+    """
+
     def __init__(self, word) -> None:
         self.word = word
         self.key = Core.intelx_key()
-        if self.key is None:
+        if not isinstance(self.key, str) or not self.key.strip():
             raise MissingKey('Intelx')
         self.database = 'https://2.intelx.io'
         self.results: dict[str, Any] = {}
@@ -68,22 +83,34 @@ class SearchIntelx:
         self.proxy = proxy
         await self.do_search()
         intelx_parser = intelxparser.Parser()
-        self.info = await intelx_parser.parse_dictionaries(self.results)
+        raw_emails, raw_selectors = await intelx_parser.parse_dictionaries(self.results)
+        emails: set[str] = set()
+        interesting_urls: set[str] = set()
+        hostnames: set[str] = set()
+
+        for email in raw_emails:
+            if email.count('@') != 1:
+                continue
+            local_part, domain = email.lower().rsplit('@', maxsplit=1)
+            if local_part and (normalized_domain := _normalize_scoped_hostname(domain, self.word)):
+                emails.add(f'{local_part}@{normalized_domain}')
+
+        for selector in raw_selectors:
+            try:
+                parsed = urlparse(selector if '://' in selector else f'//{selector}')
+            except ValueError:
+                continue
+            interesting_urls.add(selector)
+            if normalized_hostname := _normalize_scoped_hostname(parsed.hostname, self.word):
+                hostnames.add(normalized_hostname)
+
+        self.info = sorted(emails), sorted(interesting_urls), sorted(hostnames)
 
     async def get_emails(self) -> list[str]:
         return self.info[0]
 
-    async def get_interestingurls(self) -> tuple[list[str], list[str]]:
-        urls = self.info[1]
-        subdomains = []
+    async def get_hostnames(self) -> list[str]:
+        return self.info[2]
 
-        for url in urls:
-            try:
-                parsed = urlparse(url)
-                domain = parsed.netloc
-                if domain.count('.') > 1 and self.word in domain:
-                    subdomains.append(domain)
-            except Exception:
-                continue
-
-        return urls, list(set(subdomains))
+    async def get_interestingurls(self) -> list[str]:
+        return self.info[1]

--- a/theHarvester/parsers/intelxparser.py
+++ b/theHarvester/parsers/intelxparser.py
@@ -1,25 +1,30 @@
 class Parser:
     def __init__(self) -> None:
-        self.emails: set = set()
-        self.hosts: set = set()
+        self.emails: set[str] = set()
+        self.selectors: set[str] = set()
 
-    async def parse_dictionaries(self, results: dict) -> tuple:
+    async def parse_dictionaries(self, results: object) -> tuple[set[str], set[str]]:
         """Parse method to parse json results
         :param results: Dictionary containing a list of dictionaries known as selectors
-        :return: tuple of emails and hosts
+        :return: tuple of emails and non-email selectors
         """
-        if results is not None:
-            for dictionary in results['selectors']:
-                field = dictionary['selectorvalue']
-                if '@' in field:
-                    self.emails.add(field)
-                else:
-                    field = str(field)
-                    if 'http' in field or 'https' in field:
-                        if field[:5] == 'https':
-                            field = field[8:]
-                        else:
-                            field = field[7:]
-                    self.hosts.add(field.replace(')', '').replace(',', ''))
-            return self.emails, self.hosts
-        return None, None
+        if not isinstance(results, dict):
+            return self.emails, self.selectors
+        selectors = results.get('selectors')
+        if not isinstance(selectors, list):
+            return self.emails, self.selectors
+
+        for dictionary in selectors:
+            if not isinstance(dictionary, dict):
+                continue
+            field = dictionary.get('selectorvalue')
+            if not isinstance(field, str):
+                continue
+            field = field.strip().rstrip('),')
+            if not field:
+                continue
+            if '@' in field and '://' not in field:
+                self.emails.add(field)
+            else:
+                self.selectors.add(field)
+        return self.emails, self.selectors

--- a/theHarvester/parsers/intelxparser.py
+++ b/theHarvester/parsers/intelxparser.py
@@ -14,17 +14,17 @@ class Parser:
         if not isinstance(selectors, list):
             return self.emails, self.selectors
 
-        for dictionary in selectors:
-            if not isinstance(dictionary, dict):
+        for selector in selectors:
+            if not isinstance(selector, dict):
                 continue
-            field = dictionary.get('selectorvalue')
-            if not isinstance(field, str):
+            selector_value = selector.get('selectorvalue')
+            if not isinstance(selector_value, str):
                 continue
-            field = field.strip().rstrip('),')
-            if not field:
+            selector_value = selector_value.strip().rstrip('),')
+            if not selector_value:
                 continue
-            if '@' in field and '://' not in field:
-                self.emails.add(field)
+            if '@' in selector_value and '://' not in selector_value:
+                self.emails.add(selector_value)
             else:
-                self.selectors.add(field)
+                self.selectors.add(selector_value)
         return self.emails, self.selectors


### PR DESCRIPTION
## Summary

- return flat IntelX interesting-URL results instead of nested lists
- normalize and scope email and hostname evidence while retaining parseable third-party selectors as interesting evidence
- handle blank credentials and malformed provider rows without crashing
- route IntelX hostnames through normal persistence and reports
- update the README's executable source matrix and link the official API documentation in the adapter

## Why

The previous getter returned a tuple of lists to a shared path expecting a flat iterable. That could place lists inside the interesting-URL collection, causing SQLite binding failures and TypeError during deduplication. IntelX hostname evidence also never entered normal reports.

Clean port of NotoriousRebel/theHarvester#131; addresses NotoriousRebel/theHarvester#130.

## Verification

- focused IntelX and executable README-contract tests: 7 passed
- Ruff check and format: passed
- mypy for changed Python files: passed
- remaining local suite: 159 passed, 4 skipped, with two known pre-#2411 live-provider tests deselected

Provider requests are covered with a fake aiohttp session; no live IntelX request was used.
