### PR TITLE
Exhaust current Common Crawl indexes

### DIFF
--- a/tests/discovery/test_commoncrawl.py
+++ b/tests/discovery/test_commoncrawl.py
@@ -1,0 +1,135 @@
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from theHarvester.discovery import commoncrawl
+
+
+@pytest.mark.asyncio
+async def test_process_exhausts_current_catalog_index_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    catalog = [
+        {
+            'id': 'CC-MAIN-2026-30',
+            'cdx-api': 'https://index.commoncrawl.org/CC-MAIN-2026-30-index',
+            'to': '2026-07-12T00:00:00',
+        }
+    ]
+
+    async def fake_fetch_all(urls: list[str], **kwargs: object) -> list[object]:
+        if urls == ['https://index.commoncrawl.org/collinfo.json']:
+            assert kwargs['json'] is True
+            return [catalog]
+
+        responses: list[str] = []
+        for url in urls:
+            query = parse_qs(urlsplit(url).query)
+            if query.get('showNumPages') == ['true']:
+                responses.append('{"pages": 2, "pageSize": 5, "blocks": 6}')
+            elif query['url'] == ['*.example.com'] and query['page'] == ['0']:
+                responses.append('{"url":"https://api.example.com/v1"}')
+            elif query['url'] == ['*.example.com'] and query['page'] == ['1']:
+                responses.append('{"url":"https://mail.example.com/inbox"}')
+            elif query['url'] == ['example.com/*'] and query['page'] == ['0']:
+                responses.append('{"url":"https://example.com/"}')
+            else:
+                responses.append('{"url":"https://www.example.com/about"}')
+        return responses
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = commoncrawl.SearchCommoncrawl('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == {
+        'api.example.com',
+        'example.com',
+        'mail.example.com',
+        'www.example.com',
+    }
+
+
+@pytest.mark.asyncio
+async def test_process_uses_unique_indexes_from_latest_catalog_year_window_and_scopes_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current_endpoint = 'https://index.commoncrawl.org/CC-MAIN-2026-30-index'
+    recent_endpoint = 'https://index.commoncrawl.org/CC-MAIN-2025-35-index'
+    old_endpoint = 'https://index.commoncrawl.org/CC-MAIN-2024-30-index'
+    catalog = [
+        {'id': 'CC-MAIN-2026-30', 'cdx-api': current_endpoint, 'to': '2026-07-12T00:00:00'},
+        {'id': 'CC-MAIN-2025-35', 'cdx-api': recent_endpoint, 'to': '2025-08-28T00:00:00'},
+        {'id': 'CC-MAIN-2026-30-copy', 'cdx-api': current_endpoint, 'to': '2026-07-12T00:00:00'},
+        {'id': 'CC-MAIN-2024-30', 'cdx-api': old_endpoint, 'to': '2024-07-22T00:00:00'},
+    ]
+    requested_urls: list[str] = []
+
+    async def fake_fetch_all(urls: list[str], **kwargs: object) -> list[object]:
+        if urls == ['https://index.commoncrawl.org/collinfo.json']:
+            return [catalog]
+
+        requested_urls.extend(urls)
+        responses: list[str] = []
+        for url in urls:
+            parsed = urlsplit(url)
+            query = parse_qs(parsed.query)
+            if query.get('showNumPages') == ['true']:
+                responses.append('{"pages": 1, "pageSize": 5, "blocks": 1}')
+            elif parsed.path.endswith('CC-MAIN-2026-30-index') and query['url'] == ['*.example.com']:
+                responses.append('{"url":"https://API.Example.COM./v1"}')
+            elif parsed.path.endswith('CC-MAIN-2026-30-index'):
+                responses.append('{"url":"https://example.com/"}')
+            elif query['url'] == ['*.example.com']:
+                responses.append('{"url":"https://api.example.com/duplicate"}\n{"url":"https://dev.example.com/"}')
+            else:
+                responses.append('{"url":"https://example.com.attacker.net/"}\n{"url":"https://notexample.com/"}')
+        return responses
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = commoncrawl.SearchCommoncrawl('Example.COM.')
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com', 'dev.example.com', 'example.com'}
+    assert sum(current_endpoint in url for url in requested_urls) == 4
+    assert sum(recent_endpoint in url for url in requested_urls) == 4
+    assert all(old_endpoint not in url for url in requested_urls)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('broken_payload', ['not-json', ''])
+async def test_process_reports_failed_or_malformed_index_without_discarding_other_results(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], broken_payload: str
+) -> None:
+    broken_endpoint = 'https://index.commoncrawl.org/CC-MAIN-2026-30-index'
+    good_endpoint = 'https://index.commoncrawl.org/CC-MAIN-2026-26-index'
+    catalog = [
+        {'id': 'CC-MAIN-BROKEN', 'cdx-api': 'https://index.commoncrawl.org/broken-index'},
+        {'id': 'CC-MAIN-2026-30', 'cdx-api': broken_endpoint, 'to': '2026-07-12T00:00:00'},
+        {'id': 'CC-MAIN-2026-26', 'cdx-api': good_endpoint, 'to': '2026-06-18T00:00:00'},
+    ]
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        if urls == ['https://index.commoncrawl.org/collinfo.json']:
+            return [catalog]
+
+        responses: list[str] = []
+        for url in urls:
+            parsed = urlsplit(url)
+            query = parse_qs(parsed.query)
+            if query.get('showNumPages') == ['true']:
+                responses.append('{"pages": 1, "pageSize": 5, "blocks": 1}')
+            elif parsed.path.endswith('CC-MAIN-2026-30-index'):
+                responses.append(broken_payload)
+            else:
+                responses.append('{"url":"https://survivor.example.com/"}')
+        return responses
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = commoncrawl.SearchCommoncrawl('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == {'survivor.example.com'}
+    output = capsys.readouterr().out
+    assert 'CC-MAIN-BROKEN' in output
+    assert 'CC-MAIN-2026-30' in output

--- a/tests/discovery/test_commoncrawl.py
+++ b/tests/discovery/test_commoncrawl.py
@@ -1,3 +1,4 @@
+import logging
 from urllib.parse import parse_qs, urlsplit
 
 import pytest
@@ -98,7 +99,7 @@ async def test_process_uses_unique_indexes_from_latest_catalog_year_window_and_s
 @pytest.mark.asyncio
 @pytest.mark.parametrize('broken_payload', ['not-json', ''])
 async def test_process_reports_failed_or_malformed_index_without_discarding_other_results(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], broken_payload: str
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, broken_payload: str
 ) -> None:
     broken_endpoint = 'https://index.commoncrawl.org/CC-MAIN-2026-30-index'
     good_endpoint = 'https://index.commoncrawl.org/CC-MAIN-2026-26-index'
@@ -127,9 +128,67 @@ async def test_process_reports_failed_or_malformed_index_without_discarding_othe
     monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
 
     search = commoncrawl.SearchCommoncrawl('example.com')
-    await search.process()
+    with caplog.at_level(logging.WARNING, logger=commoncrawl.__name__):
+        await search.process()
 
     assert await search.get_hostnames() == {'survivor.example.com'}
-    output = capsys.readouterr().out
-    assert 'CC-MAIN-BROKEN' in output
-    assert 'CC-MAIN-2026-30' in output
+    assert 'CC-MAIN-BROKEN' in caplog.text
+    assert 'CC-MAIN-2026-30' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_process_reports_non_json_upstream_response(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    catalog = [
+        {
+            'id': 'CC-MAIN-2026-30',
+            'cdx-api': 'https://index.commoncrawl.org/CC-MAIN-2026-30-index',
+            'to': '2026-07-12T00:00:00',
+        }
+    ]
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        if urls == ['https://index.commoncrawl.org/collinfo.json']:
+            return [catalog]
+        if 'showNumPages=true' in urls[0]:
+            return ['{"pages": 1, "pageSize": 5, "blocks": 1}']
+        return ['<html><h1>504 Gateway Time-out</h1></html>']
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    with (
+        caplog.at_level(logging.WARNING, logger=commoncrawl.__name__),
+        pytest.raises(RuntimeError, match='all Common Crawl queries failed'),
+    ):
+        await commoncrawl.SearchCommoncrawl('example.com').process()
+
+    assert 'unexpected non-JSON response' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_process_keeps_results_when_another_query_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    catalog = [
+        {
+            'id': 'CC-MAIN-2026-30',
+            'cdx-api': 'https://index.commoncrawl.org/CC-MAIN-2026-30-index',
+            'to': '2026-07-12T00:00:00',
+        }
+    ]
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        if urls == ['https://index.commoncrawl.org/collinfo.json']:
+            return [catalog]
+        query = parse_qs(urlsplit(urls[0]).query)
+        if query.get('showNumPages') == ['true']:
+            return ['{"pages": 1, "pageSize": 5, "blocks": 1}']
+        if query['url'] == ['*.example.com']:
+            return ['{"url":"https://api.example.com/v1"}']
+        return ['<html><h1>504 Gateway Time-out</h1></html>']
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = commoncrawl.SearchCommoncrawl('example.com')
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com'}

--- a/tests/discovery/test_commoncrawl.py
+++ b/tests/discovery/test_commoncrawl.py
@@ -21,7 +21,7 @@ async def test_process_exhausts_current_catalog_index_pages(monkeypatch: pytest.
             assert kwargs['json'] is True
             return [catalog]
 
-        responses: list[str] = []
+        responses: list[object] = []
         for url in urls:
             query = parse_qs(urlsplit(url).query)
             if query.get('showNumPages') == ['true']:
@@ -69,7 +69,7 @@ async def test_process_uses_unique_indexes_from_latest_catalog_year_window_and_s
             return [catalog]
 
         requested_urls.extend(urls)
-        responses: list[str] = []
+        responses: list[object] = []
         for url in urls:
             parsed = urlsplit(url)
             query = parse_qs(parsed.query)
@@ -97,6 +97,69 @@ async def test_process_uses_unique_indexes_from_latest_catalog_year_window_and_s
 
 
 @pytest.mark.asyncio
+async def test_process_rejects_untrusted_catalog_endpoints(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    catalog = [
+        {
+            'id': 'CC-MAIN-HOSTILE',
+            'cdx-api': 'https://internal.example/CC-MAIN-HOSTILE-index',
+            'to': '2026-07-13T00:00:00',
+        },
+        {
+            'id': 'CC-MAIN-2026-30',
+            'cdx-api': 'https://index.commoncrawl.org/CC-MAIN-2026-30-index',
+            'to': '2026-07-12T00:00:00',
+        },
+    ]
+    requested_urls: list[str] = []
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        if urls == ['https://index.commoncrawl.org/collinfo.json']:
+            return [catalog]
+        requested_urls.extend(urls)
+        return ['{"pages": 0, "pageSize": 5, "blocks": 0}']
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    with caplog.at_level(logging.WARNING, logger=commoncrawl.__name__):
+        await commoncrawl.SearchCommoncrawl('example.com').process()
+
+    assert requested_urls
+    assert all(url.startswith('https://index.commoncrawl.org/') for url in requested_urls)
+    assert 'CC-MAIN-HOSTILE' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_process_batches_provider_page_counts(monkeypatch: pytest.MonkeyPatch) -> None:
+    catalog = [
+        {
+            'id': 'CC-MAIN-2026-30',
+            'cdx-api': 'https://index.commoncrawl.org/CC-MAIN-2026-30-index',
+            'to': '2026-07-12T00:00:00',
+        }
+    ]
+    page_batches: list[int] = []
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        if urls == ['https://index.commoncrawl.org/collinfo.json']:
+            return [catalog]
+        query = parse_qs(urlsplit(urls[0]).query)
+        if query.get('showNumPages') == ['true']:
+            return ['{"pages": 3, "pageSize": 5, "blocks": 3}']
+        page_batches.append(len(urls))
+        return [f'{{"url":"https://host-{parse_qs(urlsplit(url).query)["page"][0]}.example.com/"}}' for url in urls]
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(commoncrawl.SearchCommoncrawl, 'PAGE_BATCH_SIZE', 2, raising=False)
+
+    await commoncrawl.SearchCommoncrawl('example.com').process()
+
+    assert page_batches == [2, 1, 2, 1]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize('broken_payload', ['not-json', ''])
 async def test_process_reports_failed_or_malformed_index_without_discarding_other_results(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, broken_payload: str
@@ -113,7 +176,7 @@ async def test_process_reports_failed_or_malformed_index_without_discarding_othe
         if urls == ['https://index.commoncrawl.org/collinfo.json']:
             return [catalog]
 
-        responses: list[str] = []
+        responses: list[object] = []
         for url in urls:
             parsed = urlsplit(url)
             query = parse_qs(parsed.query)
@@ -164,6 +227,43 @@ async def test_process_reports_non_json_upstream_response(
         await commoncrawl.SearchCommoncrawl('example.com').process()
 
     assert 'unexpected non-JSON response' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_process_keeps_later_valid_page_after_malformed_page(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    catalog = [
+        {
+            'id': 'CC-MAIN-2026-30',
+            'cdx-api': 'https://index.commoncrawl.org/CC-MAIN-2026-30-index',
+            'to': '2026-07-12T00:00:00',
+        }
+    ]
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        if urls == ['https://index.commoncrawl.org/collinfo.json']:
+            return [catalog]
+        query = parse_qs(urlsplit(urls[0]).query)
+        if query.get('showNumPages') == ['true']:
+            pages = 2 if query['url'] == ['*.example.com'] else 1
+            return [f'{{"pages": {pages}, "pageSize": 5, "blocks": {pages}}}']
+        if query['url'] == ['*.example.com']:
+            return [
+                'not-json' if parse_qs(urlsplit(url).query)['page'] == ['0'] else '{"url":"https://api.example.com/v1"}'
+                for url in urls
+            ]
+        return ['<html><h1>504 Gateway Time-out</h1></html>']
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = commoncrawl.SearchCommoncrawl('example.com')
+
+    with caplog.at_level(logging.WARNING, logger=commoncrawl.__name__):
+        await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com'}
+    assert 'malformed JSON line' in caplog.text
 
 
 @pytest.mark.asyncio

--- a/theHarvester/discovery/commoncrawl.py
+++ b/theHarvester/discovery/commoncrawl.py
@@ -1,7 +1,8 @@
 import json as _stdlib_json
 import logging
-import re
+from datetime import datetime, timedelta
 from types import ModuleType
+from urllib.parse import urlencode, urlsplit
 
 from theHarvester.lib.core import AsyncFetcher, Core
 
@@ -19,11 +20,14 @@ except Exception:
 
 
 class SearchCommoncrawl:
-    """Class uses Common Crawl index API to gather subdomains from archived web data"""
+    """Gather subdomains from every crawl ending within one year of the newest catalog entry."""
+
+    INDEX_LOOKBACK = timedelta(days=365)
+    PAGE_SIZE = 5
 
     def __init__(self, word) -> None:
-        self.word = word
-        self.totalhosts: set = set()
+        self.word = word.lower().rstrip('.')
+        self.totalhosts: set[str] = set()
         self.proxy = False
         self.hostname = 'https://index.commoncrawl.org'
 
@@ -33,13 +37,15 @@ class SearchCommoncrawl:
         results: list = []
         if not payload:
             return results
+        if payload.lstrip().startswith('<'):
+            raise ValueError('unexpected non-JSON response')
 
         for line in payload.strip().split('\n'):
             if line.strip():
                 try:
                     results.append(json.loads(line))
-                except Exception:
-                    continue
+                except Exception as error:
+                    raise ValueError('malformed JSON line') from error
         return results
 
     def _extract_domain_from_url(self, url: str) -> str:
@@ -47,79 +53,87 @@ class SearchCommoncrawl:
         if not url:
             return ''
 
-        # Remove protocol
-        url = re.sub(r'^https?://', '', url)
+        parsed = urlsplit(url if '://' in url else f'//{url}')
+        return (parsed.hostname or '').lower().rstrip('.')
 
-        # Extract domain part (before first /)
-        domain = url.split('/')[0]
+    @classmethod
+    def _select_indexes(cls, catalog: list[object]) -> list[dict]:
+        dated_indexes: list[tuple[datetime, dict]] = []
+        for entry in catalog:
+            if not isinstance(entry, dict):
+                logger.warning('Common Crawl API error for index unknown: invalid catalog entry')
+                continue
+            index_id = entry.get('id', 'unknown')
+            if not isinstance(entry.get('cdx-api'), str):
+                logger.warning(f'Common Crawl API error for index {index_id}: invalid catalog entry')
+                continue
+            try:
+                timestamp = datetime.fromisoformat(str(entry['to'])).replace(tzinfo=None)
+            except (KeyError, ValueError):
+                logger.warning(f'Common Crawl API error for index {index_id}: invalid catalog entry')
+                continue
+            dated_indexes.append((timestamp, entry))
 
-        # Remove port if present
-        domain = domain.split(':')[0]
+        if not dated_indexes:
+            return []
 
-        return domain.lower()
+        cutoff = max(timestamp for timestamp, _ in dated_indexes) - cls.INDEX_LOOKBACK
+        selected: list[dict] = []
+        endpoints: set[str] = set()
+        for timestamp, entry in sorted(dated_indexes, key=lambda item: item[0], reverse=True):
+            endpoint = entry['cdx-api']
+            if timestamp >= cutoff and endpoint not in endpoints:
+                endpoints.add(endpoint)
+                selected.append(entry)
+        return selected
 
     async def do_search(self) -> None:
         try:
             headers = {'User-agent': Core.get_user_agent()}
+            catalog_response = await AsyncFetcher.fetch_all(
+                [f'{self.hostname}/collinfo.json'], headers=headers, proxy=self.proxy, json=True
+            )
+            if not catalog_response or not isinstance(catalog_response[0], list) or not catalog_response[0]:
+                logger.error('Common Crawl API error: invalid index catalog')
+                return
 
-            # Use recent Common Crawl indexes
-            indexes = [
-                'CC-MAIN-2024-18',  # April 2024
-                'CC-MAIN-2024-10',  # February 2024
-                'CC-MAIN-2023-50',  # December 2023
-            ]
+            indexes = self._select_indexes(catalog_response[0])
+            if not indexes:
+                logger.error('Common Crawl API error: index catalog contains no usable entries')
+                return
 
+            successful_queries = 0
             for index in indexes:
-                try:
-                    # Search for subdomains using wildcard
-                    url = f'{self.hostname}/{index}-index?url=*.{self.word}&output=json&limit=1000'
-
-                    response = await AsyncFetcher.fetch_all([url], headers=headers, proxy=self.proxy)
-
-                    if not response or not isinstance(response, list) or not response[0]:
-                        continue
-
+                endpoint = index['cdx-api']
+                for query in (f'*.{self.word}', f'{self.word}/*'):
                     try:
-                        data = self._safe_parse_json_lines(response[0])
-                    except Exception as e:
-                        logger.info(f'Failed to parse Common Crawl response for {index}: {e}')
-                        continue
-
-                    # Extract domains from URLs
-                    for record in data:
-                        if isinstance(record, dict):
-                            original_url = record.get('url', '')
-                            if original_url:
-                                domain = self._extract_domain_from_url(original_url)
-
-                                # Check if it's a subdomain of our target
-                                if domain.endswith(f'.{self.word}') or domain == self.word:
-                                    self.totalhosts.add(domain)
-
-                    # Also search for the main domain
-                    main_url = f'{self.hostname}/{index}-index?url={self.word}/*&output=json&limit=100'
-
-                    main_response = await AsyncFetcher.fetch_all([main_url], headers=headers, proxy=self.proxy)
-
-                    if main_response and isinstance(main_response, list) and main_response[0]:
-                        try:
-                            main_data = self._safe_parse_json_lines(main_response[0])
-                            for record in main_data:
+                        count_url = f'{endpoint}?{urlencode({"url": query, "output": "json", "pageSize": self.PAGE_SIZE, "showNumPages": "true"})}'
+                        count_response = await AsyncFetcher.fetch_all([count_url], headers=headers, proxy=self.proxy)
+                        page_count = json.loads(count_response[0])['pages']
+                        page_urls = [
+                            f'{endpoint}?{urlencode({"url": query, "output": "json", "pageSize": self.PAGE_SIZE, "page": page})}'
+                            for page in range(page_count)
+                        ]
+                        responses = await AsyncFetcher.fetch_all(page_urls, headers=headers, proxy=self.proxy)
+                        for response in responses:
+                            if not response:
+                                raise ValueError('empty page response')
+                            for record in self._safe_parse_json_lines(response):
                                 if isinstance(record, dict):
-                                    original_url = record.get('url', '')
-                                    if original_url:
-                                        domain = self._extract_domain_from_url(original_url)
-                                        if domain.endswith(f'.{self.word}') or domain == self.word:
-                                            self.totalhosts.add(domain)
-                        except Exception as e:
-                            logger.info(f'Failed to parse Common Crawl main domain response for {index}: {e}')
+                                    domain = self._extract_domain_from_url(record.get('url', ''))
+                                    if domain.endswith(f'.{self.word}') or domain == self.word:
+                                        self.totalhosts.add(domain)
+                        successful_queries += 1
+                    except Exception as error:
+                        logger.warning(f'Common Crawl API error for index {index.get("id", "unknown")}: {error}')
 
-                except Exception as e:
-                    logger.info(f'Common Crawl API error for index {index}: {e}')
-                    continue
+            if not successful_queries:
+                raise RuntimeError('all Common Crawl queries failed')
 
-        except Exception as e:
-            logger.info(f'Common Crawl API error: {e}')
+        except RuntimeError:
+            raise
+        except Exception as error:
+            logger.error(f'Common Crawl API error: {error}')
 
     async def get_hostnames(self) -> set:
         return self.totalhosts

--- a/theHarvester/discovery/commoncrawl.py
+++ b/theHarvester/discovery/commoncrawl.py
@@ -24,6 +24,7 @@ class SearchCommoncrawl:
 
     INDEX_LOOKBACK = timedelta(days=365)
     PAGE_SIZE = 5
+    PAGE_BATCH_SIZE = 10
 
     def __init__(self, word) -> None:
         self.word = word.lower().rstrip('.')
@@ -35,6 +36,7 @@ class SearchCommoncrawl:
     def _safe_parse_json_lines(payload: str) -> list:
         """Parse JSON lines format"""
         results: list = []
+        malformed = False
         if not payload:
             return results
         if payload.lstrip().startswith('<'):
@@ -44,8 +46,12 @@ class SearchCommoncrawl:
             if line.strip():
                 try:
                     results.append(json.loads(line))
-                except Exception as error:
-                    raise ValueError('malformed JSON line') from error
+                except Exception:
+                    malformed = True
+        if malformed:
+            if not results:
+                raise ValueError('malformed JSON line')
+            logger.warning('Common Crawl response contained a malformed JSON line; valid records were preserved')
         return results
 
     def _extract_domain_from_url(self, url: str) -> str:
@@ -64,7 +70,19 @@ class SearchCommoncrawl:
                 logger.warning('Common Crawl API error for index unknown: invalid catalog entry')
                 continue
             index_id = entry.get('id', 'unknown')
-            if not isinstance(entry.get('cdx-api'), str):
+            endpoint = entry.get('cdx-api')
+            if not isinstance(endpoint, str):
+                logger.warning(f'Common Crawl API error for index {index_id}: invalid catalog entry')
+                continue
+            parsed_endpoint = urlsplit(endpoint)
+            if (
+                parsed_endpoint.scheme != 'https'
+                or parsed_endpoint.netloc != 'index.commoncrawl.org'
+                or not parsed_endpoint.path.startswith('/CC-MAIN-')
+                or not parsed_endpoint.path.endswith('-index')
+                or parsed_endpoint.query
+                or parsed_endpoint.fragment
+            ):
                 logger.warning(f'Common Crawl API error for index {index_id}: invalid catalog entry')
                 continue
             try:
@@ -109,25 +127,41 @@ class SearchCommoncrawl:
                     try:
                         count_url = f'{endpoint}?{urlencode({"url": query, "output": "json", "pageSize": self.PAGE_SIZE, "showNumPages": "true"})}'
                         count_response = await AsyncFetcher.fetch_all([count_url], headers=headers, proxy=self.proxy)
-                        page_count = json.loads(count_response[0])['pages']
-                        page_urls = [
-                            f'{endpoint}?{urlencode({"url": query, "output": "json", "pageSize": self.PAGE_SIZE, "page": page})}'
-                            for page in range(page_count)
-                        ]
-                        responses = await AsyncFetcher.fetch_all(page_urls, headers=headers, proxy=self.proxy)
-                        for response in responses:
-                            if not response:
-                                raise ValueError('empty page response')
-                            for record in self._safe_parse_json_lines(response):
-                                if isinstance(record, dict):
-                                    domain = self._extract_domain_from_url(record.get('url', ''))
-                                    if domain.endswith(f'.{self.word}') or domain == self.word:
-                                        self.totalhosts.add(domain)
-                        successful_queries += 1
+                        count_payload = json.loads(count_response[0])
+                        page_count = count_payload.get('pages') if isinstance(count_payload, dict) else None
+                        if isinstance(page_count, bool) or not isinstance(page_count, int) or page_count < 0:
+                            raise ValueError('invalid page count')
+                        query_succeeded = page_count == 0
+                        for first_page in range(0, page_count, self.PAGE_BATCH_SIZE):
+                            page_urls = [
+                                f'{endpoint}?{urlencode({"url": query, "output": "json", "pageSize": self.PAGE_SIZE, "page": page})}'
+                                for page in range(first_page, min(first_page + self.PAGE_BATCH_SIZE, page_count))
+                            ]
+                            responses = await AsyncFetcher.fetch_all(page_urls, headers=headers, proxy=self.proxy)
+                            if not isinstance(responses, list) or not responses:
+                                raise ValueError('invalid page batch')
+                            for response in responses:
+                                try:
+                                    if not response:
+                                        raise ValueError('empty page response')
+                                    for record in self._safe_parse_json_lines(response):
+                                        if isinstance(record, dict):
+                                            domain = self._extract_domain_from_url(record.get('url', ''))
+                                            if domain.endswith(f'.{self.word}') or domain == self.word:
+                                                self.totalhosts.add(domain)
+                                    query_succeeded = True
+                                except ValueError as error:
+                                    logger.warning(f'Common Crawl page error for index {index.get("id", "unknown")}: {error}')
+                                except Exception:
+                                    logger.warning(
+                                        f'Common Crawl page error for index {index.get("id", "unknown")}: unexpected page failure'
+                                    )
+                        if query_succeeded:
+                            successful_queries += 1
                     except Exception as error:
                         logger.warning(f'Common Crawl API error for index {index.get("id", "unknown")}: {error}')
 
-            if not successful_queries:
+            if not successful_queries and not self.totalhosts:
                 raise RuntimeError('all Common Crawl queries failed')
 
         except RuntimeError:

--- a/theHarvester/discovery/commoncrawl.py
+++ b/theHarvester/discovery/commoncrawl.py
@@ -20,7 +20,11 @@ except Exception:
 
 
 class SearchCommoncrawl:
-    """Gather subdomains from every crawl ending within one year of the newest catalog entry."""
+    """Gather subdomains from every crawl ending within one year of the newest catalog entry.
+
+    API docs: https://commoncrawl.org/get-started
+    Index catalog: https://index.commoncrawl.org/collinfo.json
+    """
 
     INDEX_LOOKBACK = timedelta(days=365)
     PAGE_SIZE = 5


### PR DESCRIPTION
## Summary

- discover current crawl indexes from the official Common Crawl catalog
- select unique indexes ending within one year of the newest catalog entry
- enumerate every page for wildcard and root-domain queries
- fetch pages in batches of ten to bound memory and concurrent requests without truncating results
- accept only official Common Crawl HTTPS index endpoints before forwarding the target or proxy setting
- normalize, scope, and deduplicate hostnames across indexes and pages
- preserve usable partial results when another page, query, or index fails

## Why

The source used three fixed 2023 and 2024 index names and fixed record limits. Those indexes become stale and leave later pages unqueried. This change follows the current catalog and page-count protocol while keeping failures observable and isolating malformed pages.

API docs: https://commoncrawl.org/get-started

Index catalog: https://index.commoncrawl.org/collinfo.json

## Scope

This is a clean two-file port from NotoriousRebel/theHarvester#73 and issue #57. It excludes private research and fork-only evidence architecture.

## Verification

- focused Common Crawl tests: 9 passed
- full offline suite: 184 passed, 6 skipped live tests
- Ruff lint and format checks passed
- mypy passed for product code and the Common Crawl tests
- git diff check passed
- Standards review: no findings
- Spec review: no findings
- zero direct print calls and zero em dashes

No live Common Crawl request was used.
