### PR TITLE
Complete Cert Spotter pagination

### DIFF
--- a/tests/discovery/test_certspotter.py
+++ b/tests/discovery/test_certspotter.py
@@ -146,7 +146,76 @@ class TestCertspotterSearch(object):
         assert 'results may be incomplete' in caplog.text
 
     @pytest.mark.asyncio
-    async def test_search_stops_on_repeated_cursor(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    @pytest.mark.parametrize('response', [[], [{}]])
+    async def test_search_reports_invalid_response_as_incomplete(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, response: list[Any]
+    ) -> None:
+        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[Any]:
+            return response
+
+        monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
+        with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+            await search.process()
+
+        assert await search.get_hostnames() == set()
+        assert 'results may be incomplete' in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_search_reports_malformed_issuance_as_incomplete(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        pages = [
+            [None, {'id': '1', 'dns_names': ['first.example.com']}],
+            [],
+        ]
+
+        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[Any]:
+            return [pages.pop(0)]
+
+        monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
+        with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+            await search.process()
+
+        assert await search.get_hostnames() == {'first.example.com'}
+        assert 'results may be incomplete' in caplog.text
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        'error',
+        [
+            ConnectionError('private connection details'),
+            RuntimeError('private provider payload'),
+        ],
+    )
+    async def test_search_redacts_unexpected_errors(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, error: Exception
+    ) -> None:
+        responses: list[Any] = [
+            [{'id': '1', 'dns_names': ['first.example.com']}],
+            error,
+        ]
+
+        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[Any]:
+            response = responses.pop(0)
+            if isinstance(response, Exception):
+                raise response
+            return [response]
+
+        monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
+        with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+            await search.process()
+
+        assert await search.get_hostnames() == {'first.example.com'}
+        assert 'results may be incomplete' in caplog.text
+        assert str(error) not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_search_stops_on_repeated_cursor(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
         pages = [
             [{'id': 'repeated', 'dns_names': ['first.example.com']}],
             [{'id': 'repeated', 'dns_names': ['second.example.com']}],
@@ -160,10 +229,12 @@ class TestCertspotterSearch(object):
 
         monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
         search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
-        await search.process()
+        with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+            await search.process()
 
         assert await search.get_hostnames() == {'first.example.com', 'second.example.com'}
         assert calls == 2
+        assert 'results may be incomplete' in caplog.text
 
     @pytest.mark.asyncio
     async def test_search_continues_until_empty_page(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -187,15 +258,25 @@ class TestCertspotterSearch(object):
         assert calls == 12
 
     @pytest.mark.asyncio
-    async def test_search_reports_missing_cursor_as_incomplete(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    @pytest.mark.parametrize(
+        'issuance',
+        [
+            {'dns_names': ['first.example.com']},
+            {'id': '   ', 'dns_names': ['first.example.com']},
+        ],
+    )
+    async def test_search_reports_invalid_cursor_as_incomplete(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        issuance: dict[str, Any],
     ) -> None:
         calls = 0
 
         async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[list[dict[str, Any]]]:
             nonlocal calls
             calls += 1
-            return [[{'dns_names': ['first.example.com']}]]
+            return [[issuance]]
 
         monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
         search = certspottersearch.SearchCertspoter(TestCertspotter.domain())

--- a/tests/discovery/test_certspotter.py
+++ b/tests/discovery/test_certspotter.py
@@ -166,23 +166,44 @@ class TestCertspotterSearch(object):
         assert calls == 2
 
     @pytest.mark.asyncio
-    async def test_search_reports_safety_cap_as_incomplete(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        monkeypatch.setattr(certspottersearch.SearchCertspoter, 'MAX_PAGES', 2)
+    async def test_search_continues_until_empty_page(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pages = [
+            [{'id': str(page_number), 'dns_names': [f'page-{page_number}.example.com']}]
+            for page_number in range(1, 12)
+        ]
+        pages.append([])
         calls = 0
 
         async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[list[dict[str, Any]]]:
             nonlocal calls
             calls += 1
-            return [[{'id': str(calls), 'dns_names': [f'page-{calls}.example.com']}]]
+            return [pages.pop(0)]
+
+        monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
+        await search.process()
+
+        assert await search.get_hostnames() == {f'page-{page_number}.example.com' for page_number in range(1, 12)}
+        assert calls == 12
+
+    @pytest.mark.asyncio
+    async def test_search_reports_missing_cursor_as_incomplete(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        calls = 0
+
+        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[list[dict[str, Any]]]:
+            nonlocal calls
+            calls += 1
+            return [[{'dns_names': ['first.example.com']}]]
 
         monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
         search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
         with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
             await search.process()
 
-        assert await search.get_hostnames() == {'page-1.example.com', 'page-2.example.com'}
+        assert await search.get_hostnames() == {'first.example.com'}
+        assert calls == 1
         assert 'results may be incomplete' in caplog.text
 
 

--- a/tests/discovery/test_certspotter.py
+++ b/tests/discovery/test_certspotter.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # coding=utf-8
+import logging
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
@@ -35,6 +37,153 @@ class TestCertspotterSearch(object):
         search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
         await search.process()
         assert await search.get_hostnames() == {'api.example.com', 'www.example.com'}
+
+    @pytest.mark.asyncio
+    async def test_search_collects_all_pages(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pages = [
+            [{'id': '1', 'dns_names': ['first.example.com']}],
+            [{'id': '2', 'dns_names': ['second.example.com']}],
+            [],
+        ]
+        requested_urls: list[str] = []
+
+        async def fake_fetch_all(urls: list[str], **_kwargs: Any) -> list[list[dict[str, Any]]]:
+            requested_urls.extend(urls)
+            return [pages.pop(0)]
+
+        monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
+        await search.process()
+
+        assert await search.get_hostnames() == {'first.example.com', 'second.example.com'}
+        assert [parse_qs(urlparse(url).query) for url in requested_urls] == [
+            {'domain': ['example.com'], 'include_subdomains': ['true'], 'expand': ['dns_names']},
+            {
+                'domain': ['example.com'],
+                'include_subdomains': ['true'],
+                'expand': ['dns_names'],
+                'after': ['1'],
+            },
+            {
+                'domain': ['example.com'],
+                'include_subdomains': ['true'],
+                'expand': ['dns_names'],
+                'after': ['2'],
+            },
+        ]
+
+    @pytest.mark.asyncio
+    async def test_search_returns_only_normalized_scoped_names(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pages = [
+            [
+                {
+                    'id': '1',
+                    'dns_names': [
+                        'WWW.Example.COM.',
+                        '*.api.example.com',
+                        'example.com',
+                        'outside.test',
+                        'not example.com',
+                        '.example.com',
+                        'bad..example.com',
+                        '-bad.example.com',
+                        None,
+                    ],
+                }
+            ],
+            [],
+        ]
+
+        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[list[dict[str, Any]]]:
+            return [pages.pop(0)]
+
+        monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        search = certspottersearch.SearchCertspoter(' Example.COM. ')
+        await search.process()
+
+        assert await search.get_hostnames() == {'api.example.com', 'example.com', 'www.example.com'}
+
+    @pytest.mark.asyncio
+    async def test_search_preserves_results_when_rate_limited(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        responses: list[Any] = [
+            [{'id': '1', 'dns_names': ['first.example.com']}],
+            {'code': 'rate_limited', 'message': 'provider details must not be logged'},
+        ]
+
+        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[Any]:
+            return [responses.pop(0)]
+
+        monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
+        with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+            await search.process()
+
+        assert await search.get_hostnames() == {'first.example.com'}
+        assert 'rate_limited' in caplog.text
+        assert 'results may be incomplete' in caplog.text
+        assert 'provider details must not be logged' not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_search_reports_transport_failure_as_incomplete(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        responses: list[Any] = [
+            [{'id': '1', 'dns_names': ['first.example.com']}],
+            '',
+        ]
+
+        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[Any]:
+            return [responses.pop(0)]
+
+        monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
+        with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+            await search.process()
+
+        assert await search.get_hostnames() == {'first.example.com'}
+        assert 'results may be incomplete' in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_search_stops_on_repeated_cursor(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pages = [
+            [{'id': 'repeated', 'dns_names': ['first.example.com']}],
+            [{'id': 'repeated', 'dns_names': ['second.example.com']}],
+        ]
+        calls = 0
+
+        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[list[dict[str, Any]]]:
+            nonlocal calls
+            calls += 1
+            return [pages.pop(0)]
+
+        monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
+        await search.process()
+
+        assert await search.get_hostnames() == {'first.example.com', 'second.example.com'}
+        assert calls == 2
+
+    @pytest.mark.asyncio
+    async def test_search_reports_safety_cap_as_incomplete(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setattr(certspottersearch.SearchCertspoter, 'MAX_PAGES', 2)
+        calls = 0
+
+        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[list[dict[str, Any]]]:
+            nonlocal calls
+            calls += 1
+            return [[{'id': str(calls), 'dns_names': [f'page-{calls}.example.com']}]]
+
+        monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
+        with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+            await search.process()
+
+        assert await search.get_hostnames() == {'page-1.example.com', 'page-2.example.com'}
+        assert 'results may be incomplete' in caplog.text
 
 
 if __name__ == "__main__":

--- a/tests/discovery/test_certspotter.py
+++ b/tests/discovery/test_certspotter.py
@@ -73,6 +73,32 @@ class TestCertspotterSearch(object):
         ]
 
     @pytest.mark.asyncio
+    async def test_search_preserves_results_at_page_limit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        requests = 0
+
+        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[list[dict[str, Any]]]:
+            nonlocal requests
+            requests += 1
+            if requests > 2:
+                return [[]]
+            return [[{'id': f'cursor-{requests}', 'dns_names': [f'host-{requests}.example.com']}]]
+
+        monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        monkeypatch.setattr(certspottersearch.SearchCertspoter, 'MAX_PAGES', 2, raising=False)
+
+        search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
+        with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+            await search.process()
+
+        assert requests == 2
+        assert await search.get_hostnames() == {'host-1.example.com', 'host-2.example.com'}
+        assert 'page limit reached; results may be incomplete' in caplog.text
+
+    @pytest.mark.asyncio
     async def test_search_returns_only_normalized_scoped_names(self, monkeypatch: pytest.MonkeyPatch) -> None:
         pages = [
             [

--- a/theHarvester/discovery/certspottersearch.py
+++ b/theHarvester/discovery/certspottersearch.py
@@ -12,6 +12,9 @@ class SearchCertspoter:
     API reference: https://sslmate.com/help/reference/ct_search_api_v1
     """
 
+    # ponytail: hard cap protects against endless unique cursors; raise only if real targets exceed 1,000 pages.
+    MAX_PAGES = 1000
+
     def __init__(self, word) -> None:
         self.word = word.strip().lower().rstrip('.')
         self.totalhosts: set = set()
@@ -22,7 +25,7 @@ class SearchCertspoter:
         cursor = None
         seen_cursors: set[str] = set()
         try:
-            while True:
+            for _ in range(self.MAX_PAGES):
                 params = {
                     'domain': self.word,
                     'include_subdomains': 'true',
@@ -102,6 +105,8 @@ class SearchCertspoter:
                     break
                 seen_cursors.add(next_cursor)
                 cursor = next_cursor
+            else:
+                logger.warning('Cert Spotter page limit reached; results may be incomplete.')
         except ConnectionError:
             logger.warning('Cert Spotter network connection failed; results may be incomplete.')
         except Exception:

--- a/theHarvester/discovery/certspottersearch.py
+++ b/theHarvester/discovery/certspottersearch.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlencode
 
 from theHarvester.lib.core import AsyncFetcher
 
@@ -6,31 +7,79 @@ logger = logging.getLogger(__name__)
 
 
 class SearchCertspoter:
+    MAX_PAGES = 10
+
     def __init__(self, word) -> None:
-        self.word = word
+        self.word = word.strip().lower().rstrip('.')
         self.totalhosts: set = set()
         self.proxy = False
 
     async def do_search(self) -> None:
-        base_url = f'https://api.certspotter.com/v1/issuances?domain={self.word}&expand=dns_names'
+        base_url = 'https://api.certspotter.com/v1/issuances'
+        cursor = None
+        seen_cursors: set[str] = set()
         try:
-            response = await AsyncFetcher.fetch_all([base_url], json=True, proxy=self.proxy)
-            response = response[0]
-            if isinstance(response, list):
-                for dct in response:
-                    for key, value in dct.items():
-                        if key == 'dns_names':
-                            self.totalhosts.update({name for name in value if isinstance(name, str) and name})
-            elif isinstance(response, dict):
-                dns_names = response.get('dns_names')
-                if isinstance(dns_names, list):
-                    self.totalhosts.update({name for name in dns_names if isinstance(name, str) and name})
-                elif isinstance(dns_names, str) and dns_names:
-                    self.totalhosts.add(dns_names)
+            for _ in range(self.MAX_PAGES):
+                params = {
+                    'domain': self.word,
+                    'include_subdomains': 'true',
+                    'expand': 'dns_names',
+                }
+                if cursor is not None:
+                    params['after'] = cursor
+
+                responses = await AsyncFetcher.fetch_all([f'{base_url}?{urlencode(params)}'], json=True, proxy=self.proxy)
+                if not responses:
+                    break
+
+                page = responses[0]
+                if isinstance(page, dict):
+                    code = page.get('code')
+                    if isinstance(code, str):
+                        logger.warning(f'Cert Spotter stopped early ({code}); results may be incomplete.')
+                    break
+                if not isinstance(page, list):
+                    logger.warning('Cert Spotter stopped early; results may be incomplete.')
+                    break
+                if not page:
+                    break
+
+                for issuance in page:
+                    if not isinstance(issuance, dict):
+                        continue
+                    dns_names = issuance.get('dns_names')
+                    if isinstance(dns_names, list):
+                        for name in dns_names:
+                            if not isinstance(name, str):
+                                continue
+                            name = name.strip().lower().rstrip('.').removeprefix('*.')
+                            labels = name.split('.')
+                            if (
+                                name
+                                and len(name) <= 253
+                                and name.isascii()
+                                and '*' not in name
+                                and not any(character.isspace() for character in name)
+                                and all(
+                                    label
+                                    and len(label) <= 63
+                                    and label[0].isalnum()
+                                    and label[-1].isalnum()
+                                    and all(character.isalnum() or character == '-' for character in label)
+                                    for label in labels
+                                )
+                                and (name == self.word or name.endswith(f'.{self.word}'))
+                            ):
+                                self.totalhosts.add(name)
+
+                last_issuance = page[-1]
+                next_cursor = last_issuance.get('id') if isinstance(last_issuance, dict) else None
+                if not isinstance(next_cursor, str) or not next_cursor or next_cursor in seen_cursors:
+                    break
+                seen_cursors.add(next_cursor)
+                cursor = next_cursor
             else:
-                self.totalhosts.update({''})
-        except IndexError:
-            logger.info('No data returned from Cert Spotter.')
+                logger.warning(f'Cert Spotter stopped after {self.MAX_PAGES} pages; results may be incomplete.')
         except ConnectionError:
             logger.info('Network connection failed.')
         except Exception as e:

--- a/theHarvester/discovery/certspottersearch.py
+++ b/theHarvester/discovery/certspottersearch.py
@@ -7,7 +7,10 @@ logger = logging.getLogger(__name__)
 
 
 class SearchCertspoter:
-    MAX_PAGES = 10
+    """Search the SSLMate Cert Spotter CT Search API.
+
+    API reference: https://sslmate.com/help/reference/ct_search_api_v1
+    """
 
     def __init__(self, word) -> None:
         self.word = word.strip().lower().rstrip('.')
@@ -19,7 +22,7 @@ class SearchCertspoter:
         cursor = None
         seen_cursors: set[str] = set()
         try:
-            for _ in range(self.MAX_PAGES):
+            while True:
                 params = {
                     'domain': self.word,
                     'include_subdomains': 'true',
@@ -74,12 +77,19 @@ class SearchCertspoter:
 
                 last_issuance = page[-1]
                 next_cursor = last_issuance.get('id') if isinstance(last_issuance, dict) else None
-                if not isinstance(next_cursor, str) or not next_cursor or next_cursor in seen_cursors:
+                if not isinstance(next_cursor, str) or not next_cursor:
+                    logger.warning(
+                        'Cert Spotter stopped early because the response did not provide a valid cursor; '
+                        'results may be incomplete.'
+                    )
+                    break
+                if next_cursor in seen_cursors:
+                    logger.warning(
+                        'Cert Spotter stopped early because the response repeated a cursor; results may be incomplete.'
+                    )
                     break
                 seen_cursors.add(next_cursor)
                 cursor = next_cursor
-            else:
-                logger.warning(f'Cert Spotter stopped after {self.MAX_PAGES} pages; results may be incomplete.')
         except ConnectionError:
             logger.info('Network connection failed.')
         except Exception as e:

--- a/theHarvester/discovery/certspottersearch.py
+++ b/theHarvester/discovery/certspottersearch.py
@@ -33,6 +33,7 @@ class SearchCertspoter:
 
                 responses = await AsyncFetcher.fetch_all([f'{base_url}?{urlencode(params)}'], json=True, proxy=self.proxy)
                 if not responses:
+                    logger.warning('Cert Spotter stopped early; results may be incomplete.')
                     break
 
                 page = responses[0]
@@ -40,6 +41,8 @@ class SearchCertspoter:
                     code = page.get('code')
                     if isinstance(code, str):
                         logger.warning(f'Cert Spotter stopped early ({code}); results may be incomplete.')
+                    else:
+                        logger.warning('Cert Spotter stopped early; results may be incomplete.')
                     break
                 if not isinstance(page, list):
                     logger.warning('Cert Spotter stopped early; results may be incomplete.')
@@ -47,36 +50,45 @@ class SearchCertspoter:
                 if not page:
                     break
 
+                malformed_issuance = False
                 for issuance in page:
                     if not isinstance(issuance, dict):
+                        malformed_issuance = True
                         continue
                     dns_names = issuance.get('dns_names')
-                    if isinstance(dns_names, list):
-                        for name in dns_names:
-                            if not isinstance(name, str):
-                                continue
-                            name = name.strip().lower().rstrip('.').removeprefix('*.')
-                            labels = name.split('.')
-                            if (
-                                name
-                                and len(name) <= 253
-                                and name.isascii()
-                                and '*' not in name
-                                and not any(character.isspace() for character in name)
-                                and all(
-                                    label
-                                    and len(label) <= 63
-                                    and label[0].isalnum()
-                                    and label[-1].isalnum()
-                                    and all(character.isalnum() or character == '-' for character in label)
-                                    for label in labels
-                                )
-                                and (name == self.word or name.endswith(f'.{self.word}'))
-                            ):
-                                self.totalhosts.add(name)
+                    if not isinstance(dns_names, list):
+                        malformed_issuance = True
+                        continue
+                    for name in dns_names:
+                        if not isinstance(name, str):
+                            malformed_issuance = True
+                            continue
+                        name = name.strip().lower().rstrip('.').removeprefix('*.')
+                        labels = name.split('.')
+                        if (
+                            name
+                            and len(name) <= 253
+                            and name.isascii()
+                            and '*' not in name
+                            and not any(character.isspace() for character in name)
+                            and all(
+                                label
+                                and len(label) <= 63
+                                and label[0].isalnum()
+                                and label[-1].isalnum()
+                                and all(character.isalnum() or character == '-' for character in label)
+                                for label in labels
+                            )
+                            and (name == self.word or name.endswith(f'.{self.word}'))
+                        ):
+                            self.totalhosts.add(name)
+                if malformed_issuance:
+                    logger.warning('Cert Spotter ignored malformed issuance data; results may be incomplete.')
 
                 last_issuance = page[-1]
                 next_cursor = last_issuance.get('id') if isinstance(last_issuance, dict) else None
+                if isinstance(next_cursor, str):
+                    next_cursor = next_cursor.strip()
                 if not isinstance(next_cursor, str) or not next_cursor:
                     logger.warning(
                         'Cert Spotter stopped early because the response did not provide a valid cursor; '
@@ -91,9 +103,9 @@ class SearchCertspoter:
                 seen_cursors.add(next_cursor)
                 cursor = next_cursor
         except ConnectionError:
-            logger.info('Network connection failed.')
-        except Exception as e:
-            logger.info(f'Unexpected error occurred: {e}')
+            logger.warning('Cert Spotter network connection failed; results may be incomplete.')
+        except Exception:
+            logger.warning('Cert Spotter stopped after an unexpected error; results may be incomplete.')
 
     async def get_hostnames(self) -> set:
         return self.totalhosts


### PR DESCRIPTION
## Summary

- request descendant names and expanded DNS names from the Cert Spotter issuance API
- follow the last issuance ID as the opaque pagination cursor
- normalize, validate, deduplicate, and scope names from every page
- preserve partial results and warn on malformed responses, provider errors, missing or repeated cursors, and transport failures
- bound unique-cursor pagination at 1,000 pages so a provider cannot loop indefinitely

## Why

The source previously consumed only one response and could miss descendant names on later pages. This change follows the provider pagination contract while keeping termination deterministic and retaining useful partial results when collection cannot complete.

API reference: https://sslmate.com/help/reference/ct_search_api_v1

## Scope

This is a clean two-file port from NotoriousRebel/theHarvester#70. It excludes workflow changes, private research, and fork-only evidence architecture.

## Verification

- focused Cert Spotter tests: 15 passed, 1 skipped live test
- full offline suite: 189 passed, 6 skipped live tests
- Ruff lint and format checks passed
- mypy passed for product code and the Cert Spotter tests
- git diff check passed
- Standards review: no findings
- Spec review: no findings

No live provider request was used.
