### PR TITLE
Complete Wayback CDX pagination

### DIFF
--- a/tests/discovery/test_waybackarchive.py
+++ b/tests/discovery/test_waybackarchive.py
@@ -10,13 +10,16 @@ from theHarvester.discovery import waybackarchive
 async def test_process_collects_more_than_one_cdx_page(monkeypatch: pytest.MonkeyPatch) -> None:
     first_page = '\n'.join(f'https://host-{index}.example.com/path' for index in range(100))
     second_page = '\n'.join(f'https://host-{index}.example.com/path' for index in range(100, 125))
+    resume_key = 'com%2Cexample%29%2F+20260101000000%21'
     requests: list[dict[str, list[str]]] = []
+    requested_urls: list[str] = []
 
     async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
+        requested_urls.extend(urls)
         query = parse_qs(urlparse(urls[0]).query)
         requests.append(query)
         if query['url'] == ['*.example.com']:
-            return [f'{first_page}\n\nnext-page'] if 'resumeKey' not in query else [second_page]
+            return [f'{first_page}\n\n{resume_key}'] if 'resumeKey' not in query else [second_page]
         return ['']
 
     monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
@@ -25,7 +28,11 @@ async def test_process_collects_more_than_one_cdx_page(monkeypatch: pytest.Monke
     await search.process()
 
     assert await search.get_hostnames() == {f'host-{index}.example.com' for index in range(125)}
-    assert [query.get('resumeKey') for query in requests if query['url'] == ['*.example.com']] == [None, ['next-page']]
+    assert [query.get('resumeKey') for query in requests if query['url'] == ['*.example.com']] == [
+        None,
+        ['com,example)/ 20260101000000!'],
+    ]
+    assert f'resumeKey={resume_key}' in requested_urls[1]
     assert all(query['showResumeKey'] == ['true'] for query in requests)
 
 

--- a/tests/discovery/test_waybackarchive.py
+++ b/tests/discovery/test_waybackarchive.py
@@ -1,0 +1,152 @@
+import logging
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from theHarvester.discovery import waybackarchive
+
+
+@pytest.mark.asyncio
+async def test_process_collects_more_than_one_cdx_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    first_page = '\n'.join(f'https://host-{index}.example.com/path' for index in range(100))
+    second_page = '\n'.join(f'https://host-{index}.example.com/path' for index in range(100, 125))
+    requests: list[dict[str, list[str]]] = []
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
+        query = parse_qs(urlparse(urls[0]).query)
+        requests.append(query)
+        if query['url'] == ['*.example.com']:
+            return [f'{first_page}\n\nnext-page'] if 'resumeKey' not in query else [second_page]
+        return ['']
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = waybackarchive.SearchWaybackarchive('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == {f'host-{index}.example.com' for index in range(125)}
+    assert [query.get('resumeKey') for query in requests if query['url'] == ['*.example.com']] == [None, ['next-page']]
+    assert all(query['showResumeKey'] == ['true'] for query in requests)
+
+
+@pytest.mark.asyncio
+async def test_process_stops_when_a_resume_key_repeats(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[dict[str, list[str]]] = []
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
+        query = parse_qs(urlparse(urls[0]).query)
+        requests.append(query)
+        if query['url'] == ['*.example.com']:
+            return ['https://api.example.com/path\n\nrepeated-key']
+        return ['']
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = waybackarchive.SearchWaybackarchive('example.com')
+    await search.process()
+
+    wildcard_requests = [query for query in requests if query['url'] == ['*.example.com']]
+    assert len(wildcard_requests) == 2
+    assert await search.get_hostnames() == {'api.example.com'}
+
+
+@pytest.mark.asyncio
+async def test_process_normalizes_and_scope_checks_each_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = '\n'.join(
+        (
+            'HTTPS://API.Example.COM:8443/path',
+            'https://example.com/root',
+            'https://notexample.com/path',
+            'https://example.com.attacker.net/path',
+            'https://bad host.example.com/path',
+            'malformed row',
+        )
+    )
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
+        query = parse_qs(urlparse(urls[0]).query)
+        return [payload] if query['url'] == ['*.example.com'] else ['']
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = waybackarchive.SearchWaybackarchive('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com', 'example.com'}
+
+
+@pytest.mark.asyncio
+async def test_process_normalizes_the_requested_domain(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[dict[str, list[str]]] = []
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
+        query = parse_qs(urlparse(urls[0]).query)
+        requests.append(query)
+        return ['https://api.example.com/path'] if query['url'] == ['*.example.com'] else ['']
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = waybackarchive.SearchWaybackarchive('Example.COM.')
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com'}
+    assert requests[0]['url'] == ['*.example.com']
+
+
+@pytest.mark.asyncio
+async def test_process_keeps_partial_results_when_a_later_page_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
+        query = parse_qs(urlparse(urls[0]).query)
+        if query['url'] == ['*.example.com']:
+            if 'resumeKey' in query:
+                raise TimeoutError
+            return ['https://api.example.com/path\n\nnext-page']
+        return ['https://example.com/path']
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = waybackarchive.SearchWaybackarchive('example.com')
+    with caplog.at_level(logging.INFO, logger=waybackarchive.__name__):
+        await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com', 'example.com'}
+    assert 'Wayback Archive API error for pattern *.example.com' in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('payload', ['', '<html>provider error</html>', {'unexpected': 'shape'}])
+async def test_process_ignores_empty_html_and_non_text_responses(monkeypatch: pytest.MonkeyPatch, payload: object) -> None:
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        return [payload]
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = waybackarchive.SearchWaybackarchive('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == set()
+
+
+@pytest.mark.asyncio
+async def test_process_respects_the_per_query_page_bound(monkeypatch: pytest.MonkeyPatch) -> None:
+    wildcard_requests = 0
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
+        nonlocal wildcard_requests
+        query = parse_qs(urlparse(urls[0]).query)
+        if query['url'] == ['*.example.com']:
+            wildcard_requests += 1
+            return [f'https://host-{wildcard_requests}.example.com/path\n\npage-{wildcard_requests}']
+        return ['']
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(waybackarchive.SearchWaybackarchive, 'MAX_PAGES_PER_QUERY', 2)
+
+    search = waybackarchive.SearchWaybackarchive('example.com')
+    await search.process()
+
+    assert wildcard_requests == 2
+    assert await search.get_hostnames() == {'host-1.example.com', 'host-2.example.com'}

--- a/tests/discovery/test_waybackarchive.py
+++ b/tests/discovery/test_waybackarchive.py
@@ -124,21 +124,38 @@ async def test_process_keeps_partial_results_when_a_later_page_times_out(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('payload', ['', '<html>provider error</html>', {'unexpected': 'shape'}])
-async def test_process_ignores_empty_html_and_non_text_responses(monkeypatch: pytest.MonkeyPatch, payload: object) -> None:
+@pytest.mark.parametrize(
+    ('payload', 'expected_log'),
+    [
+        ('', 'returned no page data'),
+        ('<html>provider error</html>', 'returned invalid page data'),
+        ({'unexpected': 'shape'}, 'returned invalid page data'),
+    ],
+)
+async def test_process_ignores_empty_html_and_non_text_responses(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    payload: object,
+    expected_log: str,
+) -> None:
     async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
         return [payload]
 
     monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
 
     search = waybackarchive.SearchWaybackarchive('example.com')
-    await search.process()
+    with caplog.at_level(logging.INFO, logger=waybackarchive.__name__):
+        await search.process()
 
     assert await search.get_hostnames() == set()
+    assert expected_log in caplog.text
 
 
 @pytest.mark.asyncio
-async def test_process_respects_the_per_query_page_bound(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_process_respects_the_per_query_page_bound(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     wildcard_requests = 0
 
     async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
@@ -153,7 +170,9 @@ async def test_process_respects_the_per_query_page_bound(monkeypatch: pytest.Mon
     monkeypatch.setattr(waybackarchive.SearchWaybackarchive, 'MAX_PAGES_PER_QUERY', 2)
 
     search = waybackarchive.SearchWaybackarchive('example.com')
-    await search.process()
+    with caplog.at_level(logging.INFO, logger=waybackarchive.__name__):
+        await search.process()
 
     assert wildcard_requests == 2
     assert await search.get_hostnames() == {'host-1.example.com', 'host-2.example.com'}
+    assert 'Wayback Archive page limit reached for pattern *.example.com; results may be incomplete' in caplog.text

--- a/theHarvester/discovery/waybackarchive.py
+++ b/theHarvester/discovery/waybackarchive.py
@@ -43,9 +43,9 @@ class SearchWaybackarchive:
         return hostname
 
     @staticmethod
-    def _parse_page(payload: str) -> tuple[list[str], str | None]:
+    def _parse_page(payload: object) -> tuple[list[str], str | None] | None:
         if not isinstance(payload, str) or payload.lstrip().startswith('<'):
-            return [], None
+            return None
 
         body, separator, continuation = payload.replace('\r\n', '\n').rpartition('\n\n')
         if not separator:
@@ -70,10 +70,18 @@ class SearchWaybackarchive:
 
             url = f'{self.hostname}/cdx/search/cdx?{urlencode(query)}'
             response = await AsyncFetcher.fetch_all([url], headers=headers, proxy=self.proxy)
-            if not response or not isinstance(response, list) or not response[0]:
+            if not response or not isinstance(response, list):
+                logger.info(f'Wayback Archive returned an invalid response container for pattern {pattern}')
+                return
+            if not response[0]:
+                logger.info(f'Wayback Archive returned no page data for pattern {pattern}')
                 return
 
-            lines, next_resume_key = self._parse_page(response[0])
+            page = self._parse_page(response[0])
+            if page is None:
+                logger.info(f'Wayback Archive returned invalid page data for pattern {pattern}; stopping pagination')
+                return
+            lines, next_resume_key = page
             for line in lines:
                 if not line:
                     continue
@@ -85,6 +93,7 @@ class SearchWaybackarchive:
                 return
             seen_resume_keys.add(next_resume_key)
             resume_key = next_resume_key
+        logger.info(f'Wayback Archive page limit reached for pattern {pattern}; results may be incomplete')
 
     async def do_search(self) -> None:
         try:

--- a/theHarvester/discovery/waybackarchive.py
+++ b/theHarvester/discovery/waybackarchive.py
@@ -1,5 +1,5 @@
 import logging
-import re
+from urllib.parse import urlencode, urlsplit
 
 from theHarvester.lib.core import AsyncFetcher, Core
 
@@ -7,10 +7,17 @@ logger = logging.getLogger(__name__)
 
 
 class SearchWaybackarchive:
-    """Class uses Internet Archive's Wayback Machine CDX API to find historical subdomains"""
+    """Use the Internet Archive Wayback CDX API to find historical subdomains.
+
+    API documentation: https://github.com/internetarchive/wayback/tree/master/wayback-cdx-server
+    """
+
+    PAGE_SIZE = 1000
+    # ponytail: hard cap protects against endless cursors; raise only if real targets exceed one million rows.
+    MAX_PAGES_PER_QUERY = 1000
 
     def __init__(self, word) -> None:
-        self.word = word
+        self.word = word.strip().rstrip('.').lower()
         self.totalhosts: set = set()
         self.proxy = False
         self.hostname = 'https://web.archive.org'
@@ -19,52 +26,76 @@ class SearchWaybackarchive:
         """Extract domain from URL"""
         if not url:
             return ''
+        try:
+            parsed = urlsplit(url if '://' in url else f'//{url}')
+            hostname = (parsed.hostname or '').rstrip('.').lower()
+        except ValueError:
+            return ''
+        if len(hostname) > 253 or any(
+            not label
+            or len(label) > 63
+            or label.startswith('-')
+            or label.endswith('-')
+            or not all(character.isascii() and (character.isalnum() or character == '-') for character in label)
+            for label in hostname.split('.')
+        ):
+            return ''
+        return hostname
 
-        # Remove protocol
-        url = re.sub(r'^https?://', '', url)
+    @staticmethod
+    def _parse_page(payload: str) -> tuple[list[str], str | None]:
+        if not isinstance(payload, str) or payload.lstrip().startswith('<'):
+            return [], None
 
-        # Extract domain part (before first /)
-        domain = url.split('/')[0]
+        body, separator, continuation = payload.replace('\r\n', '\n').rpartition('\n\n')
+        if not separator:
+            return payload.splitlines(), None
 
-        # Remove port if present
-        domain = domain.split(':')[0]
+        continuation_lines = [line.strip() for line in continuation.splitlines() if line.strip()]
+        return body.splitlines(), continuation_lines[0] if len(continuation_lines) == 1 else None
 
-        return domain.lower()
+    async def _search_pattern(self, pattern: str, headers: dict[str, str]) -> None:
+        resume_key: str | None = None
+        seen_resume_keys: set[str] = set()
+        for _ in range(self.MAX_PAGES_PER_QUERY):
+            query = {
+                'url': pattern,
+                'fl': 'original',
+                'collapse': 'urlkey',
+                'limit': self.PAGE_SIZE,
+                'showResumeKey': 'true',
+            }
+            if resume_key is not None:
+                query['resumeKey'] = resume_key
+
+            url = f'{self.hostname}/cdx/search/cdx?{urlencode(query)}'
+            response = await AsyncFetcher.fetch_all([url], headers=headers, proxy=self.proxy)
+            if not response or not isinstance(response, list) or not response[0]:
+                return
+
+            lines, next_resume_key = self._parse_page(response[0])
+            for line in lines:
+                if not line:
+                    continue
+                domain = self._extract_domain_from_url(line.strip())
+                if domain.endswith(f'.{self.word}') or domain == self.word:
+                    self.totalhosts.add(domain)
+
+            if next_resume_key is None or next_resume_key in seen_resume_keys:
+                return
+            seen_resume_keys.add(next_resume_key)
+            resume_key = next_resume_key
 
     async def do_search(self) -> None:
         try:
             headers = {'User-agent': Core.get_user_agent()}
 
-            # Search for subdomains in wayback machine
-            # Using different approaches due to API timeout issues
-
-            # Method 1: Search for wildcard subdomains (limited results to avoid timeout)
-            urls_to_try = [
-                f'{self.hostname}/cdx/search/cdx?url=*.{self.word}&fl=original&collapse=urlkey&limit=100',
-                f'{self.hostname}/cdx/search/cdx?url={self.word}/*&fl=original&collapse=urlkey&limit=50',
-            ]
-
-            for url in urls_to_try:
+            for pattern in (f'*.{self.word}', f'{self.word}/*'):
                 try:
-                    response = await AsyncFetcher.fetch_all([url], headers=headers, proxy=self.proxy)
-
-                    if not response or not isinstance(response, list) or not response[0]:
-                        continue
-
-                    # Parse line-by-line response (not JSON)
-                    lines = response[0].strip().split('\n') if isinstance(response[0], str) else []
-
-                    for line in lines:
-                        if line and not line.startswith('<'):  # Skip HTML error messages
-                            # Each line is a URL
-                            domain = self._extract_domain_from_url(line.strip())
-
-                            # Check if it's a subdomain of our target
-                            if domain.endswith(f'.{self.word}') or domain == self.word:
-                                self.totalhosts.add(domain)
+                    await self._search_pattern(pattern, headers)
 
                 except Exception as e:
-                    logger.info(f'Wayback Archive API error for URL {url}: {e}')
+                    logger.info(f'Wayback Archive API error for pattern {pattern}: {e}')
                     continue
 
         except Exception as e:

--- a/theHarvester/discovery/waybackarchive.py
+++ b/theHarvester/discovery/waybackarchive.py
@@ -1,5 +1,5 @@
 import logging
-from urllib.parse import urlencode, urlsplit
+from urllib.parse import unquote_plus, urlencode, urlsplit
 
 from theHarvester.lib.core import AsyncFetcher, Core
 
@@ -66,7 +66,7 @@ class SearchWaybackarchive:
                 'showResumeKey': 'true',
             }
             if resume_key is not None:
-                query['resumeKey'] = resume_key
+                query['resumeKey'] = unquote_plus(resume_key)
 
             url = f'{self.hostname}/cdx/search/cdx?{urlencode(query)}'
             response = await AsyncFetcher.fetch_all([url], headers=headers, proxy=self.proxy)


### PR DESCRIPTION
## Summary

- follow Wayback CDX resume-key pagination instead of stopping after the first limited response
- normalize and scope-check hostnames on every page
- retain partial results when a later page fails
- stop on missing or repeated cursors and cap each query at one million rows
- cover pagination, malformed responses, scope boundaries, timeouts, and the request cap offline

## Why

The adapter requested only 100 wildcard rows and 50 root rows, so larger CDX result sets were silently truncated. The official CDX documentation recommends resume keys for efficient large queries.

API documentation: https://github.com/internetarchive/wayback/tree/master/wayback-cdx-server

Clean port of NotoriousRebel/theHarvester#69; addresses NotoriousRebel/theHarvester#56.

## Verification

- focused Wayback tests: 9 passed
- Ruff check and format: passed
- mypy for changed files: passed
- remaining local suite: 161 passed, 4 skipped, with two known pre-#2411 live-provider tests deselected

All provider behavior is exercised with a fake fetcher; no live reconnaissance was used.
