### PR TITLE
fix: sync uv lock cutoff metadata

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,10 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiodns"
 version = "4.0.4"


### PR DESCRIPTION
## Summary

- sync the committed uv lock with the configured seven-day dependency cutoff
- reuse existing upstream commit 424b672c
- unblock Docker builds that run uv sync --locked

## Verification

- uv lock --check --offline, repeated twice
- UV_PROJECT_ENVIRONMENT=<temporary path> uv sync --locked --no-dev --no-cache --compile-bytecode

Both commands passed locally. A full Docker build was blocked before the install layer by a registry metadata timeout while fetching ghcr.io/astral-sh/uv:latest.