### PR TITLE
Handle malformed Mojeek API responses

### DIFF
--- a/tests/test_mojeek.py
+++ b/tests/test_mojeek.py
@@ -1,56 +1,175 @@
+from typing import Any
+
 import pytest
+
 from theHarvester.discovery import mojeek
 
+
+def _patch_mojeek(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    api_key: str,
+    api_responses: list[Any] | None = None,
+    scrape_responses: list[Any] | None = None,
+) -> list[dict[str, Any]]:
+    requests: list[dict[str, Any]] = []
+
+    async def fake_fetch_all(
+        urls: list[str] | set[str],
+        headers: dict[str, str] | None = None,
+        proxy: bool = False,
+        json: bool = False,
+    ) -> list[Any]:
+        requests.append(
+            {
+                'urls': list(urls),
+                'headers': headers,
+                'proxy': proxy,
+                'json': json,
+            }
+        )
+        responses = api_responses if json else scrape_responses
+        return responses if responses is not None else []
+
+    monkeypatch.setattr(mojeek.Core, 'mojeek_key', staticmethod(lambda: api_key))
+    monkeypatch.setattr(mojeek.Core, 'get_user_agent', staticmethod(lambda: 'UA'))
+    monkeypatch.setattr(mojeek.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    return requests
+
+
 class TestMojeekSearch:
+    @pytest.mark.asyncio
+    async def test_keyless_mode_uses_scraping_without_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        requests = _patch_mojeek(
+            monkeypatch,
+            api_key='',
+            scrape_responses=['Contact security@example.com at docs.example.com'],
+        )
+
+        search = mojeek.SearchMojeek(word='example.com', limit=10)
+        await search.process()
+
+        assert requests == [
+            {
+                'urls': ['https://www.mojeek.com/search?q=example.com&s=0'],
+                'headers': {'User-Agent': 'UA'},
+                'proxy': False,
+                'json': False,
+            }
+        ]
+        assert await search.get_emails() == {'security@example.com'}
+        assert set(await search.get_hostnames()) - {'example.com'} == {'docs.example.com'}
 
     @pytest.mark.asyncio
-    async def test_process_and_parsing(self, monkeypatch):
-        called = {}
+    async def test_keyed_api_success_parses_results_without_scraping(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        requests = _patch_mojeek(
+            monkeypatch,
+            api_key='test-key',
+            api_responses=[
+                {
+                    'response': {
+                        'results': [
+                            {
+                                'url': 'https:\\/\\/blog.example.com\\/contact',
+                                'title': 'Contact admin@example.com',
+                                'desc': 'API docs at api.example.com',
+                            }
+                        ]
+                    }
+                }
+            ],
+        )
 
-        async def fake_fetch_all(urls, headers=None, proxy=False):
-            called["urls"] = urls
-            called["headers"] = headers
-            called["proxy"] = proxy
-            return [
-                "Contact admin@exemple.com sur www.exemple.com \n",
-                " dev@exemple.com est présent sur api.exemple.com \n"
-            ]
-
-        import theHarvester.lib.core as core_module
-        monkeypatch.setattr(core_module.AsyncFetcher, "fetch_all", fake_fetch_all)
-        monkeypatch.setattr(core_module.Core, "get_user_agent", staticmethod(lambda: "UA"), raising=True)
-
-        search = mojeek.SearchMojeek(word="exemple.com", limit=20)
+        search = mojeek.SearchMojeek(word='example.com', limit=20)
         await search.process(proxy=True)
 
-        expected_urls = [
-            "https://www.mojeek.com/search?q=%40exemple.com&s=0",
-            "https://www.mojeek.com/search?q=%40exemple.com&s=10"
+        assert requests == [
+            {
+                'urls': [
+                    'https://api.mojeek.com/search?api_key=test-key&q=example.com&fmt=json&s=1',
+                    'https://api.mojeek.com/search?api_key=test-key&q=example.com&fmt=json&s=11',
+                ],
+                'headers': {'User-Agent': 'UA'},
+                'proxy': True,
+                'json': True,
+            }
         ]
-        
-        assert any("mojeek.com" in url for url in called["urls"])
-        
-        emails = await search.get_emails()
-        hosts = await search.get_hostnames()
+        assert await search.get_emails() == {'admin@example.com'}
+        assert set(await search.get_hostnames()) - {'example.com'} == {
+            'api.example.com',
+            'blog.example.com',
+        }
 
-        assert "admin@exemple.com" in emails
-        assert "dev@exemple.com" in emails
-        assert "www.exemple.com" in hosts
-        assert "api.exemple.com" in hosts
-
+    @pytest.mark.parametrize(
+        'api_responses',
+        [
+            [],
+            [''],
+            [{'results': ['not-an-object']}],
+            [{'results': [{}]}],
+            [{'status': 'Access denied'}],
+            [
+                {'results': [{'url': 'https://api-only.example.com', 'title': 'api-only@example.com'}]},
+                '',
+            ],
+            [
+                {'results': [{'url': 'https://api-only.example.com', 'title': 'api-only@example.com'}]},
+                {'status': 'Access denied'},
+            ],
+            [
+                {'results': [{'url': 'https://api-only.example.com', 'title': 'api-only@example.com'}]},
+                {'status': None},
+            ],
+        ],
+        ids=[
+            'empty',
+            'non-mapping-response',
+            'malformed-results',
+            'empty-result',
+            'denied',
+            'partial-then-malformed',
+            'partial-then-denied',
+            'partial-then-malformed-status',
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_pagination_limit(self, monkeypatch):
-        captured = {}
+    async def test_unusable_api_response_falls_back_to_scraping(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        api_responses: list[Any],
+    ) -> None:
+        requests = _patch_mojeek(
+            monkeypatch,
+            api_key='test-key',
+            api_responses=api_responses,
+            scrape_responses=['Contact admin@example.com at search.example.com'],
+        )
 
-        async def fake_fetch_all(urls, headers=None, proxy=False):
-            captured["urls"] = urls
-            return [""] * len(urls)
+        search = mojeek.SearchMojeek(word='example.com', limit=20)
+        await search.process(proxy=True)
 
-        import theHarvester.lib.core as core_module
-        monkeypatch.setattr(core_module.AsyncFetcher, "fetch_all", fake_fetch_all)
-        monkeypatch.setattr(core_module.Core, "get_user_agent", staticmethod(lambda: "UA"), raising=True)
-
-        search = mojeek.SearchMojeek(word="exemple.com", limit=10)
-        await search.process()
-        
-        assert len(captured["urls"]) == 1
+        assert requests == [
+            {
+                'urls': [
+                    'https://api.mojeek.com/search?api_key=test-key&q=example.com&fmt=json&s=1',
+                    'https://api.mojeek.com/search?api_key=test-key&q=example.com&fmt=json&s=11',
+                ],
+                'headers': {'User-Agent': 'UA'},
+                'proxy': True,
+                'json': True,
+            },
+            {
+                'urls': [
+                    'https://www.mojeek.com/search?q=example.com&s=0',
+                    'https://www.mojeek.com/search?q=example.com&s=10',
+                ],
+                'headers': {'User-Agent': 'UA'},
+                'proxy': True,
+                'json': False,
+            },
+        ]
+        assert await search.get_emails() == {'admin@example.com'}
+        assert set(await search.get_hostnames()) - {'example.com'} == {'search.example.com'}

--- a/theHarvester/discovery/mojeek.py
+++ b/theHarvester/discovery/mojeek.py
@@ -37,22 +37,50 @@ class SearchMojeek:
             responses = await AsyncFetcher.fetch_all(urls, headers=headers, proxy=self.proxy, json=True)
 
             api_success = False
+            api_unusable = False
+            api_text_parts: list[str] = []
             for response in responses:
+                if not isinstance(response, dict):
+                    api_unusable = True
+                    continue
+
                 data = response.get('response', response)
+                if not isinstance(data, dict):
+                    api_unusable = True
+                    continue
 
-                if data and 'results' in data:
-                    results = data['results']
-                    if len(results) > 0:
+                results = data.get('results')
+                if isinstance(results, list):
+                    for result in results:
+                        if not isinstance(result, dict):
+                            api_unusable = True
+                            continue
+                        url_value = result.get('url')
+                        title_value = result.get('title')
+                        description_value = result.get('desc')
+                        url = url_value.replace('\\/', '/') if isinstance(url_value, str) else ''
+                        title = title_value if isinstance(title_value, str) else ''
+                        description = description_value if isinstance(description_value, str) else ''
+                        if not any((url, title, description)):
+                            api_unusable = True
+                            continue
                         api_success = True
-                        for result in results:
-                            url = result.get('url', '').replace('\\/', '/')
-                            self.total_results += f' {url} {result.get("title", "")} {result.get("desc", "")} '
+                        api_text_parts.append(f' {url} {title} {description} ')
+                elif 'results' in data:
+                    api_unusable = True
 
-                elif data and 'status' in data and 'denied' in data['status'].lower():
-                    logger.info(f'[!] Mojeek API: Access denied ({data["status"]}).')
+                status = data.get('status')
+                if isinstance(status, str) and 'denied' in status.lower():
+                    api_unusable = True
+                    logger.info(f'[!] Mojeek API: Access denied ({status}).')
                     break
+                if 'status' in data and not isinstance(status, str):
+                    api_unusable = True
+                if 'results' not in data and 'status' not in data:
+                    api_unusable = True
 
-            if api_success:
+            if api_success and not api_unusable:
+                self.total_results += ''.join(api_text_parts)
                 logger.info('[*] Mojeek: API search completed successfully.')
                 return
             else:


### PR DESCRIPTION
## Summary

- validate Mojeek API response, payload, result, and field types before parsing
- fall back deterministically to scraping when any API page is empty, malformed, or denied
- stage API evidence until the full batch is valid so rejected partial responses cannot leak into scrape results
- cover keyed API and keyless scraping modes with exact offline request assertions

## Why

Mojeek API mode called `.get()` on every fetched response, so a non-mapping response could crash enumeration. A partly valid batch could also retain API evidence before a later bad page triggered scraping.

Tracks NotoriousRebel/theHarvester#121. Review after #2426 per the fork issue ordering; this branch is independently based on `dev`.

## Verification

- 10 focused Mojeek tests passed with fake responses
- full suite: 183 passed, 6 skipped
- Ruff lint and format checks passed
- mypy passed
- separate Standards and Spec reviews reported no blocking findings
- no real key or live provider request was used