### PR TITLE
style: remove remaining em dashes

### DIFF
--- a/theHarvester/discovery/takeover.py
+++ b/theHarvester/discovery/takeover.py
@@ -92,9 +92,9 @@ class TakeOver:
             else:
                 return
         except IndexError:
-            logger.info('Response was empty — possible network error or invalid URL.')
+            logger.info('Response was empty: possible network error or invalid URL.')
         except ujson.JSONDecodeError:
-            logger.info('Failed to parse JSON — cert fingerprints might be unavailable.')
+            logger.info('Failed to parse JSON: cert fingerprints might be unavailable.')
         except KeyError as ke:
             logger.info(f'Missing expected field in fingerprint: {ke}')
         except TypeError as te:


### PR DESCRIPTION
## Summary

- replace the final two em dash characters in tracked source text
- keep the existing takeover log meaning unchanged

## Verification

- repository-wide tracked-file scan finds zero em dash characters
- All checks passed!
- 