### PR TITLE
Keep DuckDuckGo discovery provider-only

### DIFF
--- a/tests/discovery/test_duckduckgo.py
+++ b/tests/discovery/test_duckduckgo.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+import pytest
+
+from theHarvester.discovery import duckduckgosearch
+
+
+@pytest.mark.asyncio
+async def test_duckduckgo_does_not_fetch_provider_returned_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[tuple[list[str], bool]] = []
+    payload = """
+    {
+      "AbstractURL": "https://api.example.com",
+      "AbstractText": "Contact admin@example.com.",
+      "Results": [{"FirstURL": "https://outside.test"}]
+    }
+    """
+
+    async def fake_fetch_all(
+        urls: list[str] | set[str],
+        *,
+        headers: dict[str, str] | None = None,
+        proxy: bool = False,
+        **_kwargs: Any,
+    ) -> list[str]:
+        requests.append((list(urls), proxy))
+        return [payload]
+
+    monkeypatch.setattr(duckduckgosearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = duckduckgosearch.SearchDuckDuckGo('example.com', 100)
+    await search.process(proxy=True)
+
+    assert requests == [(['https://api.duckduckgo.com/?q=example.com&format=json&pretty=1'], True)]
+    assert await search.get_hostnames() == ['api.example.com']
+    assert await search.get_emails() == {'admin@example.com'}

--- a/theHarvester/discovery/duckduckgosearch.py
+++ b/theHarvester/discovery/duckduckgosearch.py
@@ -1,11 +1,5 @@
-import logging
-
-import ujson
-
 from theHarvester.lib.core import AsyncFetcher, Core
 from theHarvester.parsers import myparser
-
-logger = logging.getLogger(__name__)
 
 
 class SearchDuckDuckGo:
@@ -22,60 +16,12 @@ class SearchDuckDuckGo:
         self.proxy: bool = False
 
     async def do_search(self) -> None:
-        # Do normal scraping.
+        # Query only the provider; URLs in the response are evidence, not crawl targets.
         url = self.api.replace('x', self.word)
         headers = {'User-Agent': Core.get_user_agent()}
         first_resp = await AsyncFetcher.fetch_all([url], headers=headers, proxy=self.proxy)
         self.results = first_resp[0]
         self.totalresults += self.results
-        urls = await self.crawl(self.results)
-        urls = {url for url in urls if len(url) > 5}
-        all_resps = await AsyncFetcher.fetch_all(urls)
-        self.totalresults += ''.join(all_resps)
-
-    async def crawl(self, text: str) -> set[str]:
-        """Function parses json and returns URLs.
-        :param text: formatted json
-        :return: set of URLs
-        """
-        urls = set()
-        try:
-            load = ujson.loads(text)
-            for keys in load.keys():  # Iterate through keys of dict.
-                val = load.get(keys)
-
-                if isinstance(val, int) or isinstance(val, dict) or val is None:
-                    continue
-
-                if isinstance(val, list):
-                    if len(val) == 0:  # Make sure not indexing an empty list.
-                        continue
-                    val = val[0]  # The First value should be dict.
-
-                    if isinstance(val, dict):  # Validation check.
-                        for key in val.keys():
-                            value = val.get(key)
-                            if isinstance(value, str) and value != '' and ('https://' in value or 'http://' in value):
-                                urls.add(value)
-
-                if isinstance(val, str) and val != '' and ('https://' in val or 'http://' in val):
-                    urls.add(val)
-            tmp = set()
-            for url in urls:
-                if '<' in url and 'href=' in url:  # Format is <href="https://www.website.com"/>
-                    equal_index = url.index('=')
-                    true_url = ''
-                    for ch in url[equal_index + 1 :]:
-                        if ch == '"':
-                            tmp.add(true_url)
-                            break
-                        true_url += ch
-                elif url != '':
-                    tmp.add(url)
-            return tmp
-        except Exception as e:
-            logger.info(f'Exception occurred: {e}')
-            return set()
 
     async def get_emails(self):
         rawres = myparser.Parser(self.totalresults, self.word)


### PR DESCRIPTION
## Problem

DuckDuckGo currently treats URLs embedded in its provider response as crawl targets. That can trigger direct requests to the target or unrelated third parties, bypass the selected proxy, and turn a passive provider query into active interaction.

## Change

- keep the DuckDuckGo adapter to one provider API request
- pass the untouched provider response to the existing shared parser
- preserve proxy use on the provider request
- remove the now-unused response URL crawler and JSON dependency from this adapter

## Verification

- .                                                                        [100%]
1 passed in 0.37s (1 passed)
- ..........s............................................s..............ss [ 39%]
ss...................................................................... [ 79%]
......................................                                   [100%]
=============================== warnings summary ===============================
.venv/lib/python3.14/site-packages/backoff/_decorator.py:101
  /private/tmp/theharvester-upstream-duckduckgo-clean/.venv/lib/python3.14/site-packages/backoff/_decorator.py:101: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
    if asyncio.iscoroutinefunction(target):

.venv/lib/python3.14/site-packages/fastapi/testclient.py:1
  /private/tmp/theharvester-upstream-duckduckgo-clean/.venv/lib/python3.14/site-packages/fastapi/testclient.py:1: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
    from starlette.testclient import TestClient as TestClient  # noqa

tests/test_security.py::TestCORSConfiguration::test_cors_does_not_allow_credentials_with_wildcard_origins
tests/test_security.py::TestCORSConfiguration::test_cors_does_not_allow_credentials_with_wildcard_origins
tests/test_security.py::TestCORSConfiguration::test_cors_does_not_allow_credentials_with_wildcard_origins
  /private/tmp/theharvester-upstream-duckduckgo-clean/.venv/lib/python3.14/site-packages/slowapi/extension.py:720: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
    if asyncio.iscoroutinefunction(func):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
176 passed, 6 skipped, 5 warnings in 12.34s (176 passed, 6 skipped)
- All checks passed!
- 83 files already formatted
- Success: no issues found in 83 source files

All verification is offline and uses a fake HTTP boundary with reserved example domains.

Related: https://github.com/NotoriousRebel/theHarvester/issues/117