### PR TITLE
Correct Brave Search pagination limits

### DIFF
--- a/tests/discovery/test_brave.py
+++ b/tests/discovery/test_brave.py
@@ -1,0 +1,199 @@
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from theHarvester.discovery import bravesearch
+from theHarvester.lib.configuration import InMemoryCredentialAdapter
+
+
+def _result(index: int) -> dict[str, str]:
+    return {
+        'title': f'Result {index}',
+        'description': f'host-{index}.example.com',
+        'url': f'https://host-{index}.example.com',
+    }
+
+
+def _response(results: list[dict[str, str]], *, more: bool) -> dict[str, Any]:
+    return {
+        'query': {'more_results_available': more},
+        'web': {'results': results},
+    }
+
+
+@pytest.fixture
+def brave_credentials() -> InMemoryCredentialAdapter:
+    return InMemoryCredentialAdapter({'brave': {'key': 'test-token'}})
+
+
+@pytest.fixture(autouse=True)
+def no_brave_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(bravesearch.asyncio, 'sleep', no_sleep)
+
+
+@pytest.mark.asyncio
+async def test_brave_uses_page_offsets_and_one_global_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    brave_credentials: InMemoryCredentialAdapter,
+) -> None:
+    responses = iter(
+        [
+            _response([_result(index) for index in range(20)], more=True),
+            _response([_result(index) for index in range(20, 30)], more=True),
+        ]
+    )
+    requests: list[dict[str, list[str]]] = []
+
+    async def fake_fetch(*, url: str, **_kwargs: Any) -> dict[str, Any]:
+        requests.append(parse_qs(urlparse(url).query))
+        return next(responses)
+
+    monkeypatch.setattr(bravesearch.AsyncFetcher, 'fetch', fake_fetch)
+    search = bravesearch.SearchBrave('example.com', 25, credential_adapter=brave_credentials)
+    await search.process()
+
+    assert requests == [
+        {
+            'q': ['"example.com"'],
+            'count': ['20'],
+            'offset': ['0'],
+            'safesearch': ['off'],
+            'freshness': ['all'],
+            'extra_snippets': ['true'],
+            'text_decorations': ['true'],
+            'spellcheck': ['true'],
+        },
+        {
+            'q': ['"example.com"'],
+            'count': ['5'],
+            'offset': ['1'],
+            'safesearch': ['off'],
+            'freshness': ['all'],
+            'extra_snippets': ['true'],
+            'text_decorations': ['true'],
+            'spellcheck': ['true'],
+        },
+    ]
+    assert len(search.results) == 25
+
+
+@pytest.mark.asyncio
+async def test_brave_requests_another_page_only_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+    brave_credentials: InMemoryCredentialAdapter,
+) -> None:
+    responses = iter(
+        [
+            _response([_result(1)], more=False),
+            _response([_result(2)], more=False),
+        ]
+    )
+    requests: list[dict[str, list[str]]] = []
+
+    async def fake_fetch(*, url: str, **_kwargs: Any) -> dict[str, Any]:
+        requests.append(parse_qs(urlparse(url).query))
+        return next(responses, _response([], more=False))
+
+    monkeypatch.setattr(bravesearch.AsyncFetcher, 'fetch', fake_fetch)
+    search = bravesearch.SearchBrave('example.com', 10, credential_adapter=brave_credentials)
+    await search.process()
+
+    assert [(request['q'], request['offset'], request['count']) for request in requests] == [
+        (['"example.com"'], ['0'], ['10']),
+        (['site:example.com'], ['0'], ['9']),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_brave_continues_sparse_pages_while_more_results_are_available(
+    monkeypatch: pytest.MonkeyPatch,
+    brave_credentials: InMemoryCredentialAdapter,
+) -> None:
+    responses = iter(
+        [
+            _response([_result(1)], more=True),
+            _response([_result(index) for index in range(2, 21)], more=False),
+        ]
+    )
+    requests: list[dict[str, list[str]]] = []
+
+    async def fake_fetch(*, url: str, **_kwargs: Any) -> dict[str, Any]:
+        requests.append(parse_qs(urlparse(url).query))
+        return next(responses)
+
+    monkeypatch.setattr(bravesearch.AsyncFetcher, 'fetch', fake_fetch)
+    search = bravesearch.SearchBrave('example.com', 20, credential_adapter=brave_credentials)
+    await search.process()
+
+    assert [(request['offset'], request['count']) for request in requests] == [
+        (['0'], ['20']),
+        (['1'], ['19']),
+    ]
+    assert len(search.results) == 20
+
+
+@pytest.mark.asyncio
+async def test_brave_stops_after_an_exact_full_page(
+    monkeypatch: pytest.MonkeyPatch,
+    brave_credentials: InMemoryCredentialAdapter,
+) -> None:
+    requests: list[dict[str, list[str]]] = []
+
+    async def fake_fetch(*, url: str, **_kwargs: Any) -> dict[str, Any]:
+        requests.append(parse_qs(urlparse(url).query))
+        return _response([_result(index) for index in range(20)], more=True)
+
+    monkeypatch.setattr(bravesearch.AsyncFetcher, 'fetch', fake_fetch)
+    search = bravesearch.SearchBrave('example.com', 20, credential_adapter=brave_credentials)
+    await search.process()
+
+    assert [(request['offset'], request['count']) for request in requests] == [(['0'], ['20'])]
+
+
+@pytest.mark.asyncio
+async def test_brave_rate_limit_does_not_skip_to_the_next_page(
+    monkeypatch: pytest.MonkeyPatch,
+    brave_credentials: InMemoryCredentialAdapter,
+) -> None:
+    responses = iter(
+        [
+            {'error': {'message': 'Rate limit exceeded', 'code': 'rate_limit_exceeded'}},
+            _response([], more=False),
+        ]
+    )
+    requests: list[dict[str, list[str]]] = []
+
+    async def fake_fetch(*, url: str, **_kwargs: Any) -> dict[str, Any]:
+        requests.append(parse_qs(urlparse(url).query))
+        return next(responses)
+
+    monkeypatch.setattr(bravesearch.AsyncFetcher, 'fetch', fake_fetch)
+    search = bravesearch.SearchBrave('example.com', 40, credential_adapter=brave_credentials)
+    await search.process()
+
+    assert [(request['q'], request['offset']) for request in requests] == [
+        (['"example.com"'], ['0']),
+        (['site:example.com'], ['0']),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_brave_never_exceeds_maximum_page_offset(
+    monkeypatch: pytest.MonkeyPatch,
+    brave_credentials: InMemoryCredentialAdapter,
+) -> None:
+    requests: list[dict[str, list[str]]] = []
+
+    async def fake_fetch(*, url: str, **_kwargs: Any) -> dict[str, Any]:
+        requests.append(parse_qs(urlparse(url).query))
+        return _response([_result(len(requests))], more=True)
+
+    monkeypatch.setattr(bravesearch.AsyncFetcher, 'fetch', fake_fetch)
+    search = bravesearch.SearchBrave('example.com', 1_000, credential_adapter=brave_credentials)
+    await search.process()
+
+    assert [request['offset'] for request in requests] == [[str(offset)] for offset in range(10)] * 2

--- a/theHarvester/discovery/bravesearch.py
+++ b/theHarvester/discovery/bravesearch.py
@@ -41,14 +41,16 @@ class SearchBrave:
         queries = [f'"{self.word}"', f'site:{self.word}']
 
         for query in queries:
+            if len(self.results) >= self.limit:
+                break
             try:
-                # Calculate number of pages based on limit (20 results per page)
-                pages = min((self.limit // 20) + 1, 5)  # Maximum 5 pages
-
-                for offset in range(0, pages * 20, 20):
+                for offset in range(10):
+                    remaining = self.limit - len(self.results)
+                    if remaining <= 0:
+                        break
                     params = {
                         'q': query,
-                        'count': min(20, self.limit - len(self.results)),
+                        'count': min(20, remaining),
                         'offset': offset,
                         'safesearch': 'off',
                         'freshness': 'all',
@@ -77,7 +79,7 @@ class SearchBrave:
                             logger.info(f'Rate limit exceeded. Increasing delay to {self.rate_limit_delay * 2} seconds')
                             self.rate_limit_delay *= 2
                             await asyncio.sleep(self.rate_limit_delay)
-                            continue
+                            break
                         elif 'quota' in error_msg.lower() or error_code == 'quota_exceeded':
                             logger.info('Brave Search API quota exceeded')
                             break
@@ -85,7 +87,7 @@ class SearchBrave:
                             break
 
                     if 'web' in resp and 'results' in resp['web']:
-                        results = resp['web']['results']
+                        results = resp['web']['results'][:remaining]
                         if not results:
                             break
 
@@ -105,6 +107,8 @@ class SearchBrave:
 
                         # Stop if we've reached our limit
                         if len(self.results) >= self.limit:
+                            break
+                        if not resp.get('query', {}).get('more_results_available', False):
                             break
                     else:
                         logger.info('Unexpected response format from Brave Search API')


### PR DESCRIPTION
## Summary

- use Brave's zero-based page offsets from 0 through 9
- carry one result budget across exact-domain and site queries
- stop when `more_results_available` is false and truncate oversized provider pages to the remaining budget

## Why

Brave defines `offset` as a page number, but the adapter advanced it as a result index (`0`, `20`, `40`). That could send invalid requests, exceed exact limits, and request a second query after the global budget was exhausted.

Tracks NotoriousRebel/theHarvester#119.

Provider reference: https://api-dashboard.search.brave.com/app/documentation/web-search/get-started

## Verification

- 8 focused Brave tests passed with fake responses
- full suite: 181 passed, 6 skipped
- Ruff lint and format checks passed
- mypy passed
- separate Standards and Spec reviews reported no blocking findings
- no live provider requests were made