### PR TITLE
fix: update Baidu query and report verification failures

### DIFF
--- a/tests/discovery/test_baidusearch.py
+++ b/tests/discovery/test_baidusearch.py
@@ -5,6 +5,40 @@ from theHarvester.discovery import baidusearch
 
 class TestBaiduSearch:
     @pytest.mark.asyncio
+    async def test_empty_fetch_response_is_reported(self, monkeypatch):
+        async def fake_fetch_all(urls, headers=None, proxy=False):
+            return ['']
+
+        monkeypatch.setattr(baidusearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        search = baidusearch.SearchBaidu(word='example.com', limit=10)
+
+        with pytest.raises(RuntimeError, match='empty response'):
+            await search.process()
+
+    @pytest.mark.asyncio
+    async def test_partial_empty_fetch_response_is_ignored(self, monkeypatch):
+        async def fake_fetch_all(urls, headers=None, proxy=False):
+            return ['', 'a.example.com']
+
+        monkeypatch.setattr(baidusearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        search = baidusearch.SearchBaidu(word='example.com', limit=20)
+
+        await search.process()
+
+        assert await search.get_hostnames() == ['a.example.com']
+
+    @pytest.mark.asyncio
+    async def test_security_verification_is_reported(self, monkeypatch):
+        async def fake_fetch_all(urls, headers=None, proxy=False):
+            return ['<html><title>百度安全验证</title></html>']
+
+        monkeypatch.setattr(baidusearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        search = baidusearch.SearchBaidu(word='example.com', limit=10)
+
+        with pytest.raises(RuntimeError, match='security verification'):
+            await search.process()
+
+    @pytest.mark.asyncio
     async def test_process_and_parsing(self, monkeypatch):
         called = {}
 
@@ -29,9 +63,9 @@ class TestBaiduSearch:
         await search.process(proxy=True)
 
         expected_urls = [
-            "https://www.baidu.com/s?wd=%40example.com&pn=0&oq=example.com",
-            "https://www.baidu.com/s?wd=%40example.com&pn=10&oq=example.com",
-            "https://www.baidu.com/s?wd=%40example.com&pn=20&oq=example.com",
+            "https://www.baidu.com/s?wd=site%3Aexample.com&pn=0",
+            "https://www.baidu.com/s?wd=site%3Aexample.com&pn=10",
+            "https://www.baidu.com/s?wd=site%3Aexample.com&pn=20",
         ]
         assert called["urls"] == expected_urls
         assert called["proxy"] is True
@@ -52,7 +86,7 @@ class TestBaiduSearch:
 
         async def fake_fetch_all(urls, headers=None, proxy=False):
             captured["urls"] = urls
-            return [""] * len(urls)
+            return ["<html></html>"] * len(urls)
 
         import theHarvester.lib.core as core_module
 
@@ -64,6 +98,6 @@ class TestBaiduSearch:
 
         # For limit=20, range(0, 20, 10) yields 0 and 10 only (20 is excluded)
         assert captured["urls"] == [
-            "https://www.baidu.com/s?wd=%40example.com&pn=0&oq=example.com",
-            "https://www.baidu.com/s?wd=%40example.com&pn=10&oq=example.com",
+            "https://www.baidu.com/s?wd=site%3Aexample.com&pn=0",
+            "https://www.baidu.com/s?wd=site%3Aexample.com&pn=10",
         ]

--- a/theHarvester/discovery/baidusearch.py
+++ b/theHarvester/discovery/baidusearch.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from theHarvester.lib.core import AsyncFetcher, Core
 from theHarvester.parsers import myparser
 
@@ -13,10 +15,20 @@ class SearchBaidu:
 
     async def do_search(self) -> None:
         headers = {'Host': self.hostname, 'User-agent': Core.get_user_agent()}
-        base_url = f'https://{self.server}/s?wd=%40{self.word}&pn=xx&oq={self.word}'
-        urls = [base_url.replace('xx', str(num)) for num in range(0, self.limit, 10) if num <= self.limit]
+        base_url = f'https://{self.server}/s'
+        urls = [
+            f'{base_url}?{urlencode({"wd": f"site:{self.word}", "pn": num})}'
+            for num in range(0, self.limit, 10)
+            if num <= self.limit
+        ]
         responses = await AsyncFetcher.fetch_all(urls, headers=headers, proxy=self.proxy)
+        if not responses or all(not response for response in responses):
+            raise RuntimeError('Baidu returned an empty response')
         for response in responses:
+            if not response:
+                continue
+            if '百度安全验证' in response or 'wappass.baidu.com/static/captcha' in response:
+                raise RuntimeError('Baidu returned a security verification page')
             self.total_results += response
 
     async def process(self, proxy: bool = False) -> None:


### PR DESCRIPTION
## Summary

- replace the obsolete `@domain` query with an encoded `site:domain` query
- report empty responses and Baidu security verification pages instead of silently returning no results
- preserve usable pages when an individual pagination request returns an empty response

## Policy decision

This keeps Baidu available for explicit invocation and fails clearly when Baidu requires verification. It does not add browser automation, generated cookies, CAPTCHA handling, or proxy claims because those approaches were not shown to be portable. Whether Baidu belongs in the default all-source set can be decided separately.

## Verification

- `uv run pytest`: 178 passed, 6 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy theHarvester`
- bounded `example.com` check confirmed that an empty Baidu response is now reported

Addresses #2403.
