### PR TITLE
feat: select sources by result capability

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -62,6 +62,14 @@ _Avoid_: Scan, monitoring cycle, session
 One attempt to run one canonical discovery source within an enumeration run, with an explicit completion status and summary counts.
 _Avoid_: Source result, provider response
 
+**Source capability**:
+A declared class of normalized result that a source can contribute to consolidated enumeration output, independent of whether one source execution yields any data.
+_Avoid_: Guaranteed result, module return type, source category
+
+**Capability selection**:
+An operator request to run sources that declare one or more selected source capabilities. Multiple capabilities form a union, explicit source selection remains available, and capability selection does not filter fields returned by a selected source.
+_Avoid_: Result filter, backend category, capability intersection
+
 **Source family**:
 A group of discovery sources whose observations depend on the same underlying dataset or collection mechanism. Family membership preserves source credit while preventing correlated observations from being treated as independent corroboration.
 _Avoid_: Duplicate source, provider category

--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ Query several passive sources:
 uv run theHarvester -d example.com -b crtsh,certspotter,commoncrawl
 ```
 
+Run every source that can contribute subdomains:
+
+```bash
+uv run theHarvester -d example.com -b subdomains
+```
+
+Combine capability selectors, or mix them with explicit source names:
+
+```bash
+uv run theHarvester -d example.com -b emails,urls,certspotter
+```
+
+Capability selectors form a union and choose which sources run. They do not discard other result types returned by those sources. Available selectors are `subdomains`, `emails`, `ips`, `asns`, `urls`, and `people`. `-b all` continues to run every registered source.
+
 Save both JSON and XML reports:
 
 ```bash

--- a/tests/lib/test_core.py
+++ b/tests/lib/test_core.py
@@ -17,6 +17,58 @@ def mock_environ(monkeypatch, tmp_path: Path):
     monkeypatch.setenv("HOME", str(tmp_path))
 
 
+def test_email_capability_expands_to_email_sources() -> None:
+    assert Core.expand_source_selection("emails") == [
+        "baidu",
+        "bitbucket",
+        "brave",
+        "censys",
+        "duckduckgo",
+        "github-code",
+        "gitlab",
+        "hudsonrock",
+        "hunter",
+        "intelx",
+        "leakix",
+        "leaklookup",
+        "mojeek",
+        "rocketreach",
+        "sherlockeye",
+        "tomba",
+        "venacus",
+        "windvane",
+        "yahoo",
+        "zoomeye",
+    ]
+
+
+def test_capabilities_and_explicit_sources_form_a_union() -> None:
+    assert Core.expand_source_selection("certspotter, urls") == [
+        "bevigil",
+        "builtwith",
+        "certspotter",
+        "intelx",
+        "rocketreach",
+        "urlscan",
+        "venacus",
+        "zoomeye",
+    ]
+
+
+def test_multiple_capabilities_form_a_union() -> None:
+    assert Core.expand_source_selection("asns,people") == [
+        "criminalip",
+        "onyphe",
+        "urlscan",
+        "venacus",
+        "zoomeye",
+    ]
+
+
+def test_all_preserves_every_supported_source() -> None:
+    assert Core.expand_source_selection("ALL") == Core.get_supportedengines()
+
+
 def mock_read_text(mocked: dict[Path, str | Exception]):
     read_text = Path.read_text
 

--- a/tests/lib/test_source_catalog.py
+++ b/tests/lib/test_source_catalog.py
@@ -1,0 +1,71 @@
+import ast
+from pathlib import Path
+
+from theHarvester.lib.core import Core
+from theHarvester.lib.source_catalog import SOURCE_SPECS, ResultRoute, SourceSpec, get_source_spec
+
+
+def _scheduled_source_names() -> list[str]:
+    tree = ast.parse(Path('theHarvester/__main__.py').read_text())
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare) or len(node.ops) != 1 or not isinstance(node.ops[0], ast.Eq):
+            continue
+        if not isinstance(node.left, ast.Name) or node.left.id != 'engineitem' or len(node.comparators) != 1:
+            continue
+        comparator = node.comparators[0]
+        if isinstance(comparator, ast.Constant) and isinstance(comparator.value, str):
+            names.append(comparator.value)
+    return names
+
+
+def test_source_specs_cover_supported_sources() -> None:
+    scheduled = _scheduled_source_names()
+
+    assert len(scheduled) == len(set(scheduled))
+    assert set(SOURCE_SPECS) == set(scheduled)
+    assert set(SOURCE_SPECS) <= set(Core.get_supportedengines())
+
+
+def test_source_capabilities_are_derived_from_result_routes() -> None:
+    spec = SourceSpec(
+        name='example',
+        routes=frozenset(
+            {
+                ResultRoute.HOSTS,
+                ResultRoute.LINKS,
+                ResultRoute.INTERESTING_URLS,
+            }
+        ),
+    )
+
+    assert spec.capabilities == frozenset({'subdomains', 'urls'})
+
+
+def test_source_specs_describe_consolidated_routes_not_getter_presence() -> None:
+    assert SOURCE_SPECS['gitlab'].routes == frozenset({ResultRoute.HOSTS, ResultRoute.EMAILS})
+    assert SOURCE_SPECS['haveibeenpwned'].routes == frozenset()
+    assert SOURCE_SPECS['urlscan'].routes == frozenset(
+        {
+            ResultRoute.HOSTS,
+            ResultRoute.IPS,
+            ResultRoute.ASNS,
+            ResultRoute.INTERESTING_URLS,
+        }
+    )
+
+
+def test_capability_selection_preserves_every_declared_route() -> None:
+    assert 'venacus' in Core.expand_source_selection('emails')
+    assert get_source_spec('venacus').routes == frozenset(
+        {
+            ResultRoute.EMAILS,
+            ResultRoute.IPS,
+            ResultRoute.PEOPLE,
+            ResultRoute.INTERESTING_URLS,
+        }
+    )
+
+
+def test_source_lookup_preserves_case_insensitive_legacy_labels() -> None:
+    assert get_source_spec('CRTsh') is SOURCE_SPECS['crtsh']

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -6,7 +6,17 @@ from pathlib import Path
 
 import yaml
 
+from theHarvester.lib.core import Core
+
 RESULT_COLUMNS = ('Hosts', 'Emails', 'IPs', 'ASNs', 'URLs / links', 'People')
+CAPABILITY_COLUMNS = {
+    'Hosts': 'subdomains',
+    'Emails': 'emails',
+    'IPs': 'ips',
+    'ASNs': 'asns',
+    'URLs / links': 'urls',
+    'People': 'people',
+}
 STORE_RESULT_COLUMNS = {
     'store_host': {'Hosts'},
     'store_emails': {'Emails'},
@@ -124,6 +134,18 @@ def test_readme_matches_executable_source_contracts() -> None:
     assert len(documented) == 56
     assert documented == executable
     assert {'securitytrails', 'shodaninternetdb'}.isdisjoint(documented)
+
+
+def test_runtime_source_capabilities_match_executable_contracts() -> None:
+    executable = _executable_source_contracts()
+    expected = {
+        source: frozenset(CAPABILITY_COLUMNS[column] for column in columns)
+        for source, columns in executable.items()
+    }
+    runtime = Core.get_source_capabilities()
+
+    assert {source: runtime[source] for source in executable} == expected
+    assert {source for source, capabilities in runtime.items() if capabilities} <= set(executable)
 
 
 def test_readme_api_key_markers_match_configuration() -> None:

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,37 +1,21 @@
 from __future__ import annotations
 
-import ast
 import re
 from pathlib import Path
 
 import yaml
 
-from theHarvester.lib.core import Core
+from theHarvester.lib.source_catalog import SOURCE_SPECS, ResultRoute
 
 RESULT_COLUMNS = ('Hosts', 'Emails', 'IPs', 'ASNs', 'URLs / links', 'People')
-CAPABILITY_COLUMNS = {
-    'Hosts': 'subdomains',
-    'Emails': 'emails',
-    'IPs': 'ips',
-    'ASNs': 'asns',
-    'URLs / links': 'urls',
-    'People': 'people',
-}
-STORE_RESULT_COLUMNS = {
-    'store_host': {'Hosts'},
-    'store_emails': {'Emails'},
-    'store_ip': {'IPs'},
-    'store_asns': {'ASNs'},
-    'store_links': {'URLs / links'},
-    'store_interestingurls': {'URLs / links'},
-    'store_people': {'People'},
-    'store_results': {'Hosts', 'Emails', 'URLs / links'},
-}
-# These enabled store() flags cannot currently produce the named report field.
-UNAVAILABLE_STORE_RESULTS = {
-    'haveibeenpwned': {'Emails'},  # The adapter never populates its email set.
-    'netlas': {'IPs'},  # The adapter has no get_ips() method.
-    'securityscorecard': {'ASNs', 'URLs / links'},  # The adapter has neither getter.
+ROUTE_COLUMNS = {
+    ResultRoute.HOSTS: 'Hosts',
+    ResultRoute.EMAILS: 'Emails',
+    ResultRoute.IPS: 'IPs',
+    ResultRoute.ASNS: 'ASNs',
+    ResultRoute.LINKS: 'URLs / links',
+    ResultRoute.INTERESTING_URLS: 'URLs / links',
+    ResultRoute.PEOPLE: 'People',
 }
 OPTIONAL_API_KEY_SOURCES = {'hackertarget', 'leakix', 'mojeek', 'windvane'}
 API_KEY_SOURCE_ALIASES = {
@@ -57,44 +41,8 @@ WIKI_PAGES = {
 }
 
 
-def _source_name(node: ast.If) -> str | None:
-    test = node.test
-    if (
-        isinstance(test, ast.Compare)
-        and isinstance(test.left, ast.Name)
-        and test.left.id == 'engineitem'
-        and len(test.ops) == 1
-        and isinstance(test.ops[0], ast.Eq)
-        and len(test.comparators) == 1
-        and isinstance(test.comparators[0], ast.Constant)
-        and isinstance(test.comparators[0].value, str)
-    ):
-        return test.comparators[0].value
-    return None
-
-
-def _executable_source_contracts() -> dict[str, set[str]]:
-    tree = ast.parse(Path('theHarvester/__main__.py').read_text())
-    contracts: dict[str, set[str]] = {}
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.If) or (source := _source_name(node)) is None:
-            continue
-        calls = [
-            child
-            for statement in node.body
-            for child in ast.walk(statement)
-            if isinstance(child, ast.Call) and isinstance(child.func, ast.Name) and child.func.id == 'store'
-        ]
-        assert len(calls) == 1, f'{source} must have exactly one store() call'
-        enabled = {
-            keyword.arg
-            for keyword in calls[0].keywords
-            if keyword.arg in STORE_RESULT_COLUMNS and isinstance(keyword.value, ast.Constant) and keyword.value.value is True
-        }
-        contracts[source] = set().union(*(STORE_RESULT_COLUMNS[name] for name in enabled)) - UNAVAILABLE_STORE_RESULTS.get(
-            source, set()
-        )
-    return contracts
+def _declared_source_contracts() -> dict[str, set[str]]:
+    return {source: {ROUTE_COLUMNS[route] for route in spec.routes} for source, spec in SOURCE_SPECS.items()}
 
 
 def _documented_source_rows(readme: str) -> dict[str, list[str]]:
@@ -125,27 +73,15 @@ def _configured_api_key_sources() -> set[str]:
     return set().union(*(API_KEY_SOURCE_ALIASES.get(source, {source}) for source in configured))
 
 
-def test_readme_matches_executable_source_contracts() -> None:
+def test_readme_matches_declared_source_contracts() -> None:
     readme = Path('README.md').read_text()
     documented = _documented_source_contracts(readme)
-    executable = _executable_source_contracts()
+    declared = _declared_source_contracts()
 
-    assert len(executable) == 56
+    assert len(declared) == 56
     assert len(documented) == 56
-    assert documented == executable
+    assert documented == declared
     assert {'securitytrails', 'shodaninternetdb'}.isdisjoint(documented)
-
-
-def test_runtime_source_capabilities_match_executable_contracts() -> None:
-    executable = _executable_source_contracts()
-    expected = {
-        source: frozenset(CAPABILITY_COLUMNS[column] for column in columns)
-        for source, columns in executable.items()
-    }
-    runtime = Core.get_source_capabilities()
-
-    assert {source: runtime[source] for source in executable} == expected
-    assert {source for source, capabilities in runtime.items() if capabilities} <= set(executable)
 
 
 def test_readme_api_key_markers_match_configuration() -> None:

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -80,6 +80,7 @@ from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib import hostchecker, stash
 from theHarvester.lib.core import DATA_DIR, Core, show_default_error_message
 from theHarvester.lib.output import configure_logging, output_logger, print_linkedin_sections, print_section, sorted_unique
+from theHarvester.lib.source_catalog import ResultRoute, get_source_spec
 from theHarvester.screenshot.screenshot import ScreenShotter
 
 if TYPE_CHECKING:
@@ -330,47 +331,25 @@ async def start(rest_args: argparse.Namespace | None = None):
     async def store(
         search_engine: Any,
         source: str,
-        process_param: Any = None,
-        store_host: bool = False,
-        store_emails: bool = False,
-        store_ip: bool = False,
-        store_people: bool = False,
-        store_links: bool = False,
-        store_results: bool = False,
-        store_interestingurls: bool = False,
-        store_asns: bool = False,
     ) -> None:
-        """Persist details into the database.
-        The details to be stored are controlled by the parameters passed to the method.
+        """Process a source and persist its declared consolidated result routes.
 
         :param search_engine: search engine to fetch details from
         :param source: source against which the details (corresponding to the search engine) need to be persisted
-        :param process_param: any parameters to be passed to the search engine eg: Google needs google_dorking
-        :param store_host: whether to store hosts
-        :param store_emails: whether to store emails
-        :param store_ip: whether to store IP address
-        :param store_people: whether to store user details
-        :param store_links: whether to store links
-        :param store_results: whether to fetch details from get_results() and persist
-        :param store_interestingurls: whether to store interesting urls
-        :param store_asns: whether to store asns
         """
         logger.info(f'Source {source} started')
         try:
-            (
-                await search_engine.process(use_proxy)
-                if process_param is None
-                else await search_engine.process(process_param, use_proxy)
-            )
+            await search_engine.process(use_proxy)
         except Exception:
             logger.exception(f'Source {source} failed')
             raise
         db_stash = stash.StashManager()
+        routes = get_source_spec(source).routes
 
         if source:
             output_logger.info(f'[*] Searching {source[0].upper() + source[1:]}. ')
 
-        if store_host:
+        if ResultRoute.HOSTS in routes:
             discovered_hosts = await search_engine.get_hostnames()
             if source == 'intelx':
                 host_names = list(discovered_hosts)
@@ -399,43 +378,34 @@ async def start(rest_args: argparse.Namespace | None = None):
             all_hosts.extend(host_names)
             await db_stash.store_all(word, all_hosts, 'host', source)
 
-        if store_emails:
+        if ResultRoute.EMAILS in routes:
             email_list = await search_engine.get_emails()
             all_emails.extend(email_list)
             await db_stash.store_all(word, email_list, 'email', source)
 
-        if store_ip:
+        if ResultRoute.IPS in routes:
             ips_list = await search_engine.get_ips()
             all_ip.extend(ips_list)
             await db_stash.store_all(word, all_ip, 'ip', source)
 
-        if store_results:
-            email_list, host_names, urls = await search_engine.get_results()
-            all_emails.extend(email_list)
-            host_names = list({host for host in host_names if f'.{word}' in host})
-            all_urls.extend(urls)
-            all_hosts.extend(host_names)
-            await db.store_all(word, all_hosts, 'host', source)
-            await db.store_all(word, all_emails, 'email', source)
-
-        if store_people:
+        if ResultRoute.PEOPLE in routes:
             people_list = await search_engine.get_people()
             all_people.extend(people_list)
             await db_stash.store_all(word, people_list, 'people', source)
 
-        if store_links:
+        if ResultRoute.LINKS in routes:
             links = await search_engine.get_links()
             linkedin_links_tracker.extend(links)
             if len(links) > 0:
                 await db.store_all(word, links, 'linkedinlinks', source)
 
-        if store_interestingurls:
+        if ResultRoute.INTERESTING_URLS in routes:
             iurls = await search_engine.get_interestingurls()
             interesting_urls.extend(iurls)
             if len(iurls) > 0:
                 await db.store_all(word, iurls, 'interestingurls', source)
 
-        if store_asns:
+        if ResultRoute.ASNS in routes:
             fasns = await search_engine.get_asns()
             total_asns.extend(fasns)
             if len(fasns) > 0:
@@ -457,8 +427,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 baidu_search,
                                 engineitem,
-                                store_host=True,
-                                store_emails=True,
                             )
                         )
                     except Exception as e:
@@ -471,8 +439,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 bevigil_search,
                                 engineitem,
-                                store_host=True,
-                                store_interestingurls=True,
                             )
                         )
                     except Exception as e:
@@ -485,8 +451,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 bitbucket_search,
                                 engineitem,
-                                store_host=True,
-                                store_emails=True,
                             )
                         )
                     except Exception as ex:
@@ -502,8 +466,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 brave_search,
                                 engineitem,
-                                store_host=True,
-                                store_emails=True,
                             )
                         )
                     except Exception as e:
@@ -516,8 +478,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 bufferoverun_search,
                                 engineitem,
-                                store_host=True,
-                                store_ip=True,
                             )
                         )
                     except Exception as e:
@@ -526,7 +486,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'builtwith':
                     try:
                         builtwith_search = builtwith.SearchBuiltWith(word)
-                        stor_lst.append(store(builtwith_search, engineitem, store_host=True, store_interestingurls=True))
+                        stor_lst.append(store(builtwith_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             output_logger.info(f"Failed to perform BuiltWith search for word: '{word}'")
@@ -541,8 +501,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 censys_search,
                                 engineitem,
-                                store_host=True,
-                                store_emails=True,
                             )
                         )
                     except MissingKey as mk:
@@ -564,7 +522,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'certspotter':
                     try:
                         certspotter_search = certspottersearch.SearchCertspoter(word)
-                        stor_lst.append(store(certspotter_search, engineitem, None, store_host=True))
+                        stor_lst.append(store(certspotter_search, engineitem))
                     except ConnectionError as ce:
                         if not args.quiet:
                             output_logger.info(f'Network connection error while accessing Certspotter: {ce}')
@@ -588,7 +546,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 chaos_search,
                                 engineitem,
-                                store_host=True,
                             )
                         )
                     except Exception as e:
@@ -605,7 +562,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 commoncrawl_search,
                                 engineitem,
-                                store_host=True,
                             )
                         )
                     except Exception as e:
@@ -618,9 +574,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 criminalip_search,
                                 engineitem,
-                                store_host=True,
-                                store_ip=True,
-                                store_asns=True,
                             )
                         )
                     except Exception as e:
@@ -633,7 +586,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'crtsh':
                     try:
                         crtsh_search = crtsh.SearchCrtsh(word)
-                        stor_lst.append(store(crtsh_search, 'CRTsh', store_host=True))
+                        stor_lst.append(store(crtsh_search, 'CRTsh'))
                     except Exception as e:
                         output_logger.info(f'[!] A timeout occurred with crtsh, cannot find {args.domain}\n {e}')
 
@@ -644,8 +597,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 dehashed_search,
                                 engineitem,
-                                store_host=False,
-                                store_ip=True,
                             )
                         )
                     except Exception as e:
@@ -658,7 +609,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'dnsdb':
                     try:
                         dnsdb_search = dnsdb.SearchDNSDB(word)
-                        stor_lst.append(store(dnsdb_search, engineitem, store_host=True))
+                        stor_lst.append(store(dnsdb_search, engineitem))
                     except MissingKey as e:
                         if not args.quiet:
                             output_logger.info(e)
@@ -672,8 +623,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 dnsdumpster_search,
                                 engineitem,
-                                store_host=True,
-                                store_ip=True,
                             )
                         )
                     except MissingKey as e:
@@ -688,15 +637,13 @@ async def start(rest_args: argparse.Namespace | None = None):
                         store(
                             duckduckgo_search,
                             engineitem,
-                            store_host=True,
-                            store_emails=True,
                         )
                     )
 
                 elif engineitem == 'dymo':
                     try:
                         dymo_search = dymosearch.SearchDymo(word)
-                        stor_lst.append(store(dymo_search, engineitem, store_host=True))
+                        stor_lst.append(store(dymo_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             if not args.quiet:
@@ -711,8 +658,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 fofa_search,
                                 engineitem,
-                                store_host=True,
-                                store_ip=True,
                             )
                         )
                     except Exception as e:
@@ -725,7 +670,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'fullhunt':
                     try:
                         fullhunt_search = fullhuntsearch.SearchFullHunt(word)
-                        stor_lst.append(store(fullhunt_search, engineitem, store_host=True))
+                        stor_lst.append(store(fullhunt_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             if not args.quiet:
@@ -738,8 +683,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 github_search,
                                 engineitem,
-                                store_host=True,
-                                store_emails=True,
                             )
                         )
                     except MissingKey as ex:
@@ -753,8 +696,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 gitlab_search,
                                 engineitem,
-                                store_host=True,
-                                store_emails=True,
                             )
                         )
                     except Exception as e:
@@ -763,7 +704,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'hackertarget':
                     try:
                         hackertarget_search = hackertarget.SearchHackerTarget(word)
-                        stor_lst.append(store(hackertarget_search, engineitem, store_host=True))
+                        stor_lst.append(store(hackertarget_search, engineitem))
                     except Exception as e:
                         show_default_error_message(engineitem, word, e)
 
@@ -774,7 +715,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 haveibeenpwned_search,
                                 engineitem,
-                                store_emails=True,
                             )
                         )
                     except Exception as e:
@@ -791,9 +731,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 hudsonrock_search,
                                 engineitem,
-                                store_host=True,
-                                store_emails=True,
-                                store_ip=True,
                             )
                         )
                     except Exception as e:
@@ -806,8 +743,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 hunter_search,
                                 engineitem,
-                                store_host=True,
-                                store_emails=True,
                             )
                         )
                     except Exception as e:
@@ -818,7 +753,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'hunterhow':
                     try:
                         hunterhow_search = searchhunterhow.SearchHunterHow(word)
-                        stor_lst.append(store(hunterhow_search, engineitem, store_host=True))
+                        stor_lst.append(store(hunterhow_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             if not args.quiet:
@@ -833,9 +768,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 intelx_search,
                                 engineitem,
-                                store_host=True,
-                                store_interestingurls=True,
-                                store_emails=True,
                             )
                         )
                     except Exception as e:
@@ -852,8 +784,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 leakix_search,
                                 engineitem,
-                                store_host=True,
-                                store_emails=True,
                             )
                         )
                     except Exception as e:
@@ -866,7 +796,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 leaklookup_search,
                                 engineitem,
-                                store_emails=True,
                             )
                         )
                     except Exception as e:
@@ -882,8 +811,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 mojeek_search,
                                 engineitem,
-                                store_host=True,
-                                store_emails=True,
                             )
                         )
                     except Exception as e:
@@ -899,8 +826,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 netlas_search,
                                 engineitem,
-                                store_host=True,
-                                store_ip=True,
                             )
                         )
                     except Exception as e:
@@ -915,9 +840,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 onyphe_search,
                                 engineitem,
-                                store_host=True,
-                                store_ip=True,
-                                store_asns=True,
                             )
                         )
                     except ConnectionError as ce:
@@ -943,8 +865,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 otxsearch_search,
                                 engineitem,
-                                store_host=True,
-                                store_ip=True,
                             )
                         )
                     except ConnectionError as ce:
@@ -966,7 +886,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'pentesttools':
                     try:
                         pentesttools_search = pentesttools.SearchPentestTools(word)
-                        stor_lst.append(store(pentesttools_search, engineitem, store_host=True))
+                        stor_lst.append(store(pentesttools_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             if not args.quiet:
@@ -977,7 +897,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'projectdiscovery':
                     try:
                         projectdiscovery_search = projectdiscovery.SearchDiscovery(word)
-                        stor_lst.append(store(projectdiscovery_search, engineitem, store_host=True))
+                        stor_lst.append(store(projectdiscovery_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             if not args.quiet:
@@ -988,7 +908,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'rapiddns':
                     try:
                         rapiddns_search = rapiddns.SearchRapidDns(word)
-                        stor_lst.append(store(rapiddns_search, engineitem, store_host=True))
+                        stor_lst.append(store(rapiddns_search, engineitem))
                     except ConnectionError as ce:
                         if not args.quiet:
                             output_logger.info(f'Network connection error while accessing RapidDNS: {ce}')
@@ -1012,8 +932,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 robtex_search,
                                 engineitem,
-                                store_host=True,
-                                store_ip=True,
                             )
                         )
                     except Exception as e:
@@ -1022,7 +940,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'rocketreach':
                     try:
                         rocketreach_search = rocketreach.SearchRocketReach(word, limit)
-                        stor_lst.append(store(rocketreach_search, engineitem, store_links=True, store_emails=True))
+                        stor_lst.append(store(rocketreach_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             if not args.quiet:
@@ -1037,10 +955,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 securityscorecard_search,
                                 engineitem,
-                                store_host=True,
-                                store_ip=True,
-                                store_interestingurls=True,
-                                store_asns=True,
                             )
                         )
                     except Exception as e:
@@ -1056,8 +970,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 securitytrails_search,
                                 engineitem,
-                                store_host=True,
-                                store_ip=True,
                             )
                         )
                     except Exception as e:
@@ -1072,9 +984,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 sherlockeye_search,
                                 engineitem,
-                                store_host=True,
-                                store_ip=True,
-                                store_emails=True,
                             )
                         )
                     except Exception as e:
@@ -1120,7 +1029,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                                 return list(self.hosts)
 
                         shodan_wrapper = ShodanWrapper(word, shodan_search)
-                        stor_lst.append(store(shodan_wrapper, engineitem, store_host=True))
+                        stor_lst.append(store(shodan_wrapper, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             if not args.quiet:
@@ -1135,8 +1044,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 shodanidb_search,
                                 engineitem,
-                                store_host=True,
-                                store_ip=True,
                             )
                         )
                     except ConnectionError as ce:
@@ -1152,7 +1059,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'subdomaincenter':
                     try:
                         subdomaincenter_search = subdomaincenter.SubdomainCenter(word)
-                        stor_lst.append(store(subdomaincenter_search, engineitem, store_host=True))
+                        stor_lst.append(store(subdomaincenter_search, engineitem))
                     except ConnectionError as ce:
                         if not args.quiet:
                             output_logger.info(f'Network connection error while accessing SubdomainCenter: {ce}')
@@ -1172,7 +1079,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'subdomainfinderc99':
                     try:
                         subdomainfinderc99_search = subdomainfinderc99.SearchSubdomainfinderc99(word)
-                        stor_lst.append(store(subdomainfinderc99_search, engineitem, store_host=True))
+                        stor_lst.append(store(subdomainfinderc99_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             if not args.quiet:
@@ -1183,7 +1090,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'thc':
                     try:
                         thc_search = thc.SearchThc(word)
-                        stor_lst.append(store(thc_search, engineitem, store_host=True))
+                        stor_lst.append(store(thc_search, engineitem))
                     except Exception as e:
                         show_default_error_message(engineitem, word, e)
 
@@ -1194,8 +1101,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 threatcrowd_search,
                                 engineitem,
-                                store_host=True,
-                                store_ip=True,
                             )
                         )
                     except Exception as e:
@@ -1208,8 +1113,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 tomba_search,
                                 engineitem,
-                                store_host=True,
-                                store_emails=True,
                             )
                         )
                     except Exception as e:
@@ -1224,10 +1127,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 urlscan_search,
                                 engineitem,
-                                store_host=True,
-                                store_ip=True,
-                                store_interestingurls=True,
-                                store_asns=True,
                             )
                         )
                     except ConnectionError as ce:
@@ -1253,10 +1152,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 venacus_search,
                                 engineitem,
-                                store_emails=True,
-                                store_ip=True,
-                                store_people=True,
-                                store_interestingurls=True,
                             )
                         )
                     except Exception as e:
@@ -1269,7 +1164,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'virustotal':
                     try:
                         virustotal_search = virustotal.SearchVirustotal(word)
-                        stor_lst.append(store(virustotal_search, engineitem, store_host=True))
+                        stor_lst.append(store(virustotal_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             if not args.quiet:
@@ -1282,7 +1177,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 waybackarchive_search,
                                 engineitem,
-                                store_host=True,
                             )
                         )
                     except Exception as e:
@@ -1291,7 +1185,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'whoisxml':
                     try:
                         whoisxml_search = whoisxml.SearchWhoisXML(word)
-                        stor_lst.append(store(whoisxml_search, engineitem, store_host=True))
+                        stor_lst.append(store(whoisxml_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             if not args.quiet:
@@ -1306,9 +1200,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 windvane_search,
                                 engineitem,
-                                store_host=True,
-                                store_ip=True,
-                                store_emails=True,
                             )
                         )
                     except Exception as e:
@@ -1321,8 +1212,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 yahoo_search,
                                 engineitem,
-                                store_host=True,
-                                store_emails=True,
                             )
                         )
                     except ConnectionError as ce:
@@ -1348,11 +1237,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                             store(
                                 zoomeye_search,
                                 engineitem,
-                                store_host=True,
-                                store_emails=True,
-                                store_ip=True,
-                                store_interestingurls=True,
-                                store_asns=True,
                             )
                         )
                     except Exception as e:

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -203,7 +203,8 @@ async def start(rest_args: argparse.Namespace | None = None):
     parser.add_argument(
         '-b',
         '--source',
-        help="""baidu, bevigil, bitbucket, brave, bufferoverun,
+        help="""Comma-separated sources or capability selectors: subdomains, emails, ips, asns, urls, people, or all.
+                            Sources: baidu, bevigil, bitbucket, brave, bufferoverun,
                             builtwith, censys, certspotter, chaos, commoncrawl, criminalip, crtsh, dehashed, dnsdumpster, duckduckgo, dymo, fofa, fullhunt, github-code,
                             gitlab, hackertarget, haveibeenpwned, hudsonrock, hunter, hunterhow, intelx, leakix, leaklookup, mojeek, netlas, onyphe, otx, pentesttools,
                             projectdiscovery, rapiddns, robtex, rocketreach, securityscorecard, securityTrails, sherlockeye, shodan, shodanInternetDB, subdomaincenter,
@@ -443,10 +444,7 @@ async def start(rest_args: argparse.Namespace | None = None):
 
     stor_lst = []
     if args.source is not None:
-        if args.source.lower() != 'all':
-            engines = sorted(set(map(str.strip, args.source.split(','))))
-        else:
-            engines = Core.get_supportedengines()
+        engines = Core.expand_source_selection(args.source)
         # Iterate through search engines in order
         if set(engines).issubset(Core.get_supportedengines()):
             output_logger.info(f'\n[*] Target: {word} \n')

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -34,6 +34,63 @@ CONFIG_DIRS = [
 
 class Core:
     quiet: bool = False
+    _SOURCE_CAPABILITIES: ClassVar[dict[str, tuple[str, ...]]] = {
+        'baidu': ('subdomains', 'emails'),
+        'bevigil': ('subdomains', 'urls'),
+        'bitbucket': ('subdomains', 'emails'),
+        'brave': ('subdomains', 'emails'),
+        'bufferoverun': ('subdomains', 'ips'),
+        'builtwith': ('subdomains', 'urls'),
+        'censys': ('subdomains', 'emails'),
+        'certspotter': ('subdomains',),
+        'chaos': ('subdomains',),
+        'commoncrawl': ('subdomains',),
+        'criminalip': ('subdomains', 'ips', 'asns'),
+        'crtsh': ('subdomains',),
+        'dehashed': ('ips',),
+        'dnsdumpster': ('subdomains', 'ips'),
+        'duckduckgo': ('subdomains', 'emails'),
+        'dymo': ('subdomains',),
+        'fofa': ('subdomains', 'ips'),
+        'fullhunt': ('subdomains',),
+        'github-code': ('subdomains', 'emails'),
+        'gitlab': ('subdomains', 'emails'),
+        'hackertarget': ('subdomains',),
+        'haveibeenpwned': (),
+        'hudsonrock': ('subdomains', 'emails', 'ips'),
+        'hunter': ('subdomains', 'emails'),
+        'hunterhow': ('subdomains',),
+        'intelx': ('subdomains', 'emails', 'urls'),
+        'leakix': ('subdomains', 'emails'),
+        'leaklookup': ('emails',),
+        'mojeek': ('subdomains', 'emails'),
+        'netlas': ('subdomains',),
+        'onyphe': ('subdomains', 'ips', 'asns'),
+        'otx': ('subdomains', 'ips'),
+        'pentesttools': ('subdomains',),
+        'projectdiscovery': ('subdomains',),
+        'rapiddns': ('subdomains',),
+        'robtex': ('subdomains', 'ips'),
+        'rocketreach': ('emails', 'urls'),
+        'securityTrails': ('subdomains', 'ips'),
+        'securityscorecard': ('subdomains', 'ips'),
+        'sherlockeye': ('subdomains', 'emails', 'ips'),
+        'shodan': ('subdomains',),
+        'shodanInternetDB': ('subdomains', 'ips'),
+        'subdomaincenter': ('subdomains',),
+        'subdomainfinderc99': ('subdomains',),
+        'thc': ('subdomains',),
+        'threatcrowd': ('subdomains', 'ips'),
+        'tomba': ('subdomains', 'emails'),
+        'urlscan': ('subdomains', 'ips', 'asns', 'urls'),
+        'venacus': ('emails', 'ips', 'urls', 'people'),
+        'virustotal': ('subdomains',),
+        'waybackarchive': ('subdomains',),
+        'whoisxml': ('subdomains',),
+        'windvane': ('subdomains', 'emails', 'ips'),
+        'yahoo': ('subdomains', 'emails'),
+        'zoomeye': ('subdomains', 'emails', 'ips', 'asns', 'urls'),
+    }
     _API_KEY_FIELDS: ClassVar[dict[str, tuple[str, ...]]] = {
         'bevigil': ('key',),
         'bitbucket': ('key',),
@@ -349,6 +406,26 @@ class Core:
             'zoomeye',
             'zoomeyeapi',
         ]
+
+    @classmethod
+    def expand_source_selection(cls, selection: str) -> list[str]:
+        """Expand result capability selectors into source names."""
+        if selection.lower() == 'all':
+            return cls.get_supportedengines()
+        source_capabilities = cls.get_source_capabilities()
+        capabilities = {capability for source_capability in source_capabilities.values() for capability in source_capability}
+        selected: set[str] = set()
+        for token in map(str.strip, selection.split(',')):
+            if token in capabilities:
+                selected.update(source for source, source_capability in source_capabilities.items() if token in source_capability)
+            else:
+                selected.add(token)
+        return sorted(selected)
+
+    @classmethod
+    def get_source_capabilities(cls) -> dict[str, frozenset[str]]:
+        """Return the consolidated result capabilities for each supported source."""
+        return {source: frozenset(cls._SOURCE_CAPABILITIES.get(source, ())) for source in cls.get_supportedengines()}
 
     @staticmethod
     def get_user_agent() -> str:

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -18,6 +18,7 @@ from aiohttp_socks import ProxyConnector
 
 from theHarvester import __version__
 from theHarvester.lib.output import output_logger
+from theHarvester.lib.source_catalog import SOURCE_SPECS
 
 if TYPE_CHECKING:
     from collections.abc import Sized
@@ -34,63 +35,6 @@ CONFIG_DIRS = [
 
 class Core:
     quiet: bool = False
-    _SOURCE_CAPABILITIES: ClassVar[dict[str, tuple[str, ...]]] = {
-        'baidu': ('subdomains', 'emails'),
-        'bevigil': ('subdomains', 'urls'),
-        'bitbucket': ('subdomains', 'emails'),
-        'brave': ('subdomains', 'emails'),
-        'bufferoverun': ('subdomains', 'ips'),
-        'builtwith': ('subdomains', 'urls'),
-        'censys': ('subdomains', 'emails'),
-        'certspotter': ('subdomains',),
-        'chaos': ('subdomains',),
-        'commoncrawl': ('subdomains',),
-        'criminalip': ('subdomains', 'ips', 'asns'),
-        'crtsh': ('subdomains',),
-        'dehashed': ('ips',),
-        'dnsdumpster': ('subdomains', 'ips'),
-        'duckduckgo': ('subdomains', 'emails'),
-        'dymo': ('subdomains',),
-        'fofa': ('subdomains', 'ips'),
-        'fullhunt': ('subdomains',),
-        'github-code': ('subdomains', 'emails'),
-        'gitlab': ('subdomains', 'emails'),
-        'hackertarget': ('subdomains',),
-        'haveibeenpwned': (),
-        'hudsonrock': ('subdomains', 'emails', 'ips'),
-        'hunter': ('subdomains', 'emails'),
-        'hunterhow': ('subdomains',),
-        'intelx': ('subdomains', 'emails', 'urls'),
-        'leakix': ('subdomains', 'emails'),
-        'leaklookup': ('emails',),
-        'mojeek': ('subdomains', 'emails'),
-        'netlas': ('subdomains',),
-        'onyphe': ('subdomains', 'ips', 'asns'),
-        'otx': ('subdomains', 'ips'),
-        'pentesttools': ('subdomains',),
-        'projectdiscovery': ('subdomains',),
-        'rapiddns': ('subdomains',),
-        'robtex': ('subdomains', 'ips'),
-        'rocketreach': ('emails', 'urls'),
-        'securityTrails': ('subdomains', 'ips'),
-        'securityscorecard': ('subdomains', 'ips'),
-        'sherlockeye': ('subdomains', 'emails', 'ips'),
-        'shodan': ('subdomains',),
-        'shodanInternetDB': ('subdomains', 'ips'),
-        'subdomaincenter': ('subdomains',),
-        'subdomainfinderc99': ('subdomains',),
-        'thc': ('subdomains',),
-        'threatcrowd': ('subdomains', 'ips'),
-        'tomba': ('subdomains', 'emails'),
-        'urlscan': ('subdomains', 'ips', 'asns', 'urls'),
-        'venacus': ('emails', 'ips', 'urls', 'people'),
-        'virustotal': ('subdomains',),
-        'waybackarchive': ('subdomains',),
-        'whoisxml': ('subdomains',),
-        'windvane': ('subdomains', 'emails', 'ips'),
-        'yahoo': ('subdomains', 'emails'),
-        'zoomeye': ('subdomains', 'emails', 'ips', 'asns', 'urls'),
-    }
     _API_KEY_FIELDS: ClassVar[dict[str, tuple[str, ...]]] = {
         'bevigil': ('key',),
         'bitbucket': ('key',),
@@ -412,20 +356,14 @@ class Core:
         """Expand result capability selectors into source names."""
         if selection.lower() == 'all':
             return cls.get_supportedengines()
-        source_capabilities = cls.get_source_capabilities()
-        capabilities = {capability for source_capability in source_capabilities.values() for capability in source_capability}
+        capabilities = {capability for spec in SOURCE_SPECS.values() for capability in spec.capabilities}
         selected: set[str] = set()
         for token in map(str.strip, selection.split(',')):
             if token in capabilities:
-                selected.update(source for source, source_capability in source_capabilities.items() if token in source_capability)
+                selected.update(spec.name for spec in SOURCE_SPECS.values() if token in spec.capabilities)
             else:
                 selected.add(token)
         return sorted(selected)
-
-    @classmethod
-    def get_source_capabilities(cls) -> dict[str, frozenset[str]]:
-        """Return the consolidated result capabilities for each supported source."""
-        return {source: frozenset(cls._SOURCE_CAPABILITIES.get(source, ())) for source in cls.get_supportedengines()}
 
     @staticmethod
     def get_user_agent() -> str:

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -1,0 +1,111 @@
+from dataclasses import dataclass
+from enum import Enum, auto
+
+
+class ResultRoute(Enum):
+    HOSTS = auto()
+    EMAILS = auto()
+    IPS = auto()
+    ASNS = auto()
+    PEOPLE = auto()
+    LINKS = auto()
+    INTERESTING_URLS = auto()
+
+
+_ROUTE_CAPABILITIES = {
+    ResultRoute.HOSTS: 'subdomains',
+    ResultRoute.EMAILS: 'emails',
+    ResultRoute.IPS: 'ips',
+    ResultRoute.ASNS: 'asns',
+    ResultRoute.PEOPLE: 'people',
+    ResultRoute.LINKS: 'urls',
+    ResultRoute.INTERESTING_URLS: 'urls',
+}
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    name: str
+    routes: frozenset[ResultRoute]
+
+    @property
+    def capabilities(self) -> frozenset[str]:
+        return frozenset(_ROUTE_CAPABILITIES[route] for route in self.routes)
+
+
+def _spec(name: str, *routes: ResultRoute) -> SourceSpec:
+    return SourceSpec(name=name, routes=frozenset(routes))
+
+
+_SPECS = (
+    _spec('baidu', ResultRoute.HOSTS, ResultRoute.EMAILS),
+    _spec('bevigil', ResultRoute.HOSTS, ResultRoute.INTERESTING_URLS),
+    _spec('bitbucket', ResultRoute.HOSTS, ResultRoute.EMAILS),
+    _spec('brave', ResultRoute.HOSTS, ResultRoute.EMAILS),
+    _spec('bufferoverun', ResultRoute.HOSTS, ResultRoute.IPS),
+    _spec('builtwith', ResultRoute.HOSTS, ResultRoute.INTERESTING_URLS),
+    _spec('censys', ResultRoute.HOSTS, ResultRoute.EMAILS),
+    _spec('certspotter', ResultRoute.HOSTS),
+    _spec('chaos', ResultRoute.HOSTS),
+    _spec('commoncrawl', ResultRoute.HOSTS),
+    _spec('criminalip', ResultRoute.HOSTS, ResultRoute.IPS, ResultRoute.ASNS),
+    _spec('crtsh', ResultRoute.HOSTS),
+    _spec('dehashed', ResultRoute.IPS),
+    _spec('dnsdb', ResultRoute.HOSTS),
+    _spec('dnsdumpster', ResultRoute.HOSTS, ResultRoute.IPS),
+    _spec('duckduckgo', ResultRoute.HOSTS, ResultRoute.EMAILS),
+    _spec('dymo', ResultRoute.HOSTS),
+    _spec('fofa', ResultRoute.HOSTS, ResultRoute.IPS),
+    _spec('fullhunt', ResultRoute.HOSTS),
+    _spec('github-code', ResultRoute.HOSTS, ResultRoute.EMAILS),
+    _spec('gitlab', ResultRoute.HOSTS, ResultRoute.EMAILS),
+    _spec('hackertarget', ResultRoute.HOSTS),
+    _spec('haveibeenpwned'),
+    _spec('hudsonrock', ResultRoute.HOSTS, ResultRoute.EMAILS, ResultRoute.IPS),
+    _spec('hunter', ResultRoute.HOSTS, ResultRoute.EMAILS),
+    _spec('hunterhow', ResultRoute.HOSTS),
+    _spec('intelx', ResultRoute.HOSTS, ResultRoute.EMAILS, ResultRoute.INTERESTING_URLS),
+    _spec('leakix', ResultRoute.HOSTS, ResultRoute.EMAILS),
+    _spec('leaklookup', ResultRoute.EMAILS),
+    _spec('mojeek', ResultRoute.HOSTS, ResultRoute.EMAILS),
+    _spec('netlas', ResultRoute.HOSTS),
+    _spec('onyphe', ResultRoute.HOSTS, ResultRoute.IPS, ResultRoute.ASNS),
+    _spec('otx', ResultRoute.HOSTS, ResultRoute.IPS),
+    _spec('pentesttools', ResultRoute.HOSTS),
+    _spec('projectdiscovery', ResultRoute.HOSTS),
+    _spec('rapiddns', ResultRoute.HOSTS),
+    _spec('robtex', ResultRoute.HOSTS, ResultRoute.IPS),
+    _spec('rocketreach', ResultRoute.EMAILS, ResultRoute.LINKS),
+    _spec('securityTrails', ResultRoute.HOSTS, ResultRoute.IPS),
+    _spec('securityscorecard', ResultRoute.HOSTS, ResultRoute.IPS),
+    _spec('sherlockeye', ResultRoute.HOSTS, ResultRoute.EMAILS, ResultRoute.IPS),
+    _spec('shodan', ResultRoute.HOSTS),
+    _spec('shodanInternetDB', ResultRoute.HOSTS, ResultRoute.IPS),
+    _spec('subdomaincenter', ResultRoute.HOSTS),
+    _spec('subdomainfinderc99', ResultRoute.HOSTS),
+    _spec('thc', ResultRoute.HOSTS),
+    _spec('threatcrowd', ResultRoute.HOSTS, ResultRoute.IPS),
+    _spec('tomba', ResultRoute.HOSTS, ResultRoute.EMAILS),
+    _spec('urlscan', ResultRoute.HOSTS, ResultRoute.IPS, ResultRoute.ASNS, ResultRoute.INTERESTING_URLS),
+    _spec('venacus', ResultRoute.EMAILS, ResultRoute.IPS, ResultRoute.PEOPLE, ResultRoute.INTERESTING_URLS),
+    _spec('virustotal', ResultRoute.HOSTS),
+    _spec('waybackarchive', ResultRoute.HOSTS),
+    _spec('whoisxml', ResultRoute.HOSTS),
+    _spec('windvane', ResultRoute.HOSTS, ResultRoute.EMAILS, ResultRoute.IPS),
+    _spec('yahoo', ResultRoute.HOSTS, ResultRoute.EMAILS),
+    _spec(
+        'zoomeye',
+        ResultRoute.HOSTS,
+        ResultRoute.EMAILS,
+        ResultRoute.IPS,
+        ResultRoute.ASNS,
+        ResultRoute.INTERESTING_URLS,
+    ),
+)
+
+SOURCE_SPECS = {spec.name: spec for spec in _SPECS}
+_CASEFOLDED_SOURCE_SPECS = {name.casefold(): spec for name, spec in SOURCE_SPECS.items()}
+
+
+def get_source_spec(name: str) -> SourceSpec:
+    return _CASEFOLDED_SOURCE_SPECS[name.casefold()]


### PR DESCRIPTION
## Summary

- let `-b` select sources by normalized result capability
- support union selection across capabilities and explicit source names
- derive selection and persistence from one `SourceSpec.routes` declaration
- keep `-b all` behavior unchanged
- document `subdomains`, `emails`, `ips`, `asns`, `urls`, and `people`

## Why

Operators currently need to know which source names can produce the result type they want. This adds a source-selection layer so commands such as `-b subdomains` and `-b emails,urls,certspotter` select the relevant sources without filtering any other results those sources return.

Each executable source now declares its normalized result routes once in `SourceSpec`. Those routes drive capability selection, result collection and persistence, and README matrix parity. DNSDB declares the hostname route after its upstream merge.

## Compatibility

- explicit source names still work
- capability and source tokens form a union
- `-b all` still runs every registered source
- `urls` is the single operator-facing name for URL and interesting-URL results

## Verification

- `uv run pytest`: 238 passed, 6 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy theHarvester`
- no `_SOURCE_CAPABILITIES` dict remains
- no per-source `store_*` result-routing flags remain
