### PR TITLE
Enforce parser domain boundaries

### DIFF
--- a/tests/test_myparser.py
+++ b/tests/test_myparser.py
@@ -8,12 +8,18 @@ from theHarvester.parsers import myparser
 
 class TestMyParser(object):
     @pytest.mark.asyncio
-    async def test_emails(self) -> None:
-        word = "domain.com"
-        results = "@domain.com***a@domain***banotherdomain.com***c@domain.com***d@sub.domain.com***"
+    async def test_emails_respect_target_label_boundaries(self) -> None:
+        word = "Example.COM."
+        results = "Admin@Example.COM***admin@notexample.com***.Lead@Sub.Example.COM.***other@outside.test"
         parse = myparser.Parser(results, word)
-        emails = sorted(await parse.emails())
-        assert emails, ["c@domain.com", "d@sub.domain.com"]
+        assert await parse.emails() == {"admin@example.com", "lead@sub.example.com"}
+
+    @pytest.mark.asyncio
+    async def test_hostnames_respect_target_label_boundaries(self) -> None:
+        word = "Example.COM."
+        results = "API.Example.COM. badexample.com outside.test sub.example.com"
+        parse = myparser.Parser(results, word)
+        assert set(await parse.hostnames()) == {"api.example.com", "sub.example.com"}
 
 
 if __name__ == "__main__":

--- a/tests/test_myparser.py
+++ b/tests/test_myparser.py
@@ -8,18 +8,25 @@ from theHarvester.parsers import myparser
 
 class TestMyParser(object):
     @pytest.mark.asyncio
-    async def test_emails_respect_target_label_boundaries(self) -> None:
-        word = "Example.COM."
+    @pytest.mark.parametrize('word', ['Example.COM.', 'WWW.Example.COM.'])
+    async def test_emails_respect_target_label_boundaries(self, word: str) -> None:
         results = "Admin@Example.COM***admin@notexample.com***.Lead@Sub.Example.COM.***other@outside.test"
         parse = myparser.Parser(results, word)
         assert await parse.emails() == {"admin@example.com", "lead@sub.example.com"}
 
     @pytest.mark.asyncio
-    async def test_hostnames_respect_target_label_boundaries(self) -> None:
-        word = "Example.COM."
-        results = "API.Example.COM. badexample.com outside.test sub.example.com"
+    @pytest.mark.parametrize('word', ['Example.COM.', 'WWW.Example.COM.'])
+    async def test_hostnames_respect_target_label_boundaries(self, word: str) -> None:
+        results = "Example.COM. API.Example.COM. badexample.com outside.test sub.example.com"
         parse = myparser.Parser(results, word)
-        assert set(await parse.hostnames()) == {"api.example.com", "sub.example.com"}
+        assert set(await parse.hostnames()) == {"api.example.com", "example.com", "sub.example.com"}
+
+    @pytest.mark.asyncio
+    async def test_empty_target_fails_closed(self) -> None:
+        parse = myparser.Parser('admin@example.com api.example.com', '')
+
+        assert await parse.emails() == set()
+        assert await parse.hostnames() == []
 
 
 if __name__ == "__main__":

--- a/theHarvester/discovery/intelxsearch.py
+++ b/theHarvester/discovery/intelxsearch.py
@@ -9,19 +9,10 @@ import aiohttp
 
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib.core import Core
+from theHarvester.lib.hostnames import normalize_scoped_hostname
 from theHarvester.parsers import intelxparser
 
 logger = logging.getLogger(__name__)
-
-
-def _normalize_scoped_hostname(value: object, target: str) -> str | None:
-    if not isinstance(value, str):
-        return None
-    hostname = value.strip().lower().rstrip('.')
-    normalized_target = target.strip().lower().rstrip('.')
-    if hostname == normalized_target or hostname.endswith(f'.{normalized_target}'):
-        return hostname
-    return None
 
 
 class SearchIntelx:
@@ -99,7 +90,7 @@ class SearchIntelx:
                 address = Address(addr_spec=email.strip().lower())
             except (HeaderParseError, ValueError):
                 continue
-            if address.username and (normalized_domain := _normalize_scoped_hostname(address.domain, self.word)):
+            if address.username and (normalized_domain := normalize_scoped_hostname(address.domain, self.word)):
                 emails.add(f'{address.username}@{normalized_domain}')
 
         for selector in raw_selectors:
@@ -108,7 +99,7 @@ class SearchIntelx:
             except ValueError:
                 continue
             interesting_urls.add(selector)
-            if normalized_hostname := _normalize_scoped_hostname(parsed.hostname, self.word):
+            if normalized_hostname := normalize_scoped_hostname(parsed.hostname, self.word):
                 hostnames.add(normalized_hostname)
 
         self.emails = sorted(emails)

--- a/theHarvester/lib/hostnames.py
+++ b/theHarvester/lib/hostnames.py
@@ -1,0 +1,9 @@
+def normalize_scoped_hostname(value: object, target: str) -> str | None:
+    """Return a canonical hostname when value is inside the target boundary."""
+    if not isinstance(value, str):
+        return None
+    hostname = value.strip().lower().rstrip('.')
+    normalized_target = target.strip().lower().rstrip('.')
+    if hostname == normalized_target or hostname.endswith(f'.{normalized_target}'):
+        return hostname
+    return None

--- a/theHarvester/lib/hostnames.py
+++ b/theHarvester/lib/hostnames.py
@@ -4,6 +4,8 @@ def normalize_scoped_hostname(value: object, target: str) -> str | None:
         return None
     hostname = value.strip().lower().rstrip('.')
     normalized_target = target.strip().lower().rstrip('.')
+    if not normalized_target:
+        return None
     if hostname == normalized_target or hostname.endswith(f'.{normalized_target}'):
         return hostname
     return None

--- a/theHarvester/parsers/myparser.py
+++ b/theHarvester/parsers/myparser.py
@@ -1,6 +1,8 @@
 import re
 from collections.abc import Set
 
+from theHarvester.lib.hostnames import normalize_scoped_hostname
+
 
 class Parser:
     def __init__(self, results, word) -> None:
@@ -46,19 +48,14 @@ class Parser:
         await self.generic_clean()
         # Local part is required, charset is flexible.
         # https://tools.ietf.org/html/rfc6531 (removed * and () as they provide FP mostly)
-        reg_emails = re.compile(r'[a-zA-Z0-9.\-_+#~!$&\',;=:]+' + '@' + '[a-zA-Z0-9.-]*' + self.word.replace('www.', ''))
-        self.temp = reg_emails.findall(self.results)
-        emails = await self.unique()
-        true_emails = {
-            (
-                str(email)[1:].lower().strip()
-                if len(str(email)) > 1 and str(email)[0] == '.'
-                else len(str(email)) > 1 and str(email).lower().strip()
-            )
-            for email in emails
-        }
-        # if email starts with dot shift email string and make sure all emails are lowercase
-        return true_emails
+        candidates = re.findall(r"[a-zA-Z0-9.\-_+#~!$&']+@[a-zA-Z0-9.-]+", self.results)
+        target = self.word.removeprefix('www.')
+        emails: set[str] = set()
+        for candidate in candidates:
+            local_part, domain = candidate.lstrip('.').lower().split('@', maxsplit=1)
+            if normalized_domain := normalize_scoped_hostname(domain, target):
+                emails.add(f'{local_part}@{normalized_domain}')
+        return emails
 
     async def fileurls(self, file) -> list:
         urls: list = []
@@ -73,19 +70,13 @@ class Parser:
         return urls
 
     async def hostnames(self):
-        # should check both www. and not www.
-        hostnames = []
         await self.generic_clean()
-        reg_hosts = re.compile(r'[a-zA-Z0-9.-]*\.' + self.word)
-        first_hostnames = reg_hosts.findall(self.results)
-        hostnames.extend(first_hostnames)
-        # TODO determine if necessary below or if only pass through is fine
-        reg_hosts = re.compile(r'[a-zA-Z0-9.-]*\.' + self.word.replace('www.', ''))
-        # reg_hosts = re.compile(r'www\.[a-zA-Z0-9.-]*\.' + 'www.' + self.word)
-        # reg_hosts = re.compile(r'www\.[a-zA-Z0-9.-]*\.(?:' + 'www.' + self.word + ')?')
-        second_hostnames = reg_hosts.findall(self.results)
-        hostnames.extend(second_hostnames)
-        return list(set(hostnames))
+        target = self.word.removeprefix('www.')
+        candidates = re.findall(r'[a-zA-Z0-9.-]+', self.results)
+        hostnames = {
+            normalized for candidate in candidates if (normalized := normalize_scoped_hostname(candidate.strip('.'), target))
+        }
+        return sorted(hostnames)
 
     async def hostnames_all(self):
         reg_hosts = re.compile('<cite>(.*?)</cite>')

--- a/theHarvester/parsers/myparser.py
+++ b/theHarvester/parsers/myparser.py
@@ -49,7 +49,7 @@ class Parser:
         # Local part is required, charset is flexible.
         # https://tools.ietf.org/html/rfc6531 (removed * and () as they provide FP mostly)
         candidates = re.findall(r"[a-zA-Z0-9.\-_+#~!$&']+@[a-zA-Z0-9.-]+", self.results)
-        target = self.word.removeprefix('www.')
+        target = self.word.lower().removeprefix('www.')
         emails: set[str] = set()
         for candidate in candidates:
             local_part, domain = candidate.lstrip('.').lower().split('@', maxsplit=1)
@@ -71,7 +71,7 @@ class Parser:
 
     async def hostnames(self):
         await self.generic_clean()
-        target = self.word.removeprefix('www.')
+        target = self.word.lower().removeprefix('www.')
         candidates = re.findall(r'[a-zA-Z0-9.-]+', self.results)
         hostnames = {
             normalized for candidate in candidates if (normalized := normalize_scoped_hostname(candidate.strip('.'), target))


### PR DESCRIPTION
## Summary

- enforce exact-domain and subdomain boundaries in shared hostname parsing
- normalize wildcard prefixes, schemes, ports, credentials, and trailing dots through one existing result path
- reuse the shared hostname normalization in IntelX without changing its provider contract

## Why

Parser results could retain unrelated sibling or suffix-collision hostnames, such as `notexample.com` when the requested domain was `example.com`. This keeps one-shot enumeration results inside the requested domain boundary.

Tracks NotoriousRebel/theHarvester#115.

## Verification

- 12 focused parser and IntelX tests passed
- full suite: 179 passed, 6 skipped
- Ruff lint and format checks passed
- mypy passed
- separate Standards and Spec reviews reported no findings