### PR TITLE
test: align DuckDuckGo with scoped parser

### DIFF
--- a/tests/discovery/test_duckduckgo.py
+++ b/tests/discovery/test_duckduckgo.py
@@ -31,5 +31,5 @@ async def test_duckduckgo_does_not_fetch_provider_returned_urls(monkeypatch: pyt
     await search.process(proxy=True)
 
     assert requests == [(['https://api.duckduckgo.com/?q=example.com&format=json&pretty=1'], True)]
-    assert await search.get_hostnames() == ['api.example.com']
+    assert await search.get_hostnames() == ['api.example.com', 'example.com']
     assert await search.get_emails() == {'admin@example.com'}


### PR DESCRIPTION
## Summary

- align the DuckDuckGo regression test with the shared parser's in-scope apex behavior
- keep the provider-only request assertion unchanged

## Why

PR #2425 intentionally made hostname parsing retain both the exact target and its subdomains. PR #2428's fixture includes `admin@example.com`, so the parser now correctly returns `example.com` as well as `api.example.com`. The stale expectation left the post-merge `dev` Python workflow failing.

## Verification

- `uv run pytest`: 229 passed, 6 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy theHarvester`
- Standards review: no findings
- Spec review: no findings
