### PR TITLE
feat: report completed evidence runs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,7 +8,12 @@ The definitions state intended semantics; they do not imply that every discovery
 
 **Currently addressable subdomain**:
 A normalized, in-scope subdomain with current resolver consensus evidence of an A or AAAA record, or a permitted CNAME chain ending in one, that is neither wildcard-indistinguishable nor resolver-disputed.
+A candidate backed by deterministic exact-node evidence is distinguishable even when its DNS response overlaps the learned wildcard distribution.
 _Avoid_: Valid subdomain, live host, resolved host
+
+**Not currently addressable**:
+An in-scope candidate for which resolver consensus within one validation window reports no A or AAAA address and no CNAME chain ending in one. It remains secondary subdomain evidence.
+_Avoid_: Invalid subdomain, dead host
 
 **Secondary subdomain evidence**:
 An in-scope DNS-existing, historical, dangling-alias, or indeterminate name observation retained for defensive and investigative use but excluded from the primary currently addressable yield count.

--- a/tests/discovery/test_crtsh.py
+++ b/tests/discovery/test_crtsh.py
@@ -60,6 +60,15 @@ class TestCrtshSearch:
         assert set(await search.get_hostnames()) == {'a.example.com', 'b.example.com'}
 
     @pytest.mark.asyncio
+    async def test_multiline_wildcard_prefix_is_stripped(self, monkeypatch):
+        _patch_fetch(monkeypatch, [{'name_value': 'a.example.com\n*.b.example.com'}])
+        search = crtsh.SearchCrtsh('example.com')
+
+        await search.process()
+
+        assert set(await search.get_hostnames()) == {'a.example.com', 'b.example.com'}
+
+    @pytest.mark.asyncio
     async def test_numeric_prefixed_entries_are_filtered(self, monkeypatch):
         _patch_fetch(monkeypatch, [{'name_value': '1234.example.com'}, {'name_value': 'good.example.com'}])
         search = crtsh.SearchCrtsh('example.com')

--- a/tests/discovery/test_crtsh.py
+++ b/tests/discovery/test_crtsh.py
@@ -3,6 +3,7 @@ import asyncio
 import pytest
 
 from theHarvester.discovery import crtsh
+from theHarvester.lib.run import SourceIncompleteError
 
 
 def _patch_fetch(monkeypatch, payload):
@@ -100,15 +101,28 @@ class TestCrtshSearch:
         assert await search.get_hostnames() == ['api.example.com']
 
     @pytest.mark.asyncio
-    async def test_missing_name_value_key_is_handled(self, monkeypatch):
+    async def test_invalid_responses_report_failure(self, monkeypatch):
+        fetches = _patch_fetch(monkeypatch, '')
+        delays = _patch_sleep(monkeypatch)
+        search = crtsh.SearchCrtsh('example.com')
+
+        with pytest.raises(SourceIncompleteError):
+            await search.process()
+
+        assert len(fetches) == 3
+        assert delays == [2, 2]
+
+    @pytest.mark.asyncio
+    async def test_missing_name_value_key_reports_failure(self, monkeypatch):
         fetches = _patch_fetch(monkeypatch, [{'issuer_ca_id': 1}])
         delays = _patch_sleep(monkeypatch)
         search = crtsh.SearchCrtsh('example.com')
-        await search.process()
+
+        with pytest.raises(SourceIncompleteError):
+            await search.process()
 
         assert len(fetches) == 1
         assert delays == []
-        assert await search.get_hostnames() == []
 
 
 class TestCrtshIntegration:

--- a/tests/discovery/test_dnsdb.py
+++ b/tests/discovery/test_dnsdb.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import pytest
 
 from theHarvester.discovery import dnsdb
 from theHarvester.discovery.constants import MissingKey
+from theHarvester.lib.run import (
+    LegacyHostnameSource,
+    SourceIncompleteError,
+    SourceRateLimitedError,
+    SourceStatus,
+    execute_run,
+)
 
 
 def _install_response(
@@ -13,7 +21,7 @@ def _install_response(
     lines: tuple[bytes, ...],
     *,
     status: int = 200,
-    stream_error: Exception | None = None,
+    stream_error: BaseException | None = None,
 ) -> dict[str, object]:
     requested: dict[str, object] = {}
     lines_left = list(lines)
@@ -133,10 +141,10 @@ async def test_process_uses_configured_proxy_when_enabled(monkeypatch: pytest.Mo
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ('last_line', 'expected_message'),
+    ('last_line', 'expected_message', 'expected_error'),
     [
-        (b'{"cond":"limited"}\n', 'ended with limited'),
-        (b'not-json\n', 'malformed NDJSON'),
+        (b'{"cond":"limited"}\n', 'ended with limited', SourceRateLimitedError),
+        (b'not-json\n', 'malformed NDJSON', SourceIncompleteError),
     ],
 )
 async def test_process_preserves_partial_results(
@@ -144,6 +152,7 @@ async def test_process_preserves_partial_results(
     caplog: pytest.LogCaptureFixture,
     last_line: bytes,
     expected_message: str,
+    expected_error: type[Exception],
 ) -> None:
     caplog.set_level(logging.INFO, logger=dnsdb.__name__)
     monkeypatch.setattr(dnsdb.Core, 'dnsdb_key', lambda: 'dnsdb-test-key')
@@ -157,10 +166,91 @@ async def test_process_preserves_partial_results(
     )
 
     search = dnsdb.SearchDNSDB('example.com')
-    await search.process()
+    with pytest.raises(expected_error):
+        await search.process()
 
     assert await search.get_hostnames() == {'first.example.com'}
     assert any(expected_message in message for message in caplog.messages)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('lines', 'expected_message'),
+    [
+        (
+            (
+                b'{"cond":"begin"}\n',
+                b'{"obj":{"rrname":"first.example.com."}}\n',
+                b'{"obj":[]}\n',
+                b'{"cond":"succeeded"}\n',
+            ),
+            'invalid stream record',
+        ),
+        (
+            (
+                b'{"cond":"begin"}\n',
+                b'{"obj":{"rrname":"first.example.com."}}\n',
+            ),
+            'without a terminal condition',
+        ),
+    ],
+)
+async def test_process_rejects_incomplete_stream_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    lines: tuple[bytes, ...],
+    expected_message: str,
+) -> None:
+    caplog.set_level(logging.INFO, logger=dnsdb.__name__)
+    monkeypatch.setattr(dnsdb.Core, 'dnsdb_key', lambda: 'dnsdb-test-key')
+    _install_response(monkeypatch, lines)
+    search = dnsdb.SearchDNSDB('example.com')
+
+    with pytest.raises(SourceIncompleteError):
+        await search.process()
+
+    assert await search.get_hostnames() == {'first.example.com'}
+    assert any(expected_message in message for message in caplog.messages)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('last_line', 'expected_status'),
+    [
+        (b'{"cond":"limited"}\n', SourceStatus.RATE_LIMITED),
+        (b'{"cond":"failed"}\n', SourceStatus.FAILED),
+    ],
+)
+async def test_incomplete_stream_status_keeps_partial_results_in_run(
+    monkeypatch: pytest.MonkeyPatch,
+    last_line: bytes,
+    expected_status: SourceStatus,
+) -> None:
+    monkeypatch.setattr(dnsdb.Core, 'dnsdb_key', lambda: 'dnsdb-test-key')
+    _install_response(
+        monkeypatch,
+        (
+            b'{"cond":"begin"}\n',
+            b'{"obj":{"rrname":"first.example.com."}}\n',
+            last_line,
+        ),
+    )
+    search = dnsdb.SearchDNSDB('example.com')
+
+    result = await execute_run(
+        'example.com',
+        (
+            LegacyHostnameSource(
+                name='dnsdb',
+                legacy_name='dnsdb',
+                family='dnsdb',
+                search=search,
+            ),
+        ),
+    )
+
+    assert {observation.value for observation in result.observations} == {'first.example.com'}
+    assert result.source_executions[0].status is expected_status
 
 
 @pytest.mark.asyncio
@@ -180,10 +270,24 @@ async def test_process_preserves_partial_results_on_midstream_timeout(
     )
 
     search = dnsdb.SearchDNSDB('example.com')
-    await search.process()
+    with pytest.raises(SourceIncompleteError):
+        await search.process()
 
     assert await search.get_hostnames() == {'first.example.com'}
     assert any('request failed' in message for message in caplog.messages)
+
+
+@pytest.mark.asyncio
+async def test_process_propagates_cancellation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dnsdb.Core, 'dnsdb_key', lambda: 'dnsdb-test-key')
+    _install_response(
+        monkeypatch,
+        (b'{"cond":"begin"}\n',),
+        stream_error=asyncio.CancelledError(),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await dnsdb.SearchDNSDB('example.com').process()
 
 
 @pytest.mark.asyncio
@@ -191,7 +295,7 @@ async def test_process_preserves_partial_results_on_midstream_timeout(
     ('status', 'expected_error'),
     [
         (401, PermissionError),
-        (429, ConnectionError),
+        (429, SourceRateLimitedError),
         (503, ConnectionError),
     ],
 )

--- a/tests/discovery/test_intelxsearch.py
+++ b/tests/discovery/test_intelxsearch.py
@@ -142,7 +142,12 @@ async def test_orchestrator_stores_intelx_hostnames(monkeypatch: pytest.MonkeyPa
         async def get_interestingurls(self) -> list[str]:
             return []
 
+    class _RunStore:
+        async def save(self, _result) -> None:
+            return None
+
     monkeypatch.setattr(theharvester_main.stash, 'StashManager', _Stash)
+    monkeypatch.setattr(theharvester_main, 'SQLiteRunStore', _RunStore)
     monkeypatch.setattr(intelxsearch, 'SearchIntelx', _Intelx)
 
     results = await theharvester_main.start(

--- a/tests/discovery/test_shodan_engine.py
+++ b/tests/discovery/test_shodan_engine.py
@@ -22,7 +22,12 @@ class TestShodanEngine:
             async def store_all(self, domain, all, res_type, source) -> None:  # noqa: A002
                 return None
 
+        class DummyRunStore:
+            async def save(self, _result) -> None:
+                return None
+
         monkeypatch.setattr(main_module.stash, "StashManager", DummyStashManager, raising=True)
+        monkeypatch.setattr(main_module, "SQLiteRunStore", DummyRunStore, raising=True)
 
         # Stub Shodan search to avoid network and API key requirements.
         class DummySearchShodan:

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
@@ -73,6 +74,8 @@ async def test_completed_run_serializes_status_and_meaningful_timestamps() -> No
 @pytest.mark.asyncio
 async def test_complete_run_merges_late_and_direct_stage_results() -> None:
     result = await execute_run('example.com', (CompletedRunSource(),))
+    dns_completed_at = datetime(2026, 7, 15, 13, tzinfo=UTC)
+    direct_completed_at = datetime(2026, 7, 15, 14, tzinfo=UTC)
 
     completed = complete_run(
         result,
@@ -83,6 +86,8 @@ async def test_complete_run_merges_late_and_direct_stage_results() -> None:
                 1,
                 1,
                 (StageFinding(StageFindingKind.HOSTNAME, 'late.example.com:192.0.2.11'),),
+                is_action=True,
+                completed_at=dns_completed_at,
             ),
             StageResult(
                 'action:take-over',
@@ -90,6 +95,8 @@ async def test_complete_run_merges_late_and_direct_stage_results() -> None:
                 1,
                 1,
                 (StageFinding(StageFindingKind.TAKEOVER, 'api.example.com', 'not vulnerable'),),
+                is_action=True,
+                completed_at=direct_completed_at,
             ),
         ),
     )
@@ -102,11 +109,13 @@ async def test_complete_run_merges_late_and_direct_stage_results() -> None:
     assert {(item.kind, item.value, item.detail) for item in completed.selected_observations} == {
         (StageFindingKind.TAKEOVER, 'api.example.com', 'not vulnerable')
     }
-    assert {execution.source for execution in completed.source_executions} == {
-        'fixture',
+    assert {execution.source for execution in completed.source_executions} == {'fixture'}
+    assert {execution.stage for execution in completed.stage_executions} == {
         'action:dns-brute',
         'action:take-over',
     }
+    assert next(item for item in completed.observations if item.value == 'late.example.com').collected_at == dns_completed_at
+    assert completed.selected_observations[0].collected_at == direct_completed_at
 
 
 class TerminalRunSource:
@@ -145,6 +154,7 @@ async def test_terminal_reports_each_hostname_once_with_status_and_sources() -> 
                 1,
                 1,
                 (StageFinding(StageFindingKind.TAKEOVER, 'api.example.com', 'not vulnerable'),),
+                is_action=True,
             ),
         ),
     )
@@ -157,7 +167,42 @@ async def test_terminal_reports_each_hostname_once_with_status_and_sources() -> 
     assert 'Secondary evidence / needs review (2)' in terminal
     assert 'Scope-extension candidates (1)' in terminal
     assert 'status=currently-addressable; sources=fixture; takeover=not vulnerable' in terminal
+    assert 'related.example.net [status=scope-extension-candidate; sources=fixture]' in terminal
+    assert 'cdn.vendor.test [status=external-relationship; sources=fixture]' in terminal
+    assert 'status=None' not in terminal
     assert 'Run status: complete' in terminal
+
+
+@pytest.mark.asyncio
+async def test_terminal_keeps_recognizable_non_host_sections() -> None:
+    result = await execute_run('example.com', (CompletedRunSource(),))
+    result = complete_run(
+        result,
+        (
+            StageResult(
+                'fixture',
+                SourceStatus.SUCCEEDED,
+                1,
+                5,
+                (
+                    StageFinding(StageFindingKind.EMAIL, 'ops@example.com'),
+                    StageFinding(StageFindingKind.IP_ADDRESS, '192.0.2.10'),
+                    StageFinding(StageFindingKind.ASN, 'AS64500'),
+                    StageFinding(StageFindingKind.PERSON, 'Alice'),
+                    StageFinding(StageFindingKind.INTERESTING_URL, 'https://example.com/status'),
+                ),
+            ),
+        ),
+    )
+
+    terminal = format_run_terminal(result)
+
+    assert '[*] Emails found: 1' in terminal
+    assert '[*] IPs found: 1' in terminal
+    assert '[*] ASNS found: 1' in terminal
+    assert '[*] People found: 1' in terminal
+    assert '[*] Interesting Urls found: 1' in terminal
+    assert 'ops@example.com [status=observed; sources=fixture]' in terminal
 
 
 @pytest.mark.asyncio
@@ -190,7 +235,7 @@ async def test_jsonl_preserves_typed_records_provenance_and_timestamps() -> None
 @pytest.mark.asyncio
 async def test_legacy_json_and_xml_keep_existing_fields_and_add_evidence() -> None:
     validator = DnsValidator(tuple(TerminalResolver(f'resolver-{index}') for index in range(3)))
-    result = await execute_run('example.com', (CompletedRunSource(),), dns_validator=validator)
+    result = await execute_run('example.com', (TerminalRunSource(),), dns_validator=validator)
 
     legacy = legacy_json_result(
         result,
@@ -206,9 +251,21 @@ async def test_legacy_json_and_xml_keep_existing_fields_and_add_evidence() -> No
     assert legacy['emails'] == ['ops@example.com']
     assert legacy['hosts'] == ['legacy.example.com', 'api.example.com']
     assert legacy['evidence_run']['status'] == 'complete'
+    assert {item['value'] for item in legacy['evidence_run']['merged_results']} == {
+        'api.example.com',
+        'old.example.com',
+        'related.example.net',
+        'cdn.vendor.test',
+    }
     assert evidence_xml.tag == 'evidence_run'
     assert evidence_xml.attrib['status'] == 'complete'
     assert evidence_xml.find("source[@name='fixture']").attrib['status'] == 'succeeded'
+    assert {item.attrib['value'] for item in evidence_xml.findall('merged_result')} == {
+        'api.example.com',
+        'old.example.com',
+        'related.example.net',
+        'cdn.vendor.test',
+    }
 
 
 @pytest.mark.asyncio
@@ -229,6 +286,7 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
     import theHarvester.__main__ as main_module
 
     events: list[str] = []
+    terminal_messages: list[str] = []
     wordlist = tmp_path / 'api-endpoints.txt'
     wordlist.write_text('/v1/status\n')
     report = tmp_path / 'completed-run'
@@ -266,9 +324,19 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
             return None
 
         async def check(self):
-            return ['api.example.com:192.0.2.10'], ['api.example.com'], ['192.0.2.10']
+            return (
+                [
+                    'api.example.com:192.0.2.10',
+                    'api.example.com:198.51.100.10',
+                ],
+                ['api.example.com'],
+                ['192.0.2.10', '198.51.100.10'],
+            )
 
-    async def fake_reverse_all_ips_in_range(**_kwargs) -> None:
+    async def fake_reverse_all_ips_in_range(*, iprange: str, **_kwargs) -> None:
+        if iprange.startswith('192.0.2.10'):
+            raise RuntimeError('one reverse range failed')
+        await asyncio.sleep(0.05)
         events.append('dns-lookup')
 
     class FakeTakeOver:
@@ -285,6 +353,41 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
         async def get_takeover_results(self) -> dict[str, str]:
             return {'api.example.com': 'not vulnerable'}
 
+    class FakePool:
+        def __init__(self, _workers: int) -> None:
+            return None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args) -> None:
+            return None
+
+        async def map(self, function, items):
+            return [await function(item) for item in items]
+
+    class FailedScreenShotter:
+        output = 'screenshots'
+        slash = '/'
+
+        def __init__(self, _output: str) -> None:
+            return None
+
+        def verify_path(self) -> bool:
+            return True
+
+        async def verify_installation(self) -> None:
+            return None
+
+        async def visit(self, host: str):
+            return host, ('https',)
+
+        def chunk_list(self, hosts: list[str], _chunk_size: int):
+            return (hosts,)
+
+        async def take_screenshot(self, _host: str) -> None:
+            raise RuntimeError('screenshot capture failed')
+
     class FakeApiScanner:
         def __init__(self, *_args, **_kwargs) -> None:
             return None
@@ -296,22 +399,31 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
             return {'https://example.com/v1/status': SimpleNamespace(status_code=200)}
 
         def get_interesting_endpoints(self):
-            return {}
+            return {'https://example.com/v1/interesting': SimpleNamespace(status_code=200)}
 
         def get_auth_required(self):
-            return {}
+            return {'https://example.com/v1/private': SimpleNamespace(status_code=401)}
 
         def get_api_versions(self):
-            return set()
+            return {'v1'}
 
         def get_rate_limits(self):
-            return {}
+            return {'https://example.com/v1/limited': SimpleNamespace(method='GET')}
 
         def get_methods(self):
             return {'GET'}
 
         def get_status_codes(self):
-            return {200}
+            return {200, 401, 429}
+
+    class FakeShodanSearch:
+        async def search_ip(self, ip: str):
+            if ip == '198.51.100.10':
+                return {ip: 'provider failed'}
+            return {ip: {'product': 'raw-provider-secret'}}
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
 
     class FakeRunStore:
         saved: ClassVar[list] = []
@@ -324,16 +436,28 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
         events.append('terminal')
         return format_run_terminal(result)
 
+    def capture_output(message: object, *_args, **_kwargs) -> None:
+        terminal_messages.append(str(message))
+
     monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
     monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
     monkeypatch.setattr(main_module.hostchecker, 'Checker', FakeHostChecker)
     monkeypatch.setattr(main_module.dnssearch, 'DnsForce', FakeDnsForce)
-    monkeypatch.setattr(main_module.dnssearch, 'serialize_ip_range', lambda **_kwargs: '192.0.2.0/24')
+    monkeypatch.setattr(
+        main_module.dnssearch,
+        'serialize_ip_range',
+        lambda *, ip, **_kwargs: f'{ip}/24',
+    )
     monkeypatch.setattr(main_module.dnssearch, 'reverse_all_ips_in_range', fake_reverse_all_ips_in_range)
     monkeypatch.setattr(main_module.takeover, 'TakeOver', FakeTakeOver)
+    monkeypatch.setattr(main_module, 'ScreenShotter', FailedScreenShotter)
+    monkeypatch.setattr(main_module, 'Pool', FakePool)
     monkeypatch.setattr(main_module.api_endpoints, 'SearchApiEndpoints', FakeApiScanner)
+    monkeypatch.setattr(main_module.shodansearch, 'SearchShodan', FakeShodanSearch)
+    monkeypatch.setattr(main_module.asyncio, 'sleep', no_sleep)
     monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore, raising=False)
     monkeypatch.setattr(main_module, 'format_run_terminal', capture_terminal, raising=False)
+    monkeypatch.setattr(main_module.output_logger, 'info', capture_output)
 
     response = await main_module.start(
         SimpleNamespace(
@@ -347,8 +471,8 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
             limit=500,
             proxies=False,
             quiet=False,
-            screenshot='',
-            shodan=False,
+            screenshot='screenshots',
+            shodan=True,
             source='crtsh',
             start=0,
             take_over=True,
@@ -358,19 +482,72 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
     )
 
     result = response[-1]
+    terminal = '\n'.join(terminal_messages)
     assert events == ['collect', 'dns-brute', 'dns-lookup', 'takeover', 'api-scan', 'persist', 'terminal']
     assert result is FakeRunStore.saved[0]
+    assert next(item for item in result.stage_executions if item.stage == 'action:screenshot').status is SourceStatus.FAILED
     assert {entity.value for entity in result.entities} == {'api.example.com', 'late.example.com'}
     assert {(item.kind, item.value) for item in result.selected_observations} == {
         (StageFindingKind.TAKEOVER, 'api.example.com'),
         (StageFindingKind.API_ENDPOINT, 'https://example.com/v1/status'),
+        (StageFindingKind.INTERESTING_URL, 'https://example.com/v1/interesting'),
+        (StageFindingKind.API_AUTH_REQUIRED, 'https://example.com/v1/private'),
+        (StageFindingKind.API_VERSION, 'v1'),
+        (StageFindingKind.API_RATE_LIMIT, 'https://example.com/v1/limited'),
+        (StageFindingKind.HTTP_METHOD, 'GET'),
+        (StageFindingKind.HTTP_STATUS_CODE, '200'),
+        (StageFindingKind.HTTP_STATUS_CODE, '401'),
+        (StageFindingKind.HTTP_STATUS_CODE, '429'),
+        (StageFindingKind.SHODAN_RESULT, '192.0.2.10'),
     }
+    assert next(item for item in result.stage_executions if item.stage == 'action:shodan').status is SourceStatus.FAILED
     legacy_json = json.loads(report.with_suffix('.json').read_text())
     evidence_xml = ElementTree.parse(report.with_suffix('.xml')).getroot().find('evidence_run')
     jsonl = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
     assert legacy_json['evidence_run']['run_id'] == result.run_id
     assert evidence_xml.attrib['run_id'] == result.run_id
-    assert {record['record_type'] for record in jsonl} >= {'run', 'selected_observation'}
+    assert {record['record_type'] for record in jsonl} >= {'run', 'stage_execution', 'selected_observation'}
+    assert terminal.count('https://example.com/v1/status') == 1
+    assert 'raw-provider-secret' not in terminal
+    assert '[*] Interesting Urls found: 1' in terminal
+    assert '[*] Endpoints requiring authentication: 1' in terminal
+    assert '[*] Detected API versions: 1' in terminal
+    assert '[*] Rate limited endpoints: 1' in terminal
+    assert '[*] HTTP methods used: 1' in terminal
+    assert '[*] HTTP status codes encountered: 3' in terminal
+
+    from theHarvester.lib.api import api
+
+    async def completed_start(_args, *, return_evidence_run: bool = False):
+        assert return_evidence_run is True
+        return (
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            ['api.example.com', 'late.example.com'],
+            result,
+        )
+
+    monkeypatch.setattr(api.__main__, 'start', completed_start)
+    monkeypatch.setattr(api.__main__.Core, 'get_supportedengines', lambda: ['fixture'])
+
+    rest_response = TestClient(api.app).get('/query?domain=example.com&source=fixture')
+
+    assert rest_response.status_code == 200
+    assert rest_response.json()['evidence_run']['run_id'] == result.run_id
+    assert {item['value'] for item in rest_response.json()['evidence_run']['merged_results']} == {
+        'api.example.com',
+        'late.example.com',
+    }
+    assert {(item['kind'], item['value']) for item in rest_response.json()['evidence_run']['selected_observations']} >= {
+        ('takeover', 'api.example.com'),
+        ('api-endpoint', 'https://example.com/v1/status'),
+    }
 
 
 @pytest.mark.asyncio
@@ -491,12 +668,65 @@ async def test_cli_preserves_the_actual_provider_failure(monkeypatch: pytest.Mon
     assert execution.error_type == 'RuntimeError'
 
 
+@pytest.mark.asyncio
+async def test_cli_preserves_shodan_provider_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    import socket
+
+    import theHarvester.__main__ as main_module
+
+    class FailedShodanSearch:
+        async def search_ip(self, _ip: str):
+            raise RuntimeError('provider failed')
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args) -> None:
+            return None
+
+    class FakeRunStore:
+        async def save(self, _result) -> None:
+            return None
+
+    monkeypatch.setattr(socket, 'gethostbyname', lambda _domain: '192.0.2.10')
+    monkeypatch.setattr(main_module.shodansearch, 'SearchShodan', FailedShodanSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore)
+
+    response = await main_module.start(
+        SimpleNamespace(
+            api_scan=False,
+            dns_brute=False,
+            dns_lookup=False,
+            dns_resolve='',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=500,
+            proxies=False,
+            quiet=False,
+            screenshot='',
+            shodan=False,
+            source='shodan',
+            start=0,
+            take_over=False,
+            wordlist='',
+        ),
+        return_evidence_run=True,
+    )
+
+    execution = response[-1].source_executions[0]
+    assert execution.status is SourceStatus.FAILED
+    assert execution.error_type == 'RuntimeError'
+
+
 def test_rest_query_keeps_legacy_fields_and_adds_the_completed_run(monkeypatch: pytest.MonkeyPatch) -> None:
     import asyncio
 
     from theHarvester.lib.api import api
 
-    result = asyncio.run(execute_run('example.com', (CompletedRunSource(),)))
+    result = asyncio.run(execute_run('example.com', (TerminalRunSource(),)))
 
     async def fake_start(_args, *, return_evidence_run: bool = False):
         assert return_evidence_run is True
@@ -522,6 +752,46 @@ def test_rest_query_keeps_legacy_fields_and_adds_the_completed_run(monkeypatch: 
     assert response.json()['emails'] == ['ops@example.com']
     assert response.json()['hosts'] == ['api.example.com', 'old.example.com']
     assert response.json()['evidence_run']['run_id'] == result.run_id
+    assert {item['value'] for item in response.json()['evidence_run']['merged_results']} == {
+        'api.example.com',
+        'old.example.com',
+        'related.example.net',
+        'cdn.vendor.test',
+    }
+
+
+def test_rest_dnsbrute_keeps_legacy_results_and_failed_stage_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    import asyncio
+
+    from theHarvester.lib.api import api
+
+    result = asyncio.run(execute_run('example.com', ()))
+    result = complete_run(
+        result,
+        (
+            StageResult(
+                'action:dns-brute',
+                SourceStatus.FAILED,
+                1,
+                0,
+                error_type='RuntimeError',
+                is_action=True,
+            ),
+        ),
+    )
+
+    async def fake_start(_args, *, return_evidence_run: bool = False):
+        assert return_evidence_run is True
+        return [], result
+
+    monkeypatch.setattr(api.__main__, 'start', fake_start)
+
+    response = TestClient(api.app).get('/dnsbrute?domain=example.com')
+
+    assert response.status_code == 200
+    assert response.json()['dns_bruteforce'] == []
+    assert response.json()['evidence_run']['status'] == 'failed'
+    assert response.json()['evidence_run']['stage_executions'][0]['status'] == 'failed'
 
 
 @pytest.mark.parametrize(

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -551,6 +551,97 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
 
 
 @pytest.mark.asyncio
+async def test_cli_dns_validates_legacy_source_before_reporting(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    import theHarvester.__main__ as main_module
+
+    candidate = 'www.example.com'
+    report = tmp_path / 'legacy-source'
+
+    class FakeCertSpotter:
+        def __init__(self, target: str) -> None:
+            assert target == 'example.com'
+
+        async def process(self, _proxy: bool = False) -> None:
+            return None
+
+        async def get_hostnames(self) -> list[str]:
+            return [candidate]
+
+    class FakeVantage:
+        def __init__(self, nameserver: str) -> None:
+            self.name = nameserver
+
+        async def query(self, hostname: str) -> DnsResponse:
+            return DnsResponse(ipv4=('192.0.2.10',)) if hostname == candidate else DnsResponse(rcode='NXDOMAIN')
+
+        async def close(self) -> None:
+            return None
+
+    class FakeHostChecker:
+        def __init__(self, *_args: object) -> None:
+            raise AssertionError('consensus validation must replace the legacy resolver path')
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args: object) -> None:
+            return None
+
+        async def store(self, *_args: object) -> None:
+            return None
+
+    class FakeRunStore:
+        saved: ClassVar[list] = []
+
+        async def save(self, result) -> None:
+            self.saved.append(result)
+
+    terminal_messages: list[str] = []
+    monkeypatch.setattr(main_module.certspottersearch, 'SearchCertspoter', FakeCertSpotter)
+    monkeypatch.setattr(main_module, 'AioDnsResolverVantage', FakeVantage, raising=False)
+    monkeypatch.setattr(main_module.hostchecker, 'Checker', FakeHostChecker)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore, raising=False)
+    monkeypatch.setattr(main_module.output_logger, 'info', lambda message, *_args: terminal_messages.append(str(message)))
+
+    monkeypatch.setattr(
+        main_module.sys,
+        'argv',
+        [
+            'theHarvester',
+            '-d',
+            'example.com',
+            '-b',
+            'certspotter',
+            '-r',
+            '192.0.2.53,192.0.2.54,192.0.2.55',
+            '-f',
+            str(report),
+            '-q',
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await main_module.start()
+
+    assert exit_info.value.code == 0
+    result = FakeRunStore.saved[0]
+    legacy_json = json.loads(report.with_suffix('.json').read_text())
+    evidence_xml = ElementTree.parse(report.with_suffix('.xml')).getroot().find('evidence_run')
+
+    assert len(result.dns_validations) == 12
+    assert result.entities[0].addressability == 'currently-addressable'
+    assert legacy_json['hosts'] == [f'{candidate}:192.0.2.10']
+    assert [item.attrib['value'] for item in evidence_xml.findall('merged_result')] == [candidate]
+    assert '\n'.join(terminal_messages).count(f'{candidate} [status=currently-addressable') == 1
+    assert FakeRunStore.saved == [result]
+
+
+@pytest.mark.asyncio
 async def test_cli_records_provider_people_in_the_completed_run(monkeypatch: pytest.MonkeyPatch) -> None:
     import theHarvester.__main__ as main_module
 

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -1,0 +1,573 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import ClassVar
+from xml.etree import ElementTree
+
+import pytest
+from fastapi.testclient import TestClient
+
+from theHarvester.lib.dns_validation import DnsResponse, DnsValidator
+from theHarvester.lib.output import (
+    evidence_xml_fragment,
+    format_run_terminal,
+    legacy_json_result,
+    run_result_jsonl,
+)
+from theHarvester.lib.run import (
+    Derivation,
+    RunStatus,
+    SourceFinding,
+    SourceRateLimitedError,
+    SourceStatus,
+    SQLiteRunStore,
+    StageFinding,
+    StageFindingKind,
+    StageResult,
+    complete_run,
+    execute_run,
+)
+
+
+class CompletedRunSource:
+    name = 'fixture'
+    family = 'fixture-family'
+
+    async def collect(self, _target: str) -> list[SourceFinding]:
+        return [
+            SourceFinding(
+                'api.example.com',
+                observed_at=datetime(2026, 7, 15, 12, tzinfo=UTC),
+            ),
+            SourceFinding('old.example.com'),
+        ]
+
+
+class IncompleteRunSource:
+    name = 'fixture'
+    family = 'fixture-family'
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    async def collect(self, _target: str) -> list[SourceFinding]:
+        raise self.error
+
+
+@pytest.mark.asyncio
+async def test_completed_run_serializes_status_and_meaningful_timestamps() -> None:
+    result = await execute_run('example.com', (CompletedRunSource(),))
+
+    serialized = result.to_dict()
+
+    assert result.status is RunStatus.COMPLETE
+    assert serialized['started_at']
+    assert serialized['completed_at']
+    assert serialized['observations'][0]['collected_at']
+    assert serialized['observations'][0]['provider_observed_at'] == '2026-07-15T12:00:00+00:00'
+    assert 'provider_observed_at' not in serialized['observations'][1]
+
+
+@pytest.mark.asyncio
+async def test_complete_run_merges_late_and_direct_stage_results() -> None:
+    result = await execute_run('example.com', (CompletedRunSource(),))
+
+    completed = complete_run(
+        result,
+        (
+            StageResult(
+                'action:dns-brute',
+                SourceStatus.SUCCEEDED,
+                1,
+                1,
+                (StageFinding(StageFindingKind.HOSTNAME, 'late.example.com:192.0.2.11'),),
+            ),
+            StageResult(
+                'action:take-over',
+                SourceStatus.SUCCEEDED,
+                1,
+                1,
+                (StageFinding(StageFindingKind.TAKEOVER, 'api.example.com', 'not vulnerable'),),
+            ),
+        ),
+    )
+
+    assert {entity.value for entity in completed.entities} == {
+        'api.example.com',
+        'old.example.com',
+        'late.example.com',
+    }
+    assert {(item.kind, item.value, item.detail) for item in completed.selected_observations} == {
+        (StageFindingKind.TAKEOVER, 'api.example.com', 'not vulnerable')
+    }
+    assert {execution.source for execution in completed.source_executions} == {
+        'fixture',
+        'action:dns-brute',
+        'action:take-over',
+    }
+
+
+class TerminalRunSource:
+    name = 'fixture'
+    family = 'fixture-family'
+
+    async def collect(self, _target: str) -> list[SourceFinding]:
+        return [
+            SourceFinding('api.example.com'),
+            SourceFinding('old.example.com'),
+            SourceFinding('related.example.net', Derivation.SCOPE_EXTENSION),
+            SourceFinding('cdn.vendor.test', Derivation.EXTERNAL_RELATIONSHIP),
+        ]
+
+
+class TerminalResolver:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    async def query(self, hostname: str) -> DnsResponse:
+        if hostname == 'api.example.com':
+            return DnsResponse(ipv4=('192.0.2.10',))
+        return DnsResponse(rcode='NXDOMAIN')
+
+
+@pytest.mark.asyncio
+async def test_terminal_reports_each_hostname_once_with_status_and_sources() -> None:
+    validator = DnsValidator(tuple(TerminalResolver(f'resolver-{index}') for index in range(3)))
+    result = await execute_run('example.com', (TerminalRunSource(),), dns_validator=validator)
+    result = complete_run(
+        result,
+        (
+            StageResult(
+                'action:take-over',
+                SourceStatus.SUCCEEDED,
+                1,
+                1,
+                (StageFinding(StageFindingKind.TAKEOVER, 'api.example.com', 'not vulnerable'),),
+            ),
+        ),
+    )
+
+    terminal = format_run_terminal(result)
+
+    for hostname in ('api.example.com', 'old.example.com', 'related.example.net', 'cdn.vendor.test'):
+        assert terminal.count(hostname) == 1
+    assert 'Currently addressable subdomains (1)' in terminal
+    assert 'Secondary evidence / needs review (2)' in terminal
+    assert 'Scope-extension candidates (1)' in terminal
+    assert 'status=currently-addressable; sources=fixture; takeover=not vulnerable' in terminal
+    assert 'Run status: complete' in terminal
+
+
+@pytest.mark.asyncio
+async def test_jsonl_preserves_typed_records_provenance_and_timestamps() -> None:
+    validator = DnsValidator(tuple(TerminalResolver(f'resolver-{index}') for index in range(3)))
+    result = await execute_run('example.com', (CompletedRunSource(),), dns_validator=validator)
+
+    records = [json.loads(line) for line in run_result_jsonl(result).splitlines()]
+
+    assert {record['record_type'] for record in records} == {
+        'run',
+        'source_execution',
+        'discovery_observation',
+        'dns_validation_observation',
+        'merged_result',
+    }
+    assert all(record['schema_version'] == 'theharvester-evidence-v1' for record in records)
+    assert all(record['run_id'] == result.run_id for record in records)
+    discovery = [record['data'] for record in records if record['record_type'] == 'discovery_observation']
+    assert all(record['collected_at'] for record in discovery)
+    assert discovery[0]['provider_observed_at'] == '2026-07-15T12:00:00+00:00'
+    assert 'provider_observed_at' not in discovery[1]
+    validations = [record['data'] for record in records if record['record_type'] == 'dns_validation_observation']
+    assert all(record['validated_at'] for record in validations)
+    assert all('queried_at' not in record for record in validations)
+    merged = [record['data'] for record in records if record['record_type'] == 'merged_result']
+    assert all(record['provenance'] for record in merged)
+
+
+@pytest.mark.asyncio
+async def test_legacy_json_and_xml_keep_existing_fields_and_add_evidence() -> None:
+    validator = DnsValidator(tuple(TerminalResolver(f'resolver-{index}') for index in range(3)))
+    result = await execute_run('example.com', (CompletedRunSource(),), dns_validator=validator)
+
+    legacy = legacy_json_result(
+        result,
+        {
+            'cmd': 'theHarvester -d example.com',
+            'emails': ['ops@example.com'],
+            'hosts': ['legacy.example.com'],
+        },
+    )
+    evidence_xml = ElementTree.fromstring(evidence_xml_fragment(result))
+
+    assert legacy['cmd'] == 'theHarvester -d example.com'
+    assert legacy['emails'] == ['ops@example.com']
+    assert legacy['hosts'] == ['legacy.example.com', 'api.example.com']
+    assert legacy['evidence_run']['status'] == 'complete'
+    assert evidence_xml.tag == 'evidence_run'
+    assert evidence_xml.attrib['status'] == 'complete'
+    assert evidence_xml.find("source[@name='fixture']").attrib['status'] == 'succeeded'
+
+
+@pytest.mark.asyncio
+async def test_structured_run_persistence_round_trips_in_its_own_table(tmp_path) -> None:
+    result = await execute_run('example.com', (CompletedRunSource(),))
+    store = SQLiteRunStore(tmp_path / 'stash.sqlite')
+
+    await store.save(result)
+
+    assert await store.load(result.run_id) == result.to_dict()
+
+
+@pytest.mark.asyncio
+async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import theHarvester.__main__ as main_module
+
+    events: list[str] = []
+    wordlist = tmp_path / 'api-endpoints.txt'
+    wordlist.write_text('/v1/status\n')
+    report = tmp_path / 'completed-run'
+
+    class FakeCrtshSearch:
+        def __init__(self, _target: str) -> None:
+            return None
+
+        async def process(self, _proxy: bool = False) -> None:
+            events.append('collect')
+
+        async def get_hostnames(self) -> list[str]:
+            return ['api.example.com']
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args) -> None:
+            return None
+
+        async def store(self, *_args) -> None:
+            return None
+
+    class FakeDnsForce:
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def run(self):
+            events.append('dns-brute')
+            return ['late.example.com:192.0.2.11'], ['late.example.com'], ['192.0.2.11']
+
+    class FakeHostChecker:
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def check(self):
+            return ['api.example.com:192.0.2.10'], ['api.example.com'], ['192.0.2.10']
+
+    async def fake_reverse_all_ips_in_range(**_kwargs) -> None:
+        events.append('dns-lookup')
+
+    class FakeTakeOver:
+        def __init__(self, _hosts: list[str]) -> None:
+            return None
+
+        async def populate_fingerprints(self) -> None:
+            return None
+
+        async def process(self, *, proxy: bool) -> None:
+            assert proxy is False
+            events.append('takeover')
+
+        async def get_takeover_results(self) -> dict[str, str]:
+            return {'api.example.com': 'not vulnerable'}
+
+    class FakeApiScanner:
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def do_search(self) -> None:
+            events.append('api-scan')
+
+        def get_found_endpoints(self):
+            return {'https://example.com/v1/status': SimpleNamespace(status_code=200)}
+
+        def get_interesting_endpoints(self):
+            return {}
+
+        def get_auth_required(self):
+            return {}
+
+        def get_api_versions(self):
+            return set()
+
+        def get_rate_limits(self):
+            return {}
+
+        def get_methods(self):
+            return {'GET'}
+
+        def get_status_codes(self):
+            return {200}
+
+    class FakeRunStore:
+        saved: ClassVar[list] = []
+
+        async def save(self, result) -> None:
+            events.append('persist')
+            self.saved.append(result)
+
+    def capture_terminal(result) -> str:
+        events.append('terminal')
+        return format_run_terminal(result)
+
+    monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module.hostchecker, 'Checker', FakeHostChecker)
+    monkeypatch.setattr(main_module.dnssearch, 'DnsForce', FakeDnsForce)
+    monkeypatch.setattr(main_module.dnssearch, 'serialize_ip_range', lambda **_kwargs: '192.0.2.0/24')
+    monkeypatch.setattr(main_module.dnssearch, 'reverse_all_ips_in_range', fake_reverse_all_ips_in_range)
+    monkeypatch.setattr(main_module.takeover, 'TakeOver', FakeTakeOver)
+    monkeypatch.setattr(main_module.api_endpoints, 'SearchApiEndpoints', FakeApiScanner)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore, raising=False)
+    monkeypatch.setattr(main_module, 'format_run_terminal', capture_terminal, raising=False)
+
+    response = await main_module.start(
+        SimpleNamespace(
+            api_scan=True,
+            dns_brute=True,
+            dns_lookup=True,
+            dns_resolve=None,
+            dns_server=None,
+            domain='example.com',
+            filename=str(report),
+            limit=500,
+            proxies=False,
+            quiet=False,
+            screenshot='',
+            shodan=False,
+            source='crtsh',
+            start=0,
+            take_over=True,
+            wordlist=str(wordlist),
+        ),
+        return_evidence_run=True,
+    )
+
+    result = response[-1]
+    assert events == ['collect', 'dns-brute', 'dns-lookup', 'takeover', 'api-scan', 'persist', 'terminal']
+    assert result is FakeRunStore.saved[0]
+    assert {entity.value for entity in result.entities} == {'api.example.com', 'late.example.com'}
+    assert {(item.kind, item.value) for item in result.selected_observations} == {
+        (StageFindingKind.TAKEOVER, 'api.example.com'),
+        (StageFindingKind.API_ENDPOINT, 'https://example.com/v1/status'),
+    }
+    legacy_json = json.loads(report.with_suffix('.json').read_text())
+    evidence_xml = ElementTree.parse(report.with_suffix('.xml')).getroot().find('evidence_run')
+    jsonl = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
+    assert legacy_json['evidence_run']['run_id'] == result.run_id
+    assert evidence_xml.attrib['run_id'] == result.run_id
+    assert {record['record_type'] for record in jsonl} >= {'run', 'selected_observation'}
+
+
+@pytest.mark.asyncio
+async def test_cli_records_provider_people_in_the_completed_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    import theHarvester.__main__ as main_module
+
+    class FakeVenacusSearch:
+        def __init__(self, **_kwargs) -> None:
+            return None
+
+        async def process(self, _proxy: bool = False) -> None:
+            return None
+
+        async def get_emails(self) -> list[str]:
+            return []
+
+        async def get_ips(self) -> list[str]:
+            return []
+
+        async def get_people(self) -> list[dict[str, str]]:
+            return [{'name': 'Alice'}]
+
+        async def get_interestingurls(self) -> list[str]:
+            return []
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args) -> None:
+            return None
+
+    class FakeRunStore:
+        async def save(self, _result) -> None:
+            return None
+
+    monkeypatch.setattr(main_module.venacussearch, 'SearchVenacus', FakeVenacusSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore)
+
+    response = await main_module.start(
+        SimpleNamespace(
+            api_scan=False,
+            dns_brute=False,
+            dns_lookup=False,
+            dns_resolve='',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=500,
+            proxies=False,
+            quiet=False,
+            screenshot='',
+            shodan=False,
+            source='venacus',
+            start=0,
+            take_over=False,
+            wordlist='',
+        ),
+        return_evidence_run=True,
+    )
+
+    assert {(item.kind, item.value) for item in response[-1].selected_observations} == {
+        (StageFindingKind.PERSON, '{"name":"Alice"}')
+    }
+
+
+@pytest.mark.asyncio
+async def test_cli_preserves_the_actual_provider_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    import theHarvester.__main__ as main_module
+
+    class FailedCrtshSearch:
+        def __init__(self, _target: str) -> None:
+            return None
+
+        async def process(self, _proxy: bool = False) -> None:
+            raise RuntimeError('provider failed')
+
+        async def get_hostnames(self) -> list[str]:
+            raise AssertionError('failed source must not expose results')
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+    class FakeRunStore:
+        async def save(self, _result) -> None:
+            return None
+
+    monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FailedCrtshSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore)
+
+    response = await main_module.start(
+        SimpleNamespace(
+            api_scan=False,
+            dns_brute=False,
+            dns_lookup=False,
+            dns_resolve='',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=500,
+            proxies=False,
+            quiet=False,
+            screenshot='',
+            shodan=False,
+            source='crtsh',
+            start=0,
+            take_over=False,
+            wordlist='',
+        ),
+        return_evidence_run=True,
+    )
+
+    execution = response[-1].source_executions[0]
+    assert execution.status is SourceStatus.FAILED
+    assert execution.error_type == 'RuntimeError'
+
+
+def test_rest_query_keeps_legacy_fields_and_adds_the_completed_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    import asyncio
+
+    from theHarvester.lib.api import api
+
+    result = asyncio.run(execute_run('example.com', (CompletedRunSource(),)))
+
+    async def fake_start(_args, *, return_evidence_run: bool = False):
+        assert return_evidence_run is True
+        return (
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            ['ops@example.com'],
+            ['api.example.com'],
+            result,
+        )
+
+    monkeypatch.setattr(api.__main__.Core, 'get_supportedengines', lambda: ['fixture'])
+    monkeypatch.setattr(api.__main__, 'start', fake_start)
+
+    response = TestClient(api.app).get('/query?domain=example.com&source=fixture')
+
+    assert response.status_code == 200
+    assert response.json()['emails'] == ['ops@example.com']
+    assert response.json()['hosts'] == ['api.example.com', 'old.example.com']
+    assert response.json()['evidence_run']['run_id'] == result.run_id
+
+
+@pytest.mark.parametrize(
+    ('error', 'expected_run_status', 'expected_source_status'),
+    [
+        (RuntimeError('provider failed'), 'failed', 'failed'),
+        (SourceRateLimitedError(), 'partial', 'rate-limited'),
+    ],
+)
+@pytest.mark.asyncio
+async def test_incomplete_source_states_remain_visible_on_every_output(
+    error: Exception,
+    expected_run_status: str,
+    expected_source_status: str,
+) -> None:
+    result = await execute_run('example.com', (IncompleteRunSource(error),))
+
+    terminal = format_run_terminal(result)
+    records = [json.loads(line) for line in run_result_jsonl(result).splitlines()]
+    legacy = legacy_json_result(result)
+    evidence_xml = ElementTree.fromstring(evidence_xml_fragment(result))
+
+    assert f'Run status: {expected_run_status}' in terminal
+    assert f'fixture [status={expected_source_status}' in terminal
+    assert records[0]['data']['status'] == expected_run_status
+    assert legacy['evidence_run']['status'] == expected_run_status
+    assert evidence_xml.attrib['status'] == expected_run_status
+
+
+@pytest.mark.asyncio
+async def test_late_source_failure_cannot_remain_a_complete_run() -> None:
+    result = await execute_run('example.com', (CompletedRunSource(),))
+
+    completed = complete_run(
+        result,
+        (
+            StageResult(
+                'fixture',
+                SourceStatus.FAILED,
+                1,
+                0,
+                error_type='RuntimeError',
+            ),
+        ),
+    )
+
+    assert completed.status is RunStatus.FAILED
+    assert completed.source_executions[0].status is SourceStatus.FAILED
+    assert completed.source_executions[0].error_type == 'RuntimeError'

--- a/tests/lib/test_dns_validation.py
+++ b/tests/lib/test_dns_validation.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from types import SimpleNamespace
+
+import pytest
+
+from theHarvester.lib.dns_validation import (
+    Addressability,
+    AioDnsResolverVantage,
+    DnsResponse,
+    DnsValidator,
+)
+
+
+class RuleVantage:
+    def __init__(self, name: str, handler: Callable[[str], DnsResponse]) -> None:
+        self.name = name
+        self.handler = handler
+
+    async def query(self, hostname: str) -> DnsResponse:
+        return self.handler(hostname)
+
+
+def _vantages(handler: Callable[[str], DnsResponse]) -> tuple[RuleVantage, ...]:
+    return tuple(RuleVantage(f'resolver-{suffix}', handler) for suffix in ('a', 'b', 'c'))
+
+
+@pytest.mark.asyncio
+async def test_validator_records_two_of_three_consensus_without_identical_addresses() -> None:
+    candidate = 'api.example.com'
+    responses = {
+        'resolver-a': DnsResponse(
+            ipv4=('192.0.2.10',),
+            cnames=('Edge.Example.NET.',),
+            rcode='noerror',
+            ttl=300,
+            cname_chain=('Edge.Example.NET.',),
+        ),
+        'resolver-b': DnsResponse(ipv6=('2001:0db8::10',), ttl=120),
+        'resolver-c': DnsResponse(rcode='NXDOMAIN'),
+    }
+    vantages = tuple(
+        RuleVantage(name, lambda hostname, name=name: responses[name] if hostname == candidate else DnsResponse(rcode='NXDOMAIN'))
+        for name in responses
+    )
+
+    result = await DnsValidator(vantages).validate('run-id', 'example.com', (candidate,))
+
+    assert result.classifications[0].addressability is Addressability.CURRENT
+    candidate_observations = [observation for observation in result.observations if not observation.is_wildcard_control]
+    assert len(candidate_observations) == 3
+    assert candidate_observations[0].candidate == candidate
+    assert candidate_observations[0].query_name == candidate
+    assert candidate_observations[0].resolver == 'resolver-a'
+    assert candidate_observations[0].ipv4 == ('192.0.2.10',)
+    assert candidate_observations[0].cnames == ('edge.example.net',)
+    assert candidate_observations[0].cname_chain == ('edge.example.net',)
+    assert candidate_observations[0].rcode == 'NOERROR'
+    assert candidate_observations[0].ttl == 300
+    assert candidate_observations[0].queried_at.tzinfo is not None
+    assert candidate_observations[0].latency_ms >= 0
+    assert candidate_observations[1].ipv6 == ('2001:db8::10',)
+
+
+@pytest.mark.asyncio
+async def test_validator_keeps_resolver_disagreement_secondary() -> None:
+    candidate = 'api.example.com'
+    responses = iter(
+        (
+            DnsResponse(ipv4=('192.0.2.10',)),
+            DnsResponse(rcode='NXDOMAIN'),
+            DnsResponse(rcode='ERROR', error='timeout'),
+        )
+    )
+    vantages = tuple(
+        RuleVantage(f'resolver-{suffix}', lambda hostname: next(responses) if hostname == candidate else DnsResponse(rcode='NXDOMAIN'))
+        for suffix in ('a', 'b', 'c')
+    )
+
+    result = await DnsValidator(vantages).validate('run-id', 'example.com', (candidate,))
+
+    assert result.classifications[0].addressability is Addressability.RESOLVER_DISPUTED
+
+
+@pytest.mark.asyncio
+async def test_validator_records_resolver_error_observation() -> None:
+    candidate = 'api.example.com'
+
+    class ErrorVantage:
+        name = 'resolver-error'
+
+        async def query(self, _hostname: str) -> DnsResponse:
+            raise RuntimeError('resolver unavailable')
+
+    validator = DnsValidator(
+        (
+            ErrorVantage(),
+            RuleVantage('resolver-a', lambda _hostname: DnsResponse(rcode='NXDOMAIN')),
+            RuleVantage('resolver-b', lambda _hostname: DnsResponse(rcode='NXDOMAIN')),
+        )
+    )
+
+    result = await validator.validate('run-id', 'example.com', (candidate,))
+
+    error_observation = next(
+        observation
+        for observation in result.observations
+        if observation.candidate == candidate and observation.resolver == 'resolver-error'
+    )
+    assert error_observation.rcode == 'ERROR'
+    assert error_observation.error == 'RuntimeError: resolver unavailable'
+    assert result.classifications[0].addressability is Addressability.NOT_CURRENT
+
+
+@pytest.mark.asyncio
+async def test_validator_times_out_a_stalled_resolver() -> None:
+    candidate = 'api.example.com'
+
+    class StalledVantage:
+        name = 'resolver-stalled'
+
+        async def query(self, _hostname: str) -> DnsResponse:
+            await asyncio.Event().wait()
+            raise AssertionError('unreachable')
+
+    validator = DnsValidator(
+        (
+            StalledVantage(),
+            RuleVantage('resolver-a', lambda _hostname: DnsResponse(rcode='NXDOMAIN')),
+            RuleVantage('resolver-b', lambda _hostname: DnsResponse(rcode='NXDOMAIN')),
+        ),
+        timeout_seconds=0.01,
+    )
+
+    result = await validator.validate('run-id', 'example.com', (candidate,))
+
+    error_observation = next(
+        observation
+        for observation in result.observations
+        if observation.candidate == candidate and observation.resolver == 'resolver-stalled'
+    )
+    assert error_observation.error is not None
+    assert error_observation.error.startswith('TimeoutError')
+    assert result.classifications[0].addressability is Addressability.NOT_CURRENT
+
+
+@pytest.mark.asyncio
+async def test_validator_retains_empty_nonterminal_as_secondary_evidence() -> None:
+    result = await DnsValidator(_vantages(lambda _hostname: DnsResponse())).validate(
+        'run-id',
+        'example.com',
+        ('branch.example.com',),
+    )
+
+    assert result.classifications[0].addressability is Addressability.NOT_CURRENT
+
+
+@pytest.mark.asyncio
+async def test_validator_never_queries_out_of_scope_candidates() -> None:
+    queried: list[str] = []
+
+    def handler(hostname: str) -> DnsResponse:
+        queried.append(hostname)
+        return DnsResponse(rcode='NXDOMAIN')
+
+    result = await DnsValidator(_vantages(handler)).validate(
+        'run-id',
+        'example.com',
+        ('api.example.com', 'outside.test'),
+    )
+
+    assert [classification.candidate for classification in result.classifications] == ['api.example.com']
+    assert 'outside.test' not in queried
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('candidate_address', 'deterministic_exact_names', 'expected'),
+    [
+        ('192.0.2.20', (), Addressability.CURRENT),
+        ('192.0.2.10', (), Addressability.WILDCARD_INDISTINGUISHABLE),
+        ('192.0.2.10', ('api.example.com',), Addressability.CURRENT),
+    ],
+)
+async def test_validator_compares_stable_wildcard_distribution(
+    candidate_address: str,
+    deterministic_exact_names: tuple[str, ...],
+    expected: Addressability,
+) -> None:
+    candidate = 'api.example.com'
+
+    def handler(hostname: str) -> DnsResponse:
+        return DnsResponse(ipv4=(candidate_address if hostname == candidate else '192.0.2.10',))
+
+    result = await DnsValidator(_vantages(handler)).validate(
+        'run-id',
+        'example.com',
+        (candidate,),
+        deterministic_exact_names=deterministic_exact_names,
+    )
+
+    assert result.classifications[0].addressability is expected
+
+
+@pytest.mark.asyncio
+async def test_validator_detects_nested_wildcard_distribution() -> None:
+    candidate = 'api.stage.example.com'
+
+    def handler(hostname: str) -> DnsResponse:
+        if hostname == candidate or hostname.endswith('.stage.example.com'):
+            return DnsResponse(ipv4=('192.0.2.20',))
+        return DnsResponse(rcode='NXDOMAIN')
+
+    result = await DnsValidator(_vantages(handler)).validate('run-id', 'example.com', (candidate,))
+
+    assert result.classifications[0].addressability is Addressability.WILDCARD_INDISTINGUISHABLE
+
+
+@pytest.mark.asyncio
+async def test_validator_detects_wildcard_cname_distribution() -> None:
+    response = DnsResponse(
+        cnames=('wildcard.example.net',),
+        cname_chain=('wildcard.example.net',),
+    )
+
+    result = await DnsValidator(_vantages(lambda _hostname: response)).validate(
+        'run-id',
+        'example.com',
+        ('alias.example.com',),
+    )
+
+    assert result.classifications[0].addressability is Addressability.WILDCARD_INDISTINGUISHABLE
+
+
+@pytest.mark.asyncio
+async def test_validator_detects_rotating_a_aaaa_and_cname_wildcards() -> None:
+    candidate = 'www.example.com'
+    control_responses = (
+        DnsResponse(ipv4=('192.0.2.1',)),
+        DnsResponse(ipv6=('2001:db8::1',)),
+        DnsResponse(cnames=('wildcard.example.net',)),
+    )
+
+    class RotatingVantage:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.index = 0
+
+        async def query(self, hostname: str) -> DnsResponse:
+            if hostname == candidate:
+                return DnsResponse(ipv4=('192.0.2.90',))
+            response = control_responses[self.index % len(control_responses)]
+            self.index += 1
+            return response
+
+    result = await DnsValidator(tuple(RotatingVantage(f'resolver-{index}') for index in range(3))).validate(
+        'run-id',
+        'example.com',
+        (candidate,),
+    )
+
+    assert result.classifications[0].addressability is Addressability.WILDCARD_INDISTINGUISHABLE
+    controls = [observation for observation in result.observations if observation.is_wildcard_control]
+    assert {address for observation in controls for address in observation.ipv4} == {'192.0.2.1'}
+    assert {address for observation in controls for address in observation.ipv6} == {'2001:db8::1'}
+    assert {cname for observation in controls for cname in observation.cnames} == {'wildcard.example.net'}
+
+
+@pytest.mark.asyncio
+async def test_validator_uses_deepest_control_and_never_promotes_probes() -> None:
+    candidate = 'api.stage.dev.example.com'
+
+    def handler(hostname: str) -> DnsResponse:
+        if hostname == candidate:
+            return DnsResponse(ipv4=('192.0.2.20',))
+        if hostname.endswith('.stage.dev.example.com'):
+            return DnsResponse(rcode='NXDOMAIN')
+        return DnsResponse(ipv4=('192.0.2.20',))
+
+    result = await DnsValidator(_vantages(handler)).validate('run-id', 'example.com', (candidate,))
+
+    assert result.classifications[0].addressability is Addressability.CURRENT
+    controls = [observation for observation in result.observations if observation.is_wildcard_control]
+    assert {observation.wildcard_depth for observation in controls} == {
+        'example.com',
+        'dev.example.com',
+        'stage.dev.example.com',
+    }
+    assert all(observation.candidate is None for observation in controls)
+    assert candidate not in {observation.query_name for observation in controls}
+
+
+def test_validator_requires_three_distinct_vantages() -> None:
+    handler = lambda _hostname: DnsResponse(rcode='NXDOMAIN')
+
+    with pytest.raises(ValueError, match='exactly three distinct'):
+        DnsValidator((RuleVantage('same', handler), RuleVantage('same', handler), RuleVantage('other', handler)))
+
+
+@pytest.mark.asyncio
+async def test_validator_propagates_cancellation() -> None:
+    class CancelledVantage:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        async def query(self, _hostname: str) -> DnsResponse:
+            raise asyncio.CancelledError
+
+    validator = DnsValidator(tuple(CancelledVantage(f'resolver-{index}') for index in range(3)))
+
+    with pytest.raises(asyncio.CancelledError):
+        await validator.validate('run-id', 'example.com', ('api.example.com',))
+
+
+@pytest.mark.asyncio
+async def test_aiodns_vantage_follows_cname_chain_and_retains_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    import theHarvester.lib.dns_validation as validation_module
+
+    closed: list[bool] = []
+    queried: list[tuple[str, str]] = []
+
+    class FakeResolver:
+        def __init__(self, *, nameservers: list[str]) -> None:
+            assert nameservers == ['192.0.2.53']
+
+        async def query_dns(self, hostname: str, record_type: str):
+            queried.append((hostname, record_type))
+            if record_type == 'A' and hostname == 'alias.example.com':
+                return SimpleNamespace(
+                    answer=[
+                        SimpleNamespace(ttl=90, data=SimpleNamespace(cname='Edge.Example.NET.')),
+                        SimpleNamespace(ttl=60, data=SimpleNamespace(cname='Origin.Example.NET.')),
+                        SimpleNamespace(ttl=30, data=SimpleNamespace(addr='192.0.2.10')),
+                    ]
+                )
+            raise validation_module.aiodns.error.DNSError(validation_module.aiodns.error.ARES_ENODATA, 'no data')
+
+        async def close(self) -> None:
+            closed.append(True)
+
+    monkeypatch.setattr(validation_module.aiodns, 'DNSResolver', FakeResolver)
+    vantage = AioDnsResolverVantage('192.0.2.53')
+
+    response = await vantage.query('alias.example.com')
+    await vantage.close()
+
+    assert response.ipv4 == ('192.0.2.10',)
+    assert response.cnames == ('edge.example.net', 'origin.example.net')
+    assert response.cname_chain == ('edge.example.net', 'origin.example.net')
+    assert response.ttl == 30
+    assert response.rcode == 'NOERROR'
+    assert response.error is None
+    assert closed == [True]
+    assert queried == [
+        ('alias.example.com', 'A'),
+        ('alias.example.com', 'AAAA'),
+        ('alias.example.com', 'CNAME'),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_aiodns_vantage_records_nxdomain(monkeypatch: pytest.MonkeyPatch) -> None:
+    import theHarvester.lib.dns_validation as validation_module
+
+    class FakeResolver:
+        def __init__(self, *, nameservers: list[str]) -> None:
+            assert nameservers == ['192.0.2.53']
+
+        async def query_dns(self, _hostname: str, _record_type: str):
+            raise validation_module.aiodns.error.DNSError(validation_module.aiodns.error.ARES_ENOTFOUND, 'not found')
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(validation_module.aiodns, 'DNSResolver', FakeResolver)
+
+    response = await AioDnsResolverVantage('192.0.2.53').query('missing.example.com')
+
+    assert response.rcode == 'NXDOMAIN'
+    assert response.ipv4 == ()
+    assert response.ipv6 == ()
+    assert response.error is None

--- a/tests/lib/test_hostchecker.py
+++ b/tests/lib/test_hostchecker.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+
+import pytest
+
+from theHarvester.lib import hostchecker
+
+
+@pytest.mark.asyncio
+async def test_checker_normalizes_byte_addresses(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResolver:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        async def getaddrinfo(self, _host: str, _family: int) -> SimpleNamespace:
+            return SimpleNamespace(nodes=[SimpleNamespace(addr=(b'192.0.2.10', 0))])
+
+    monkeypatch.setattr(hostchecker.aiodns, 'DNSResolver', FakeResolver)
+
+    resolved, hosts, addresses = await hostchecker.Checker(
+        ['www.example.com'],
+        ['192.0.2.53'],
+    ).check()
+
+    assert resolved == ['www.example.com:192.0.2.10']
+    assert hosts == ['www.example.com']
+    assert addresses == ['192.0.2.10']

--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import replace
 from uuid import UUID
 
@@ -9,6 +10,7 @@ from theHarvester.lib.run import (
     Derivation,
     ScopeClass,
     SourceFinding,
+    SourceRateLimitedError,
     SourceStatus,
     execute_run,
     legacy_hostnames,
@@ -27,6 +29,19 @@ class FakePassiveSource:
             SourceFinding('example.com.evil.test', Derivation.SCOPE_EXTENSION),
             SourceFinding('cdn.vendor.test', Derivation.EXTERNAL_RELATIONSHIP),
         ]
+
+
+@pytest.mark.asyncio
+async def test_execute_run_propagates_cancellation() -> None:
+    class CancelledSource:
+        name = 'cancelled'
+        family = 'cancelled'
+
+        async def collect(self, _target: str) -> list[SourceFinding]:
+            raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await execute_run('example.com', (CancelledSource(),))
 
 
 @pytest.mark.asyncio
@@ -219,3 +234,69 @@ async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch
     assert {observation.source_family for observation in captured[0].observations} == {'catalog-family'}
     assert legacy_hostnames(captured[0]) == ['www.example.com']
     assert stored == [('example.com', ('www.example.com',), 'host', 'CRTsh')]
+
+
+@pytest.mark.asyncio
+async def test_dnsdb_bridge_preserves_partial_results_and_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    import argparse
+
+    import theHarvester.__main__ as main_module
+    import theHarvester.lib.run as run_module
+
+    class FakeDNSDBSearch:
+        def __init__(self, target: str) -> None:
+            assert target == 'example.com'
+
+        async def process(self, _proxy: bool = False) -> None:
+            raise SourceRateLimitedError(
+                'DNSDB result limit reached',
+                findings=(SourceFinding('partial.example.com'),),
+            )
+
+        async def get_hostnames(self) -> list[str]:
+            raise AssertionError('partial findings must come from the incomplete source result')
+
+    stored: list[tuple[str, tuple[str, ...], str, str]] = []
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, domain: str, items: list[str], result_type: str, source: str) -> None:
+            stored.append((domain, tuple(items), result_type, source))
+
+    captured: list[run_module.RunResult] = []
+
+    async def capture_run(target, sources):
+        result = await run_module.execute_run(target, sources)
+        captured.append(result)
+        return result
+
+    monkeypatch.setattr(main_module.dnsdb, 'SearchDNSDB', FakeDNSDBSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'execute_run', capture_run, raising=True)
+
+    await main_module.start(
+        argparse.Namespace(
+            api_scan=False,
+            dns_brute=False,
+            dns_lookup=False,
+            dns_resolve='',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=500,
+            proxies=False,
+            quiet=True,
+            shodan=False,
+            source='dnsdb',
+            start=0,
+            take_over=False,
+            wordlist='',
+        )
+    )
+
+    assert len(captured) == 1
+    assert captured[0].source_executions[0].status is SourceStatus.RATE_LIMITED
+    assert {observation.value for observation in captured[0].observations} == {'partial.example.com'}
+    assert stored == [('example.com', ('partial.example.com',), 'host', 'dnsdb')]

--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from uuid import UUID
 
 import pytest
@@ -184,6 +185,12 @@ async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch
     monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
     monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
     monkeypatch.setattr(main_module, 'execute_run', execute_with_temporary_store, raising=True)
+    crtsh_spec = main_module.get_source_spec('crtsh')
+    monkeypatch.setattr(
+        main_module,
+        'get_source_spec',
+        lambda _name: replace(crtsh_spec, family='catalog-family'),
+    )
 
     await main_module.start(
         argparse.Namespace(
@@ -209,5 +216,6 @@ async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch
     assert len(captured) == 1
     assert captured[0].source_executions[0].status is SourceStatus.SUCCEEDED
     assert captured[0].source_executions[0].source == 'crtsh'
+    assert {observation.source_family for observation in captured[0].observations} == {'catalog-family'}
     assert legacy_hostnames(captured[0]) == ['www.example.com']
     assert stored == [('example.com', ('www.example.com',), 'host', 'CRTsh')]

--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -335,17 +335,15 @@ async def test_crtsh_bridge_uses_three_resolvers_without_legacy_requery(
     captured: list[run_module.RunResult] = []
     output: list[object] = []
 
-    async def capture_run(target, sources, **kwargs):
-        result = await run_module.execute_run(target, sources, **kwargs)
-        captured.append(result)
-        return result
+    class CaptureRunStore:
+        async def save(self, result: run_module.RunResult) -> None:
+            captured.append(result)
 
     monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
     monkeypatch.setattr(main_module, 'AioDnsResolverVantage', FakeVantage, raising=False)
     monkeypatch.setattr(main_module.hostchecker, 'Checker', FailOnLegacyChecker)
     monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
-    monkeypatch.setattr(main_module, 'SQLiteRunStore', NoopRunStore)
-    monkeypatch.setattr(main_module, 'execute_run', capture_run, raising=True)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', CaptureRunStore)
     monkeypatch.setattr(main_module.output_logger, 'info', output.append)
 
     monkeypatch.setattr(

--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -33,6 +33,11 @@ class FakePassiveSource:
         ]
 
 
+class NoopRunStore:
+    async def save(self, _result) -> None:
+        return None
+
+
 @pytest.mark.asyncio
 async def test_execute_run_propagates_cancellation() -> None:
     class CancelledSource:
@@ -200,9 +205,7 @@ async def test_execute_run_classifies_once_and_bridges_current_dns_results() -> 
         [candidate],
         ['192.0.2.10', '192.0.2.11', '192.0.2.12'],
     )
-    control_names = {
-        observation.query_name for observation in result.dns_validations if observation.is_wildcard_control
-    }
+    control_names = {observation.query_name for observation in result.dns_validations if observation.is_wildcard_control}
     assert not control_names.intersection(observation.value for observation in result.observations)
     assert not control_names.intersection(entity.value for entity in result.entities)
 
@@ -244,6 +247,7 @@ async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch
 
     monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
     monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', NoopRunStore)
     monkeypatch.setattr(main_module, 'execute_run', execute_with_temporary_store, raising=True)
     crtsh_spec = main_module.get_source_spec('crtsh')
     monkeypatch.setattr(
@@ -340,6 +344,7 @@ async def test_crtsh_bridge_uses_three_resolvers_without_legacy_requery(
     monkeypatch.setattr(main_module, 'AioDnsResolverVantage', FakeVantage, raising=False)
     monkeypatch.setattr(main_module.hostchecker, 'Checker', FailOnLegacyChecker)
     monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', NoopRunStore)
     monkeypatch.setattr(main_module, 'execute_run', capture_run, raising=True)
     monkeypatch.setattr(main_module.output_logger, 'info', output.append)
 
@@ -364,8 +369,9 @@ async def test_crtsh_bridge_uses_three_resolvers_without_legacy_requery(
     assert set(created) == {'192.0.2.53', '192.0.2.54', '192.0.2.55'}
     assert set(closed) == set(created)
     assert captured[0].entities[0].addressability is Addressability.CURRENT
-    assert output.count(f'{candidate}:192.0.2.10') == 1
-    assert candidate not in output
+    terminal = '\n'.join(map(str, output))
+    assert terminal.count(candidate) == 1
+    assert 'status=currently-addressable; sources=crtsh' in terminal
 
 
 @pytest.mark.asyncio
@@ -406,6 +412,7 @@ async def test_dnsdb_bridge_preserves_partial_results_and_status(monkeypatch: py
 
     monkeypatch.setattr(main_module.dnsdb, 'SearchDNSDB', FakeDNSDBSearch)
     monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', NoopRunStore)
     monkeypatch.setattr(main_module, 'execute_run', capture_run, raising=True)
 
     await main_module.start(

--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 import pytest
 
+from theHarvester.lib.dns_validation import Addressability, DnsResponse, DnsValidator
 from theHarvester.lib.run import (
     Derivation,
     ScopeClass,
@@ -13,6 +14,7 @@ from theHarvester.lib.run import (
     SourceRateLimitedError,
     SourceStatus,
     execute_run,
+    legacy_dns_results,
     legacy_hostnames,
 )
 
@@ -163,6 +165,49 @@ async def test_execute_run_groups_multiple_sources_under_one_run() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_run_classifies_once_and_bridges_current_dns_results() -> None:
+    candidate = 'api.example.com'
+
+    class CandidateSource:
+        name = 'fixture'
+        family = 'fixture'
+
+        async def collect(self, _target: str) -> list[SourceFinding]:
+            return [SourceFinding(candidate)]
+
+    class Vantage:
+        def __init__(self, name: str, address: str) -> None:
+            self.name = name
+            self.address = address
+
+        async def query(self, hostname: str) -> DnsResponse:
+            return DnsResponse(ipv4=(self.address,)) if hostname == candidate else DnsResponse(rcode='NXDOMAIN')
+
+    validator = DnsValidator(
+        (
+            Vantage('resolver-a', '192.0.2.10'),
+            Vantage('resolver-b', '192.0.2.11'),
+            Vantage('resolver-c', '192.0.2.12'),
+        )
+    )
+
+    result = await execute_run('example.com', (CandidateSource(),), dns_validator=validator)
+
+    assert result.entities[0].addressability is Addressability.CURRENT
+    assert legacy_hostnames(result, 'fixture') == [candidate]
+    assert legacy_dns_results(result, 'fixture') == (
+        ['api.example.com:192.0.2.10,192.0.2.11,192.0.2.12'],
+        [candidate],
+        ['192.0.2.10', '192.0.2.11', '192.0.2.12'],
+    )
+    control_names = {
+        observation.query_name for observation in result.dns_validations if observation.is_wildcard_control
+    }
+    assert not control_names.intersection(observation.value for observation in result.observations)
+    assert not control_names.intersection(entity.value for entity in result.entities)
+
+
+@pytest.mark.asyncio
 async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch: pytest.MonkeyPatch) -> None:
     import argparse
 
@@ -234,6 +279,93 @@ async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch
     assert {observation.source_family for observation in captured[0].observations} == {'catalog-family'}
     assert legacy_hostnames(captured[0]) == ['www.example.com']
     assert stored == [('example.com', ('www.example.com',), 'host', 'CRTsh')]
+
+
+@pytest.mark.asyncio
+async def test_crtsh_bridge_uses_three_resolvers_without_legacy_requery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import theHarvester.__main__ as main_module
+    import theHarvester.lib.run as run_module
+
+    candidate = 'www.example.com'
+
+    class FakeCrtshSearch:
+        def __init__(self, target: str) -> None:
+            assert target == 'example.com'
+
+        async def process(self, _proxy: bool = False) -> None:
+            return None
+
+        async def get_hostnames(self) -> list[str]:
+            return [candidate]
+
+    created: list[str] = []
+    closed: list[str] = []
+
+    class FakeVantage:
+        def __init__(self, nameserver: str) -> None:
+            self.name = nameserver
+            created.append(nameserver)
+
+        async def query(self, hostname: str) -> DnsResponse:
+            return DnsResponse(ipv4=('192.0.2.10',)) if hostname == candidate else DnsResponse(rcode='NXDOMAIN')
+
+        async def close(self) -> None:
+            closed.append(self.name)
+
+    class FailOnLegacyChecker:
+        def __init__(self, *_args, **_kwargs) -> None:
+            raise AssertionError('validated evidence must not be queried again')
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args: object) -> None:
+            return None
+
+        async def store(self, *_args: object) -> None:
+            return None
+
+    captured: list[run_module.RunResult] = []
+    output: list[object] = []
+
+    async def capture_run(target, sources, **kwargs):
+        result = await run_module.execute_run(target, sources, **kwargs)
+        captured.append(result)
+        return result
+
+    monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
+    monkeypatch.setattr(main_module, 'AioDnsResolverVantage', FakeVantage, raising=False)
+    monkeypatch.setattr(main_module.hostchecker, 'Checker', FailOnLegacyChecker)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'execute_run', capture_run, raising=True)
+    monkeypatch.setattr(main_module.output_logger, 'info', output.append)
+
+    monkeypatch.setattr(
+        main_module.sys,
+        'argv',
+        [
+            'theHarvester',
+            '-d',
+            'example.com',
+            '-b',
+            'crtsh',
+            '-r',
+            '192.0.2.53,192.0.2.54,192.0.2.55',
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await main_module.start()
+
+    assert exit_info.value.code == 0
+    assert set(created) == {'192.0.2.53', '192.0.2.54', '192.0.2.55'}
+    assert set(closed) == set(created)
+    assert captured[0].entities[0].addressability is Addressability.CURRENT
+    assert output.count(f'{candidate}:192.0.2.10') == 1
+    assert candidate not in output
 
 
 @pytest.mark.asyncio

--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from theHarvester.lib.run import (
+    Derivation,
+    ScopeClass,
+    SourceFinding,
+    SourceStatus,
+    execute_run,
+    legacy_hostnames,
+)
+
+
+class FakePassiveSource:
+    name = 'fixture'
+    family = 'certificate-transparency'
+
+    async def collect(self, target: str) -> list[SourceFinding]:
+        assert target == 'example.com'
+        return [
+            SourceFinding('WWW.Example.COM.', Derivation.PROVIDER),
+            SourceFinding('www.example.com', Derivation.PROVIDER),
+            SourceFinding('example.com.evil.test', Derivation.SCOPE_EXTENSION),
+            SourceFinding('cdn.vendor.test', Derivation.EXTERNAL_RELATIONSHIP),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_execute_run_records_scoped_normalized_evidence_end_to_end() -> None:
+    result = await execute_run('Example.COM.', (FakePassiveSource(),))
+    next_result = await execute_run('example.com', (FakePassiveSource(),))
+
+    assert UUID(result.run_id)
+    assert result.run_id != next_result.run_id
+    assert result.target == 'example.com'
+    assert len(result.source_executions) == 1
+    execution = result.source_executions[0]
+    assert execution.status is SourceStatus.SUCCEEDED
+    assert execution.duration_ms >= 0
+    assert execution.result_count == 4
+    assert execution.observation_count == 4
+    assert execution.entity_count == 3
+
+    assert [(item.value, item.scope_class) for item in result.observations] == [
+        ('www.example.com', ScopeClass.IN_SCOPE),
+        ('www.example.com', ScopeClass.IN_SCOPE),
+        ('example.com.evil.test', ScopeClass.SCOPE_EXTENSION),
+        ('cdn.vendor.test', ScopeClass.EXTERNAL_RELATIONSHIP),
+    ]
+    assert all(item.target == 'example.com' for item in result.observations)
+    assert all(item.source == 'fixture' for item in result.observations)
+    assert all(item.source_family == 'certificate-transparency' for item in result.observations)
+    assert all(item.collected_at.tzinfo is not None for item in result.observations)
+    assert [item.derivation for item in result.observations] == [
+        Derivation.PROVIDER,
+        Derivation.PROVIDER,
+        Derivation.SCOPE_EXTENSION,
+        Derivation.EXTERNAL_RELATIONSHIP,
+    ]
+
+    merged = {item.value: item for item in result.entities}
+    assert len(merged['www.example.com'].observations) == 2
+    assert merged['www.example.com'].independent_corroboration_count == 1
+    assert merged['www.example.com'].scope_classes == (ScopeClass.IN_SCOPE,)
+    assert legacy_hostnames(result) == ['www.example.com']
+
+
+@pytest.mark.asyncio
+async def test_execute_run_does_not_persist_implicitly(monkeypatch: pytest.MonkeyPatch) -> None:
+    import theHarvester.lib.run as run_module
+
+    def fail_on_stash_access():
+        raise AssertionError('execute_run must remain an in-memory operation')
+
+    monkeypatch.setattr(run_module, 'StashManager', fail_on_stash_access, raising=False)
+
+    result = await execute_run('example.com', (FakePassiveSource(),))
+
+    assert result.target == 'example.com'
+
+
+class OutcomeSource:
+    name = 'outcome'
+    family = 'fixture-family'
+
+    def __init__(self, outcome: list[SourceFinding] | Exception) -> None:
+        self.outcome = outcome
+
+    async def collect(self, _target: str) -> list[SourceFinding]:
+        if isinstance(self.outcome, Exception):
+            raise self.outcome
+        return self.outcome
+
+
+@pytest.mark.parametrize(
+    ('outcome', 'expected'),
+    [
+        ([], SourceStatus.EMPTY),
+        (RuntimeError('provider failed'), SourceStatus.FAILED),
+    ],
+)
+@pytest.mark.asyncio
+async def test_execute_run_records_non_success_source_outcomes(
+    caplog: pytest.LogCaptureFixture,
+    outcome: list[SourceFinding] | Exception,
+    expected: SourceStatus,
+) -> None:
+    result = await execute_run('example.com', (OutcomeSource(outcome),))
+
+    assert len(result.source_executions) == 1
+    execution = result.source_executions[0]
+    assert execution.status is expected
+    assert execution.duration_ms >= 0
+    assert execution.result_count == 0
+    assert execution.observation_count == 0
+    assert execution.entity_count == 0
+    assert result.observations == ()
+    assert result.entities == ()
+    if expected is SourceStatus.FAILED:
+        assert 'Source outcome failed' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_execute_run_groups_multiple_sources_under_one_run() -> None:
+    class CorroboratingSource:
+        name = 'corroborating'
+        family = 'passive-dns'
+
+        async def collect(self, _target: str) -> list[SourceFinding]:
+            return [SourceFinding('www.example.com'), SourceFinding('example.com'), SourceFinding('')]
+
+    result = await execute_run('example.com', (FakePassiveSource(), CorroboratingSource()))
+
+    assert [execution.source for execution in result.source_executions] == ['fixture', 'corroborating']
+    assert {execution.run_id for execution in result.source_executions} == {result.run_id}
+    assert {observation.run_id for observation in result.observations} == {result.run_id}
+    corroborating_execution = result.source_executions[1]
+    assert corroborating_execution.status is SourceStatus.SUCCEEDED
+    assert corroborating_execution.result_count == 3
+    assert corroborating_execution.observation_count == 2
+    merged = {entity.value: entity for entity in result.entities}
+    assert merged['www.example.com'].independent_corroboration_count == 2
+    assert legacy_hostnames(result) == ['www.example.com']
+
+
+@pytest.mark.asyncio
+async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch: pytest.MonkeyPatch) -> None:
+    import argparse
+
+    import theHarvester.__main__ as main_module
+    import theHarvester.lib.run as run_module
+
+    process_calls: list[bool] = []
+
+    class FakeCrtshSearch:
+        def __init__(self, target: str) -> None:
+            assert target == 'example.com'
+
+        async def process(self, proxy: bool = False) -> None:
+            process_calls.append(proxy)
+
+        async def get_hostnames(self) -> list[str]:
+            return ['WWW.EXAMPLE.COM.', 'www.example.com', 'example.com.evil.test']
+
+    stored: list[tuple[str, tuple[str, ...], str, str]] = []
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, domain: str, items: list[str], result_type: str, source: str) -> None:
+            stored.append((domain, tuple(items), result_type, source))
+
+    captured: list[run_module.RunResult] = []
+
+    async def execute_with_temporary_store(target, sources):
+        result = await run_module.execute_run(target, sources)
+        captured.append(result)
+        return result
+
+    monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'execute_run', execute_with_temporary_store, raising=True)
+
+    await main_module.start(
+        argparse.Namespace(
+            api_scan=False,
+            dns_brute=False,
+            dns_lookup=False,
+            dns_resolve='',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=500,
+            proxies=False,
+            quiet=True,
+            shodan=False,
+            source='crtsh',
+            start=0,
+            take_over=False,
+            wordlist='',
+        )
+    )
+
+    assert process_calls == [False]
+    assert len(captured) == 1
+    assert captured[0].source_executions[0].status is SourceStatus.SUCCEEDED
+    assert captured[0].source_executions[0].source == 'crtsh'
+    assert legacy_hostnames(captured[0]) == ['www.example.com']
+    assert stored == [('example.com', ('www.example.com',), 'host', 'CRTsh')]

--- a/tests/lib/test_source_catalog.py
+++ b/tests/lib/test_source_catalog.py
@@ -37,9 +37,24 @@ def test_source_capabilities_are_derived_from_result_routes() -> None:
                 ResultRoute.INTERESTING_URLS,
             }
         ),
+        family='example',
     )
 
     assert spec.capabilities == frozenset({'subdomains', 'urls'})
+
+
+def test_source_specs_define_evidence_families() -> None:
+    shared_families = {
+        'certspotter': 'certificate-transparency',
+        'chaos': 'projectdiscovery',
+        'crtsh': 'certificate-transparency',
+        'projectdiscovery': 'projectdiscovery',
+        'shodan': 'shodan',
+        'shodanInternetDB': 'shodan',
+    }
+    expected = {name: shared_families.get(name, name) for name in SOURCE_SPECS}
+
+    assert {name: spec.family for name, spec in SOURCE_SPECS.items()} == expected
 
 
 def test_source_specs_describe_consolidated_routes_not_getter_presence() -> None:

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -9,6 +9,7 @@ import sys
 import time
 import traceback
 from collections.abc import Iterable
+from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING, Any
 
 import anyio
@@ -80,9 +81,17 @@ from theHarvester.discovery import (
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib import hostchecker, stash
 from theHarvester.lib.core import DATA_DIR, Core, show_default_error_message
+from theHarvester.lib.dns_validation import AioDnsResolverVantage, DnsValidator
 from theHarvester.lib.hostnames import normalize_scoped_hostname
 from theHarvester.lib.output import configure_logging, output_logger, print_linkedin_sections, print_section, sorted_unique
-from theHarvester.lib.run import LegacyHostnameSource, RunResult, SourceStatus, execute_run, legacy_hostnames
+from theHarvester.lib.run import (
+    LegacyHostnameSource,
+    RunResult,
+    SourceStatus,
+    execute_run,
+    legacy_dns_results,
+    legacy_hostnames,
+)
 from theHarvester.lib.source_catalog import ResultRoute, get_source_spec
 from theHarvester.screenshot.screenshot import ScreenShotter
 
@@ -177,7 +186,10 @@ async def start(rest_args: argparse.Namespace | None = None):
     parser.add_argument(
         '-r',
         '--dns-resolve',
-        help='Perform DNS resolution on subdomains with a resolver list or passed in resolvers, default False.',
+        help=(
+            'Perform DNS resolution on subdomains with a resolver list or passed in resolvers. '
+            'Exactly three distinct resolvers enable consensus and wildcard validation for migrated sources.'
+        ),
         default='',
         type=str,
         nargs='?',
@@ -310,7 +322,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                     output_logger.info(f'Passed DNS resolver is invalid, skipping: {item} ({e})')
 
         # if for some reason, there are duplicates
-        final_dns_resolver_list = list(set(final_dns_resolver_list))
+        final_dns_resolver_list = list(dict.fromkeys(final_dns_resolver_list))
         if len(final_dns_resolver_list) == 0:
             output_logger.info('No valid DNS resolvers were parsed from --dns-resolve; continuing without custom resolvers.')
 
@@ -366,7 +378,12 @@ async def start(rest_args: argparse.Namespace | None = None):
             output_logger.info(f'[*] Searching {source[0].upper() + source[1:]}. ')
 
         if ResultRoute.HOSTS in routes:
-            if run_result is not None:
+            has_dns_validation = run_result is not None and bool(run_result.dns_validations)
+            if run_result is not None and run_result.dns_validations:
+                resolved_pair, host_names, temp_ips = legacy_dns_results(run_result, source_spec.name)
+                all_ip.extend(temp_ips)
+                full.extend(resolved_pair)
+            elif run_result is not None:
                 host_names = legacy_hostnames(run_result, source_spec.name)
             else:
                 discovered_hosts = await search_engine.get_hostnames()
@@ -374,25 +391,26 @@ async def start(rest_args: argparse.Namespace | None = None):
                     host_names = list(discovered_hosts)
                 else:
                     host_names = list(_normalize_hosts_for_storage(discovered_hosts, word))
-            if source != 'hackertarget' and source != 'pentesttools' and source != 'rapiddns':
-                # If a source is inside this conditional, it means the hosts returned must be resolved to obtain ip
-                # This should only be checked if --dns-resolve has a wordlist
-                if dnsresolve is None or len(final_dns_resolver_list) > 0:
-                    # indicates that -r was passed in if dnsresolve is None
-                    full_hosts_checker = hostchecker.Checker(host_names, final_dns_resolver_list)
-                    # If full, this is only getting resolved hosts
-                    (
-                        resolved_pair,
-                        _temp_hosts,
-                        temp_ips,
-                    ) = await full_hosts_checker.check()
-                    all_ip.extend(temp_ips)
-                    full.extend(resolved_pair)
-                    # full.extend(temp_hosts)
+            if not has_dns_validation:
+                if source != 'hackertarget' and source != 'pentesttools' and source != 'rapiddns':
+                    # If a source is inside this conditional, it means the hosts returned must be resolved to obtain ip
+                    # This should only be checked if --dns-resolve has a wordlist
+                    if dnsresolve is None or len(final_dns_resolver_list) > 0:
+                        # indicates that -r was passed in if dnsresolve is None
+                        full_hosts_checker = hostchecker.Checker(host_names, final_dns_resolver_list)
+                        # If full, this is only getting resolved hosts
+                        (
+                            resolved_pair,
+                            _temp_hosts,
+                            temp_ips,
+                        ) = await full_hosts_checker.check()
+                        all_ip.extend(temp_ips)
+                        full.extend(resolved_pair)
+                        # full.extend(temp_hosts)
+                    else:
+                        full.extend(host_names)
                 else:
                     full.extend(host_names)
-            else:
-                full.extend(host_names)
             all_hosts.extend(host_names)
             await db_stash.store_all(word, all_hosts, 'host', source)
 
@@ -435,12 +453,25 @@ async def start(rest_args: argparse.Namespace | None = None):
     evidence_sources: list[LegacyHostnameSource] = []
 
     async def store_evidence_sources() -> None:
-        run_result = await execute_run(word, tuple(evidence_sources))
-        executions = {execution.source: execution for execution in run_result.source_executions}
-        for evidence_source in evidence_sources:
-            execution = executions[evidence_source.name]
-            if execution.status in (SourceStatus.SUCCEEDED, SourceStatus.EMPTY) or execution.observation_count:
-                await store(evidence_source.search, evidence_source.legacy_name, run_result)
+        async with AsyncExitStack() as resolver_stack:
+            dns_validator = None
+            if len(final_dns_resolver_list) == 3:
+                vantages = []
+                for nameserver in final_dns_resolver_list:
+                    vantage = AioDnsResolverVantage(nameserver)
+                    vantages.append(vantage)
+                    resolver_stack.push_async_callback(vantage.close)
+                dns_validator = DnsValidator(tuple(vantages))
+            run_result = (
+                await execute_run(word, tuple(evidence_sources), dns_validator=dns_validator)
+                if dns_validator is not None
+                else await execute_run(word, tuple(evidence_sources))
+            )
+            executions = {execution.source: execution for execution in run_result.source_executions}
+            for evidence_source in evidence_sources:
+                execution = executions[evidence_source.name]
+                if execution.status in (SourceStatus.SUCCEEDED, SourceStatus.EMPTY) or execution.observation_count:
+                    await store(evidence_source.search, evidence_source.legacy_name, run_result)
 
     if args.source is not None:
         engines = Core.expand_source_selection(args.source)

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -82,6 +82,7 @@ from theHarvester.lib import hostchecker, stash
 from theHarvester.lib.core import DATA_DIR, Core, show_default_error_message
 from theHarvester.lib.hostnames import normalize_scoped_hostname
 from theHarvester.lib.output import configure_logging, output_logger, print_linkedin_sections, print_section, sorted_unique
+from theHarvester.lib.run import LegacyHostnameSource, RunResult, SourceStatus, execute_run, legacy_hostnames
 from theHarvester.lib.source_catalog import ResultRoute, get_source_spec
 from theHarvester.screenshot.screenshot import ScreenShotter
 
@@ -342,30 +343,37 @@ async def start(rest_args: argparse.Namespace | None = None):
     async def store(
         search_engine: Any,
         source: str,
+        run_result: RunResult | None = None,
     ) -> None:
         """Process a source and persist its declared consolidated result routes.
 
         :param search_engine: search engine to fetch details from
         :param source: source against which the details (corresponding to the search engine) need to be persisted
+        :param run_result: optional completed evidence run for a migrated source
         """
-        logger.info(f'Source {source} started')
-        try:
-            await search_engine.process(use_proxy)
-        except Exception:
-            logger.exception(f'Source {source} failed')
-            raise
+        if run_result is None:
+            logger.info(f'Source {source} started')
+            try:
+                await search_engine.process(use_proxy)
+            except Exception:
+                logger.exception(f'Source {source} failed')
+                raise
         db_stash = stash.StashManager()
-        routes = get_source_spec(source).routes
+        source_spec = get_source_spec(source)
+        routes = source_spec.routes
 
         if source:
             output_logger.info(f'[*] Searching {source[0].upper() + source[1:]}. ')
 
         if ResultRoute.HOSTS in routes:
-            discovered_hosts = await search_engine.get_hostnames()
-            if source == 'intelx':
-                host_names = list(discovered_hosts)
+            if run_result is not None:
+                host_names = legacy_hostnames(run_result, source_spec.name)
             else:
-                host_names = list(_normalize_hosts_for_storage(discovered_hosts, word))
+                discovered_hosts = await search_engine.get_hostnames()
+                if source == 'intelx':
+                    host_names = list(discovered_hosts)
+                else:
+                    host_names = list(_normalize_hosts_for_storage(discovered_hosts, word))
             if source != 'hackertarget' and source != 'pentesttools' and source != 'rapiddns':
                 # If a source is inside this conditional, it means the hosts returned must be resolved to obtain ip
                 # This should only be checked if --dns-resolve has a wordlist
@@ -420,9 +428,19 @@ async def start(rest_args: argparse.Namespace | None = None):
             total_asns.extend(fasns)
             if len(fasns) > 0:
                 await db.store_all(word, fasns, 'asns', source)
-        logger.info(f'Source {source} completed')
+        if run_result is None:
+            logger.info(f'Source {source} completed')
 
     stor_lst = []
+    evidence_sources: list[LegacyHostnameSource] = []
+
+    async def store_evidence_sources() -> None:
+        run_result = await execute_run(word, tuple(evidence_sources))
+        executions = {execution.source: execution for execution in run_result.source_executions}
+        for evidence_source in evidence_sources:
+            if executions[evidence_source.name].status in (SourceStatus.SUCCEEDED, SourceStatus.EMPTY):
+                await store(evidence_source.search, evidence_source.legacy_name, run_result)
+
     if args.source is not None:
         engines = Core.expand_source_selection(args.source)
         # Iterate through search engines in order
@@ -596,7 +614,17 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'crtsh':
                     try:
                         crtsh_search = crtsh.SearchCrtsh(word)
-                        stor_lst.append(store(crtsh_search, 'CRTsh'))
+                        source_spec = get_source_spec(engineitem)
+                        evidence_sources.append(
+                            LegacyHostnameSource(
+                                name=source_spec.name,
+                                legacy_name='CRTsh',
+                                # ponytail: move families into SourceSpec when a second evidence source migrates.
+                                family='certificate-transparency',
+                                search=crtsh_search,
+                                proxy=use_proxy,
+                            )
+                        )
                     except Exception as e:
                         output_logger.info(f'[!] A timeout occurred with crtsh, cannot find {args.domain}\n {e}')
 
@@ -1253,6 +1281,9 @@ async def start(rest_args: argparse.Namespace | None = None):
                         if isinstance(e, MissingKey):
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in zoomeye: {e}')
+
+            if evidence_sources:
+                stor_lst.append(store_evidence_sources())
 
         elif rest_args is not None:
             try:

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -8,9 +8,9 @@ import string
 import sys
 import time
 import traceback
-from collections.abc import Iterable
+from collections.abc import Awaitable, Iterable
 from contextlib import AsyncExitStack
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import anyio
 import netaddr
@@ -83,20 +83,30 @@ from theHarvester.lib import hostchecker, stash
 from theHarvester.lib.core import DATA_DIR, Core, show_default_error_message
 from theHarvester.lib.dns_validation import AioDnsResolverVantage, DnsValidator
 from theHarvester.lib.hostnames import normalize_scoped_hostname
-from theHarvester.lib.output import configure_logging, output_logger, print_linkedin_sections, print_section, sorted_unique
+from theHarvester.lib.output import (
+    configure_logging,
+    evidence_xml_fragment,
+    format_run_terminal,
+    legacy_json_result,
+    output_logger,
+    run_result_jsonl,
+    sorted_unique,
+)
 from theHarvester.lib.run import (
     LegacyHostnameSource,
     RunResult,
     SourceStatus,
+    SQLiteRunStore,
+    StageFinding,
+    StageFindingKind,
+    StageResult,
+    complete_run,
     execute_run,
     legacy_dns_results,
     legacy_hostnames,
 )
 from theHarvester.lib.source_catalog import ResultRoute, get_source_spec
 from theHarvester.screenshot.screenshot import ScreenShotter
-
-if TYPE_CHECKING:
-    from collections.abc import Awaitable
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +144,7 @@ def sanitize_filename(filename: str) -> str:
     return filename
 
 
-async def start(rest_args: argparse.Namespace | None = None):
+async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_run: bool = False):
     """Main program function"""
     parser = argparse.ArgumentParser(
         description='theHarvester is used to gather open source intelligence (OSINT) on a company or domain.'
@@ -211,7 +221,7 @@ async def start(rest_args: argparse.Namespace | None = None):
     parser.add_argument(
         '-f',
         '--filename',
-        help='Save the results to an XML and JSON file.',
+        help='Save XML, legacy JSON, and normalized JSONL reports.',
         default='',
         type=str,
     )
@@ -245,11 +255,12 @@ async def start(rest_args: argparse.Namespace | None = None):
         elif rest_args.dns_brute:
             args = rest_args
             dnsbrute = (rest_args.dns_brute, True)
+            filename = args.filename
         else:
             args = rest_args
             dnsbrute = (args.dns_brute, False)
             # We need to make sure the filename is random as to not overwrite other files
-            filename: str = args.filename
+            filename = args.filename
             alphabet = string.ascii_letters + string.digits
             rest_filename += f'{"".join(secrets.choice(alphabet) for _ in range(32))}_{filename}' if len(filename) != 0 else ''
     else:
@@ -351,12 +362,39 @@ async def start(rest_args: argparse.Namespace | None = None):
 
     interesting_urls = []
     total_asns = []
+    completed_run_result: RunResult | None = None
+    stage_results: list[StageResult] = []
 
-    async def store(
+    def record_stage_result(
+        source: str,
+        started: float,
+        findings: list[StageFinding] | tuple[StageFinding, ...] = (),
+        error: Exception | None = None,
+    ) -> None:
+        unique_findings = tuple(dict.fromkeys(findings))
+        stage_results.append(
+            StageResult(
+                source=source,
+                status=(
+                    SourceStatus.FAILED
+                    if error is not None
+                    else SourceStatus.SUCCEEDED
+                    if unique_findings
+                    else SourceStatus.EMPTY
+                ),
+                duration_ms=(time.perf_counter() - started) * 1000,
+                result_count=len(findings),
+                findings=unique_findings,
+                error_type=type(error).__name__ if error is not None else None,
+            )
+        )
+
+    async def _store(
         search_engine: Any,
         source: str,
         run_result: RunResult | None = None,
-    ) -> None:
+        stage_findings: list[StageFinding] | None = None,
+    ):
         """Process a source and persist its declared consolidated result routes.
 
         :param search_engine: search engine to fetch details from
@@ -413,46 +451,106 @@ async def start(rest_args: argparse.Namespace | None = None):
                     full.extend(host_names)
             all_hosts.extend(host_names)
             await db_stash.store_all(word, all_hosts, 'host', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.HOSTNAME, host) for host in host_names)
 
         if ResultRoute.EMAILS in routes:
             email_list = await search_engine.get_emails()
             all_emails.extend(email_list)
             await db_stash.store_all(word, email_list, 'email', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.EMAIL, email) for email in email_list)
 
         if ResultRoute.IPS in routes:
             ips_list = await search_engine.get_ips()
             all_ip.extend(ips_list)
             await db_stash.store_all(word, all_ip, 'ip', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.IP_ADDRESS, str(ip)) for ip in ips_list)
 
         if ResultRoute.PEOPLE in routes:
             people_list = await search_engine.get_people()
             all_people.extend(people_list)
             await db_stash.store_all(word, people_list, 'people', source)
+            if stage_findings is not None:
+                stage_findings.extend(
+                    StageFinding(StageFindingKind.PERSON, ujson.dumps(person, sort_keys=True)) for person in people_list
+                )
 
         if ResultRoute.LINKS in routes:
             links = await search_engine.get_links()
             linkedin_links_tracker.extend(links)
             if len(links) > 0:
                 await db.store_all(word, links, 'linkedinlinks', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.URL, link) for link in links)
 
         if ResultRoute.INTERESTING_URLS in routes:
             iurls = await search_engine.get_interestingurls()
             interesting_urls.extend(iurls)
             if len(iurls) > 0:
                 await db.store_all(word, iurls, 'interestingurls', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.INTERESTING_URL, url) for url in iurls)
 
         if ResultRoute.ASNS in routes:
             fasns = await search_engine.get_asns()
             total_asns.extend(fasns)
             if len(fasns) > 0:
                 await db.store_all(word, fasns, 'asns', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.ASN, str(asn)) for asn in fasns)
         if run_result is None:
             logger.info(f'Source {source} completed')
+            return None
+        return next(
+            execution for execution in run_result.source_executions if execution.source.casefold() == source_spec.name.casefold()
+        )
+
+    def store(
+        search_engine: Any,
+        source: str,
+        run_result: RunResult | None = None,
+    ) -> Awaitable[None]:
+        async def run_stage() -> None:
+            findings: list[StageFinding] = []
+            started = time.perf_counter()
+            execution = None
+            error: Exception | None = None
+            try:
+                execution = await _store(search_engine, source, run_result, findings)
+            except Exception as stage_error:
+                error = stage_error
+                raise
+            finally:
+                source_spec = get_source_spec(source)
+                stage_results.append(
+                    StageResult(
+                        source=source_spec.name,
+                        source_family=source_spec.family,
+                        status=(
+                            execution.status
+                            if execution is not None
+                            else SourceStatus.FAILED
+                            if error is not None
+                            else SourceStatus.SUCCEEDED
+                            if findings
+                            else SourceStatus.EMPTY
+                        ),
+                        duration_ms=(time.perf_counter() - started) * 1000,
+                        result_count=execution.result_count if execution is not None else len(findings),
+                        findings=tuple(dict.fromkeys(findings)),
+                        error_type=execution.error_type if execution is not None else type(error).__name__ if error else None,
+                    )
+                )
+
+        return run_stage()
 
     stor_lst = []
     evidence_sources: list[LegacyHostnameSource] = []
 
     async def store_evidence_sources() -> None:
+        nonlocal completed_run_result
         async with AsyncExitStack() as resolver_stack:
             dns_validator = None
             if len(final_dns_resolver_list) == 3:
@@ -467,6 +565,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 if dns_validator is not None
                 else await execute_run(word, tuple(evidence_sources))
             )
+            completed_run_result = run_result
             executions = {execution.source: execution for execution in run_result.source_executions}
             for evidence_source in evidence_sources:
                 execution = executions[evidence_source.name]
@@ -1374,111 +1473,42 @@ async def start(rest_args: argparse.Namespace | None = None):
         await asyncio.gather(*tasks, return_exceptions=True)
 
     await handler(lst=stor_lst)
-    return_ips: list = []
-    if rest_args is not None and len(rest_filename) == 0 and rest_args.dns_brute is False:
-        # Indicates user is using REST api but not wanting output to be saved to a file
-        # cast to string so Rest API can understand the type
-        return_ips.extend([str(ip) for ip in sorted([netaddr.IPAddress(ip.strip()) for ip in set(all_ip)])])
-        # return list(set(all_emails)), return_ips, full, '', ''
-        all_hosts = [host.replace('www.', '') for host in all_hosts if host.replace('www.', '') in all_hosts]
-        all_hosts = list(sorted(set(all_hosts)))
-        return (
-            total_asns,
-            interesting_urls,
-            twitter_people_list_tracker,
-            linkedin_people_list_tracker,
-            linkedin_links_tracker,
-            all_urls,
-            all_ip,
-            all_emails,
-            all_hosts,
-        )
-    # Check to see if all_emails and all_hosts are defined.
-    try:
-        all_emails
-    except NameError:
-        output_logger.info('\n\n[!] No emails found because all_emails is not defined.\n\n ')
-        sys.exit(1)
-    try:
-        all_hosts
-    except NameError:
-        output_logger.info('\n\n[!] No hosts found because all_hosts is not defined.\n\n ')
-        sys.exit(1)
-
-    # Results
-    if len(total_asns) > 0:
-        print_section(f'\n[*] ASNS found: {len(total_asns)}', total_asns, '--------------------')
-        total_asns = sorted_unique(total_asns)
-
-    if len(interesting_urls) > 0:
-        print_section(f'\n[*] Interesting Urls found: {len(interesting_urls)}', interesting_urls, '--------------------')
-        interesting_urls = sorted_unique(interesting_urls)
-
-    if len(twitter_people_list_tracker) == 0 and 'twitter' in engines:
-        output_logger.info('\n[*] No Twitter users found.\n\n')
-    elif len(twitter_people_list_tracker) >= 1:
-        print_section(
-            '\n[*] Twitter Users found: ' + str(len(twitter_people_list_tracker)),
-            twitter_people_list_tracker,
-            '---------------------',
-        )
-        twitter_people_list_tracker = sorted_unique(twitter_people_list_tracker)
-
-    print_linkedin_sections(engines, linkedin_people_list_tracker, linkedin_links_tracker)
+    if completed_run_result is None:
+        completed_run_result = await execute_run(word, ())
+    recorded_sources = {result.source.casefold() for result in stage_results}
+    recorded_sources.update(execution.source.casefold() for execution in completed_run_result.source_executions)
+    for engine in engines:
+        if engine.casefold() not in recorded_sources:
+            source_spec = get_source_spec(engine)
+            stage_results.append(
+                StageResult(
+                    source=source_spec.name,
+                    source_family=source_spec.family,
+                    status=SourceStatus.FAILED,
+                    duration_ms=0,
+                    result_count=0,
+                    error_type='SourceDidNotStart',
+                )
+            )
+    total_asns = sorted_unique(total_asns)
+    interesting_urls = sorted_unique(interesting_urls)
+    twitter_people_list_tracker = sorted_unique(twitter_people_list_tracker)
     linkedin_people_list_tracker = sorted_unique(linkedin_people_list_tracker)
     linkedin_links_tracker = sorted_unique(linkedin_links_tracker)
+    all_urls = sorted_unique(all_urls)
+    ip_list = []
+    for ip in set(all_ip):
+        try:
+            value = ip.strip()
+            if value:
+                ip_list.append(str(netaddr.IPNetwork(value) if '/' in value else netaddr.IPAddress(value)))
+        except (netaddr.core.AddrFormatError, ValueError, TypeError) as error:
+            output_logger.info(f'An exception has occurred while adding: {ip} to ip_list: {error}')
+    ip_list.sort()
+    host_ip = ip_list
+    all_emails = sorted_unique(all_emails)
 
-    length_urls = len(all_urls)
-    if length_urls == 0:
-        if len(engines) >= 1 and 'trello' in engines:
-            output_logger.info('\n[*] No Trello URLs found.')
-    else:
-        total = length_urls
-        print_section('\n[*] Trello URLs found: ' + str(total), all_urls, '--------------------')
-        all_urls = sorted_unique(all_urls)
-
-    if len(all_ip) == 0:
-        output_logger.info('\n[*] No IPs found.')
-    else:
-        output_logger.info('\n[*] IPs found: ' + str(len(all_ip)))
-        output_logger.info('-------------------')
-        # use netaddr as the list may contain ipv4 and ipv6 addresses
-        ip_list = []
-        for ip in set(all_ip):
-            try:
-                ip = ip.strip()
-                if len(ip) > 0:
-                    if '/' in ip:
-                        ip_list.append(str(netaddr.IPNetwork(ip)))
-                    else:
-                        ip_list.append(str(netaddr.IPAddress(ip)))
-            except (netaddr.core.AddrFormatError, ValueError, TypeError) as e:
-                output_logger.info(f'An exception has occurred while adding: {ip} to ip_list: {e}')
-                continue
-        ip_list = list(sorted(ip_list))
-        output_logger.info('\n'.join(map(str, ip_list)))
-        # Populate host_ip from ip_list for DNS lookup, virtual hosts search, and Shodan search
-        host_ip = ip_list
-
-    if len(all_emails) == 0:
-        output_logger.info('\n[*] No emails found.')
-    else:
-        output_logger.info('\n[*] Emails found: ' + str(len(all_emails)))
-        output_logger.info('----------------------')
-        all_emails = sorted(list(set(all_emails)))
-        output_logger.info('\n'.join(all_emails))
-
-    if len(all_people) == 0:
-        output_logger.info('\n[*] No people found.')
-    else:
-        output_logger.info('\n[*] People found: ' + str(len(all_people)))
-        output_logger.info('----------------------')
-        for person in all_people:
-            output_logger.info(person)
-
-    if len(all_hosts) == 0:
-        output_logger.info('\n[*] No hosts found.\n\n')
-    else:
+    if len(all_hosts) > 0:
         db = stash.StashManager()
         if dnsresolve is None or len(final_dns_resolver_list) > 0:
             temp = set()
@@ -1497,10 +1527,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                     temp.add(host)
             full = list(sorted(temp))
             full.sort(key=lambda el: el.split(':')[0])
-            output_logger.info('\n[*] Hosts found: ' + str(len(full)))
-            output_logger.info('---------------------')
             for host in full:
-                output_logger.info(host)
                 try:
                     if ':' in host:
                         _, addr = host.split(':', 1)
@@ -1511,19 +1538,23 @@ async def start(rest_args: argparse.Namespace | None = None):
         else:
             all_hosts = [host.replace('www.', '') for host in all_hosts if host.replace('www.', '') in all_hosts]
             all_hosts = list(sorted(set(all_hosts)))
-            output_logger.info('\n[*] Hosts found: ' + str(len(all_hosts)))
-            output_logger.info('---------------------')
-            for host in all_hosts:
-                output_logger.info(host)
 
     # DNS brute force
+    resolved_pair: list[str] = []
     if dnsbrute and dnsbrute[0] is True:
         output_logger.info('\n[*] Starting DNS brute force.')
-        dns_force = dnssearch.DnsForce(word, final_dns_resolver_list, verbose=True)
-        resolved_pair, hosts, ips = await dns_force.run()
-        # Check if Rest API is being used if so return found hosts
-        if dnsbrute[1]:
-            return resolved_pair
+        stage_started = time.perf_counter()
+        try:
+            dns_force = dnssearch.DnsForce(word, final_dns_resolver_list, verbose=True)
+            resolved_pair, hosts, ips = await dns_force.run()
+            record_stage_result(
+                'action:dns-brute',
+                stage_started,
+                [StageFinding(StageFindingKind.HOSTNAME, host) for host in resolved_pair],
+            )
+        except Exception as error:
+            record_stage_result('action:dns-brute', stage_started, error=error)
+            output_logger.info(f'[!] DNS brute force failed: {error}')
         db = stash.StashManager()
         temp = set()
         for host in resolved_pair:
@@ -1547,24 +1578,13 @@ async def start(rest_args: argparse.Namespace | None = None):
                     temp.add(host)
                 if host not in all_hosts:
                     all_hosts.append(host)
-        output_logger.info('\n[*] Hosts found after DNS brute force:')
-        for sub in temp:
-            output_logger.info(sub)
         await db.store_all(word, list(sorted(temp)), 'host', 'dns_bruteforce')
 
-    takeover_results = dict()
-    # TakeOver Checking
-    if takeover_status:
-        output_logger.info('\n[*] Performing subdomain takeover check')
-        output_logger.info('\n[*] Subdomain Takeover checking IS ACTIVE RECON')
-        search_take = takeover.TakeOver(all_hosts)
-        await search_take.populate_fingerprints()
-        await search_take.process(proxy=use_proxy)
-        takeover_results = await search_take.get_takeover_results()
     # DNS reverse lookup
     dnsrev: list = []
     if dnslookup is True:
         output_logger.info('\n[*] Starting active queries for DNSLookup.')
+        stage_started = time.perf_counter()
 
         # reverse each iprange in a separate task
         __reverse_dns_tasks: dict = {}
@@ -1584,16 +1604,51 @@ async def start(rest_args: argparse.Namespace | None = None):
                 # nameservers=list(map(str, dnsserver.split(','))) if dnsserver else None))
 
         # run all the reversing tasks concurrently
-        await asyncio.gather(*__reverse_dns_tasks.values())
-        output_logger.info('\n[*] Hosts found after reverse lookup (in target domain):')
-        output_logger.info('--------------------------------------------------------')
-        for xh in dnsrev:
-            output_logger.info(xh)
+        try:
+            await asyncio.gather(*__reverse_dns_tasks.values())
+            record_stage_result(
+                'action:dns-lookup',
+                stage_started,
+                [StageFinding(StageFindingKind.HOSTNAME, host) for host in dnsrev],
+            )
+        except Exception as error:
+            record_stage_result('action:dns-lookup', stage_started, error=error)
+            output_logger.info(f'[!] Reverse DNS lookup failed: {error}')
+
+    takeover_results = dict()
+    # TakeOver Checking
+    if takeover_status:
+        output_logger.info('\n[*] Performing subdomain takeover check')
+        output_logger.info('\n[*] Subdomain Takeover checking IS ACTIVE RECON')
+        stage_started = time.perf_counter()
+        try:
+            search_take = takeover.TakeOver(all_hosts)
+            await search_take.populate_fingerprints()
+            await search_take.process(proxy=use_proxy)
+            takeover_results = await search_take.get_takeover_results()
+            record_stage_result(
+                'action:take-over',
+                stage_started,
+                [
+                    StageFinding(
+                        StageFindingKind.TAKEOVER,
+                        str(host),
+                        result if isinstance(result, str) else ujson.dumps(result, sort_keys=True),
+                    )
+                    for host, result in takeover_results.items()
+                ],
+            )
+        except Exception as error:
+            record_stage_result('action:take-over', stage_started, error=error)
+            output_logger.info(f'[!] Takeover check failed: {error}')
 
     # Screenshots
     screenshot_tups = []
-    if len(args.screenshot) > 0:
-        screen_shotter = ScreenShotter(args.screenshot)
+    screenshot_hosts: list[str] = []
+    screenshot_path = getattr(args, 'screenshot', '')
+    if len(screenshot_path) > 0:
+        stage_started = time.perf_counter()
+        screen_shotter = ScreenShotter(screenshot_path)
         path_exists = screen_shotter.verify_path()
         # Verify the path exists, if not create it or if user does not create it skips screenshot
         if path_exists:
@@ -1615,6 +1670,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                     results = await pool.map(screen_shotter.visit, list(unique_resolved_domains))
                     # Filter out domains that we couldn't connect to
                     unique_resolved_domains_list = list(sorted({tup[0] for tup in results if len(tup[1]) > 0}))
+                    screenshot_hosts.extend(unique_resolved_domains_list)
                 async with Pool(3) as pool:
                     output_logger.info(f'Length of unique resolved domains: {len(unique_resolved_domains_list)} chunking now!\n')
                     # If you have the resources, you could make the function faster by increasing the chunk number
@@ -1632,10 +1688,18 @@ async def start(rest_args: argparse.Namespace | None = None):
             total_time = f'{mon:02d}:{sec:02d}'
             output_logger.info(f'Finished taking screenshots in {total_time} seconds')
             output_logger.info('[+] Note there may be leftover chrome processes you may have to kill manually\n')
+        record_stage_result(
+            'action:screenshot',
+            stage_started,
+            [StageFinding(StageFindingKind.SCREENSHOT, host) for host in screenshot_hosts],
+        )
 
     # Shodan
     shodanres = []
+    shodan_findings: list[StageFinding] = []
+    shodan_errors: list[Exception] = []
     if shodan is True:
+        stage_started = time.perf_counter()
         output_logger.info('[*] Searching Shodan. ')
         try:
             for ip in host_ip:
@@ -1660,113 +1724,33 @@ async def start(rest_args: argparse.Namespace | None = None):
                                 value = ', '.join(map(str, value))
                             rowdata.append(value)
                         shodanres.append(rowdata)
+                        shodan_findings.append(
+                            StageFinding(
+                                StageFindingKind.SHODAN_RESULT,
+                                ip,
+                            )
+                        )
                         output_logger.info(ujson.dumps(shodandict[ip], indent=4, sort_keys=True))
                         output_logger.info('\n')
                 except Exception as ip_error:
+                    shodan_errors.append(ip_error)
                     output_logger.info(f'[SHODAN-error] Error searching {ip}: {ip_error}')
                     continue
         except Exception as e:
+            shodan_errors.append(e)
             output_logger.info(f'[!] An error occurred with Shodan: {e} ')
+        record_stage_result(
+            'action:shodan',
+            stage_started,
+            shodan_findings,
+            shodan_errors[0] if shodan_errors else None,
+        )
     else:
         pass
 
-    if filename != '':
-        output_logger.info('\n[*] Reporting started.')
-        try:
-            if len(rest_filename) == 0:
-                filename = filename.rsplit('.', 1)[0] + '.xml'
-            else:
-                filename = 'theHarvester/app/static/' + rest_filename.rsplit('.', 1)[0] + '.xml'
-            # XML REPORT SECTION
-            async with await anyio.open_file(filename, 'w+') as file:
-                await file.write('<?xml version="1.0" encoding="UTF-8"?><theHarvester>')
-                sanitized_args = [sanitize_for_xml(f'"{arg}"' if ' ' in arg else arg) for arg in sys.argv[1:]]
-                await file.write('<cmd>' + ' '.join(sanitized_args) + '</cmd>')
-                for email in all_emails:
-                    await file.write('<email>' + sanitize_for_xml(email) + '</email>')
-                for x in full:
-                    host, ip = x.split(':', 1) if ':' in x else (x, '')
-                    if ip and len(ip) > 3:
-                        await file.write(
-                            f'<host><ip>{sanitize_for_xml(ip)}</ip><hostname>{sanitize_for_xml(host)}</hostname></host>'
-                        )
-                    else:
-                        await file.write(f'<host>{sanitize_for_xml(host)}</host>')
-                for x in vhost:
-                    host, ip = x.split(':', 1) if ':' in x else (x, '')
-                    if ip and len(ip) > 3:
-                        await file.write(
-                            f'<vhost><ip>{sanitize_for_xml(ip)} </ip><hostname>{sanitize_for_xml(host)}</hostname></vhost>'
-                        )
-                    else:
-                        await file.write(f'<vhost>{sanitize_for_xml(host)}</vhost>')
-                # TODO add Shodan output into XML report
-                await file.write('</theHarvester>')
-                output_logger.info('[*] XML File saved.')
-        except (OSError, ValueError, TypeError, UnicodeEncodeError) as error:
-            output_logger.info(f'[!] An error occurred while saving the XML file: {error}')
-
-        try:
-            # JSON REPORT SECTION
-            filename = filename.rsplit('.', 1)[0] + '.json'
-            # create dict with values for JSON output
-            json_dict: dict = dict()
-            # start by adding the command line arguments
-            json_dict['cmd'] = ' '.join([f'"{arg}"' if ' ' in arg else arg for arg in sys.argv[1:]])
-            # to determine if a variable exists
-            # it should but just a validation check
-            if 'ip_list' in locals():
-                if all_ip and len(all_ip) >= 1 and ip_list and len(ip_list) > 0:
-                    json_dict['ips'] = ip_list
-
-            if len(all_emails) > 0:
-                json_dict['emails'] = all_emails
-
-            if dnsresolve is None or (len(final_dns_resolver_list) > 0 and len(full) > 0):
-                json_dict['hosts'] = full
-            elif len(all_hosts) > 0:
-                json_dict['hosts'] = all_hosts
-            else:
-                json_dict['hosts'] = []
-
-            if vhost and len(vhost) > 0:
-                json_dict['vhosts'] = vhost
-
-            if len(interesting_urls) > 0:
-                json_dict['interesting_urls'] = interesting_urls
-
-            if len(all_urls) > 0:
-                json_dict['trello_urls'] = all_urls
-
-            if len(total_asns) > 0:
-                json_dict['asns'] = total_asns
-
-            if len(twitter_people_list_tracker) > 0:
-                json_dict['twitter_people'] = twitter_people_list_tracker
-
-            if len(linkedin_people_list_tracker) > 0:
-                json_dict['linkedin_people'] = linkedin_people_list_tracker
-
-            if len(linkedin_links_tracker) > 0:
-                json_dict['linkedin_links'] = linkedin_links_tracker
-
-            if len(all_people) > 0:
-                json_dict['people'] = all_people
-
-            if takeover_status and len(takeover_results) > 0:
-                json_dict['takeover_results'] = takeover_results
-
-            json_dict['shodan'] = shodanres
-            async with await anyio.open_file(filename, 'w+') as fp:
-                dumped_json = ujson.dumps(json_dict, sort_keys=True)
-                await fp.write(dumped_json)
-            output_logger.info('[*] JSON File saved.')
-        except (OSError, ValueError, TypeError, UnicodeEncodeError) as er:
-            output_logger.info(f'[!] An error occurred while saving the JSON file: {er} ')
-        output_logger.info('\n\n')
-
     # Enhanced code block for API Endpoint scanning feature
-    if args.api_scan or 'api_endpoints' in engines:
+    if getattr(args, 'api_scan', False) or 'api_endpoints' in engines:
+        stage_started = time.perf_counter()
         try:
             # Define a default wordlist if none is specified
             wordlist = args.wordlist or str(DATA_DIR / 'wordlists' / 'api_endpoints.txt')
@@ -1858,74 +1842,102 @@ async def start(rest_args: argparse.Namespace | None = None):
                 # Also add complete domain paths to the interesting_urls list
                 all_urls.extend(new_urls)
 
+            record_stage_result(
+                'action:api-scan',
+                stage_started,
+                [
+                    StageFinding(StageFindingKind.API_ENDPOINT, endpoint, str(result.status_code))
+                    for endpoint, result in endpoints_found.items()
+                ],
+            )
             output_logger.info('\n[+] API scanning completed successfully.')
 
-        except MissingKey:
+        except MissingKey as error:
+            record_stage_result('action:api-scan', stage_started, error=error)
             output_logger.info('\n[!] API endpoint scanning requires a wordlist. Use -w to specify a wordlist file.')
             output_logger.info('    Creating a basic wordlist and trying again...')
             # The wordlist creation code above could be used here
         except Exception as e:
+            record_stage_result('action:api-scan', stage_started, error=e)
             output_logger.info(f'\n[!] An exception has occurred in API Endpoints scanning: {e}')
             output_logger.info('    Continuing with the rest of the scan...')
             traceback.print_exc()  # More detailed error information for developers
 
-    if 'securityscorecard' in engines:
+    completed_run_result = complete_run(completed_run_result, stage_results)
+    await SQLiteRunStore().save(completed_run_result)
+    output_logger.info(format_run_terminal(completed_run_result))
+
+    if filename != '':
+        output_logger.info('\n[*] Reporting started.')
+        report_base = (
+            os.path.join('theHarvester/app/static', os.path.splitext(rest_filename)[0])
+            if rest_filename
+            else os.path.splitext(filename)[0]
+        )
         try:
-            output_logger.info('\n[*] Performing SecurityScorecard scan...')
-            securityscorecard_scanner = securityscorecard.SearchSecurityScorecard(word)
-            await securityscorecard_scanner.process(use_proxy)
+            xml_filename = report_base + '.xml'
+            async with await anyio.open_file(xml_filename, 'w+') as file:
+                await file.write('<?xml version="1.0" encoding="UTF-8"?><theHarvester>')
+                sanitized_args = [sanitize_for_xml(f'"{arg}"' if ' ' in arg else arg) for arg in sys.argv[1:]]
+                await file.write('<cmd>' + ' '.join(sanitized_args) + '</cmd>')
+                for email in all_emails:
+                    await file.write('<email>' + sanitize_for_xml(email) + '</email>')
+                for value in full:
+                    host, ip = value.split(':', 1) if ':' in value else (value, '')
+                    if ip and len(ip) > 3:
+                        await file.write(
+                            f'<host><ip>{sanitize_for_xml(ip)}</ip><hostname>{sanitize_for_xml(host)}</hostname></host>'
+                        )
+                    else:
+                        await file.write(f'<host>{sanitize_for_xml(host)}</host>')
+                for value in vhost:
+                    host, ip = value.split(':', 1) if ':' in value else (value, '')
+                    if ip and len(ip) > 3:
+                        await file.write(
+                            f'<vhost><ip>{sanitize_for_xml(ip)} </ip><hostname>{sanitize_for_xml(host)}</hostname></vhost>'
+                        )
+                    else:
+                        await file.write(f'<vhost>{sanitize_for_xml(host)}</vhost>')
+                await file.write(evidence_xml_fragment(completed_run_result))
+                await file.write('</theHarvester>')
+            output_logger.info('[*] XML File saved.')
+        except (OSError, ValueError, TypeError, UnicodeEncodeError) as error:
+            output_logger.info(f'[!] An error occurred while saving the XML file: {error}')
 
-            # Use the existing API to get results
-            hosts = await securityscorecard_scanner.get_hostnames()
-            if hosts:
-                output_logger.info(f'\n[*] SecurityScorecard results: {len(hosts)} hosts found')
-                for host in hosts:
-                    output_logger.info(f'    - {host}')
-
-                all_hosts.extend(hosts)
-
-            ips = await securityscorecard_scanner.get_ips()
-            if ips:
-                output_logger.info(f'\n[*] SecurityScorecard IPs found: {len(ips)}')
-                for ip in ips:
-                    output_logger.info(f'    - {ip}')
-                all_ip.extend(ips)
-
-        except Exception as e:
-            output_logger.info(f'An exception has occurred in SecurityScorecard scanning: {e}')
-
-    if 'builtwith' in engines:
         try:
-            output_logger.info('\n[*] Performing BuiltWith scan...')
-            builtwith_scanner = builtwith.SearchBuiltWith(word)
-            await builtwith_scanner.process(use_proxy)
-
-            hosts = await builtwith_scanner.get_hostnames()
-            if hosts:
-                output_logger.info(f'\n[*] BuiltWith results: {len(hosts)} hosts found')
-                for host in hosts:
-                    output_logger.info(f'    - {host}')
-
-                # Add results to the main host list
-                all_hosts.extend(hosts)
-
-            urls = list(await builtwith_scanner.get_interesting_urls())
-            if urls:
-                output_logger.info(f'\n[*] BuiltWith interesting URLs found: {len(urls)}')
-                for url in urls:
-                    output_logger.info(f'    - {url}')
-                interesting_urls.extend(urls)
-
-        except Exception as e:
-            if isinstance(e, MissingKey):
-                if not args.quiet:
-                    output_logger.info(MissingKey('BuiltWith'))
-                else:
-                    output_logger.info(f'An exception has occurred in BuiltWith scanning: {e}')
+            json_dict: dict[str, object] = {
+                'cmd': ' '.join(f'"{arg}"' if ' ' in arg else arg for arg in sys.argv[1:]),
+                'hosts': (full if dnsresolve is None or (final_dns_resolver_list and full) else all_hosts),
+                'shodan': shodanres,
+            }
+            optional_results = {
+                'ips': ip_list if 'ip_list' in locals() else all_ip,
+                'emails': all_emails,
+                'vhosts': vhost,
+                'interesting_urls': interesting_urls,
+                'trello_urls': all_urls,
+                'asns': total_asns,
+                'twitter_people': twitter_people_list_tracker,
+                'linkedin_people': linkedin_people_list_tracker,
+                'linkedin_links': linkedin_links_tracker,
+                'people': all_people,
+                'takeover_results': takeover_results if takeover_status else {},
+            }
+            json_dict.update({key: value for key, value in optional_results.items() if value})
+            json_dict = legacy_json_result(completed_run_result, json_dict)
+            async with await anyio.open_file(report_base + '.json', 'w+') as file:
+                await file.write(ujson.dumps(json_dict, sort_keys=True))
+            output_logger.info('[*] JSON File saved.')
+            async with await anyio.open_file(report_base + '.jsonl', 'w+') as file:
+                await file.write(run_result_jsonl(completed_run_result) + '\n')
+            output_logger.info('[*] JSONL File saved.')
+        except (OSError, ValueError, TypeError, UnicodeEncodeError) as error:
+            output_logger.info(f'[!] An error occurred while saving the JSON files: {error}')
+        output_logger.info('\n\n')
 
     if rest_args is not None:
         all_hosts = sorted({host.replace('www.', '') for host in all_hosts})
-        return (
+        response = (
             total_asns,
             interesting_urls,
             twitter_people_list_tracker,
@@ -1936,6 +1948,9 @@ async def start(rest_args: argparse.Namespace | None = None):
             all_emails,
             all_hosts,
         )
+        if not rest_args.source and rest_args.dns_brute and not return_evidence_run:
+            return resolved_pair
+        return (*response, completed_run_result) if return_evidence_run else response
     sys.exit(0)
 
 

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -438,7 +438,8 @@ async def start(rest_args: argparse.Namespace | None = None):
         run_result = await execute_run(word, tuple(evidence_sources))
         executions = {execution.source: execution for execution in run_result.source_executions}
         for evidence_source in evidence_sources:
-            if executions[evidence_source.name].status in (SourceStatus.SUCCEEDED, SourceStatus.EMPTY):
+            execution = executions[evidence_source.name]
+            if execution.status in (SourceStatus.SUCCEEDED, SourceStatus.EMPTY) or execution.observation_count:
                 await store(evidence_source.search, evidence_source.legacy_name, run_result)
 
     if args.source is not None:
@@ -646,7 +647,16 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'dnsdb':
                     try:
                         dnsdb_search = dnsdb.SearchDNSDB(word)
-                        stor_lst.append(store(dnsdb_search, engineitem))
+                        source_spec = get_source_spec(engineitem)
+                        evidence_sources.append(
+                            LegacyHostnameSource(
+                                name=source_spec.name,
+                                legacy_name='dnsdb',
+                                family=source_spec.family,
+                                search=dnsdb_search,
+                                proxy=use_proxy,
+                            )
+                        )
                     except MissingKey as e:
                         if not args.quiet:
                             output_logger.info(e)

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -573,11 +573,11 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 resolver_stack.push_async_callback(vantage.close)
             return await validate_run(result, DnsValidator(tuple(vantages)))
 
-    async def finish_run(
+    async def merge_validate_and_adapt_run(
         result: RunResult,
-        results: list[StageResult],
+        new_stage_results: list[StageResult],
     ) -> tuple[RunResult, tuple[list[str], list[str], list[str]] | None]:
-        result = await validate_completed_run(complete_run(result, results))
+        result = await validate_completed_run(complete_run(result, new_stage_results))
         return result, legacy_dns_results(result) if result.dns_validations else None
 
     if args.source is not None:
@@ -1501,7 +1501,7 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 )
             )
     provider_stage_count = len(stage_results)
-    completed_run_result, legacy_results = await finish_run(completed_run_result, stage_results)
+    completed_run_result, legacy_results = await merge_validate_and_adapt_run(completed_run_result, stage_results)
     if legacy_results is not None:
         full, all_hosts, validated_ips = legacy_results
         all_ip.extend(validated_ips)
@@ -1884,7 +1884,7 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
             output_logger.info('    Continuing with the rest of the scan...')
             traceback.print_exc()  # More detailed error information for developers
 
-    completed_run_result, legacy_results = await finish_run(
+    completed_run_result, legacy_results = await merge_validate_and_adapt_run(
         completed_run_result,
         stage_results[provider_stage_count:],
     )

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -573,6 +573,13 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 resolver_stack.push_async_callback(vantage.close)
             return await validate_run(result, DnsValidator(tuple(vantages)))
 
+    async def finish_run(
+        result: RunResult,
+        results: list[StageResult],
+    ) -> tuple[RunResult, tuple[list[str], list[str], list[str]] | None]:
+        result = await validate_completed_run(complete_run(result, results))
+        return result, legacy_dns_results(result) if result.dns_validations else None
+
     if args.source is not None:
         engines = Core.expand_source_selection(args.source)
         # Iterate through search engines in order
@@ -1494,10 +1501,9 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 )
             )
     provider_stage_count = len(stage_results)
-    completed_run_result = complete_run(completed_run_result, stage_results)
-    completed_run_result = await validate_completed_run(completed_run_result)
-    if completed_run_result.dns_validations:
-        full, all_hosts, validated_ips = legacy_dns_results(completed_run_result)
+    completed_run_result, legacy_results = await finish_run(completed_run_result, stage_results)
+    if legacy_results is not None:
+        full, all_hosts, validated_ips = legacy_results
         all_ip.extend(validated_ips)
     total_asns = sorted_unique(total_asns)
     interesting_urls = sorted_unique(interesting_urls)
@@ -1878,10 +1884,12 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
             output_logger.info('    Continuing with the rest of the scan...')
             traceback.print_exc()  # More detailed error information for developers
 
-    completed_run_result = complete_run(completed_run_result, stage_results[provider_stage_count:])
-    completed_run_result = await validate_completed_run(completed_run_result)
-    if completed_run_result.dns_validations:
-        full, all_hosts, validated_ips = legacy_dns_results(completed_run_result)
+    completed_run_result, legacy_results = await finish_run(
+        completed_run_result,
+        stage_results[provider_stage_count:],
+    )
+    if legacy_results is not None:
+        full, all_hosts, validated_ips = legacy_results
         all_ip.extend(validated_ips)
         ip_list = sorted(set([*ip_list, *validated_ips]))
     await SQLiteRunStore().save(completed_run_result)

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -370,22 +370,32 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
         started: float,
         findings: list[StageFinding] | tuple[StageFinding, ...] = (),
         error: Exception | None = None,
+        *,
+        source_family: str | None = None,
+        execution: Any | None = None,
+        is_action: bool = True,
     ) -> None:
         unique_findings = tuple(dict.fromkeys(findings))
         stage_results.append(
             StageResult(
                 source=source,
                 status=(
-                    SourceStatus.FAILED
+                    execution.status
+                    if execution is not None
+                    else SourceStatus.FAILED
                     if error is not None
                     else SourceStatus.SUCCEEDED
                     if unique_findings
                     else SourceStatus.EMPTY
                 ),
                 duration_ms=(time.perf_counter() - started) * 1000,
-                result_count=len(findings),
+                result_count=execution.result_count if execution is not None else len(findings),
                 findings=unique_findings,
-                error_type=type(error).__name__ if error is not None else None,
+                source_family=source_family,
+                error_type=(
+                    execution.error_type if execution is not None else type(error).__name__ if error is not None else None
+                ),
+                is_action=is_action,
             )
         )
 
@@ -524,24 +534,14 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 raise
             finally:
                 source_spec = get_source_spec(source)
-                stage_results.append(
-                    StageResult(
-                        source=source_spec.name,
-                        source_family=source_spec.family,
-                        status=(
-                            execution.status
-                            if execution is not None
-                            else SourceStatus.FAILED
-                            if error is not None
-                            else SourceStatus.SUCCEEDED
-                            if findings
-                            else SourceStatus.EMPTY
-                        ),
-                        duration_ms=(time.perf_counter() - started) * 1000,
-                        result_count=execution.result_count if execution is not None else len(findings),
-                        findings=tuple(dict.fromkeys(findings)),
-                        error_type=execution.error_type if execution is not None else type(error).__name__ if error else None,
-                    )
+                record_stage_result(
+                    source_spec.name,
+                    started,
+                    findings,
+                    error,
+                    source_family=source_spec.family,
+                    execution=execution,
+                    is_action=False,
                 )
 
         return run_stage()
@@ -1199,8 +1199,10 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                                         output_logger.info(f'Found Shodan data for {ip}')
                                     elif ip in result and isinstance(result[ip], str):
                                         output_logger.info(f'{ip}: {result[ip]}')
+                                        raise RuntimeError(result[ip])
                                 except Exception as e:
                                     output_logger.info(f'Error in Shodan search: {e}')
+                                    raise
 
                             async def get_hostnames(self):
                                 return list(self.hosts)
@@ -1604,16 +1606,19 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 # nameservers=list(map(str, dnsserver.split(','))) if dnsserver else None))
 
         # run all the reversing tasks concurrently
-        try:
-            await asyncio.gather(*__reverse_dns_tasks.values())
-            record_stage_result(
-                'action:dns-lookup',
-                stage_started,
-                [StageFinding(StageFindingKind.HOSTNAME, host) for host in dnsrev],
-            )
-        except Exception as error:
-            record_stage_result('action:dns-lookup', stage_started, error=error)
-            output_logger.info(f'[!] Reverse DNS lookup failed: {error}')
+        results = await asyncio.gather(*__reverse_dns_tasks.values(), return_exceptions=True)
+        for result in results:
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+        reverse_error = next((result for result in results if isinstance(result, Exception)), None)
+        record_stage_result(
+            'action:dns-lookup',
+            stage_started,
+            [StageFinding(StageFindingKind.HOSTNAME, host) for host in dnsrev],
+            reverse_error,
+        )
+        if reverse_error is not None:
+            output_logger.info(f'[!] Reverse DNS lookup failed: {reverse_error}')
 
     takeover_results = dict()
     # TakeOver Checking
@@ -1648,50 +1653,61 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
     screenshot_path = getattr(args, 'screenshot', '')
     if len(screenshot_path) > 0:
         stage_started = time.perf_counter()
-        screen_shotter = ScreenShotter(screenshot_path)
-        path_exists = screen_shotter.verify_path()
-        # Verify the path exists, if not create it or if user does not create it skips screenshot
-        if path_exists:
-            await screen_shotter.verify_installation()
-            output_logger.info(f'\nScreenshots can be found in: {screen_shotter.output}{screen_shotter.slash}')
-            start_time = time.perf_counter()
-            output_logger.info('Filtering domains for ones we can reach')
-            if dnsresolve is None or len(final_dns_resolver_list) > 0:
-                unique_resolved_domains = {url.split(':')[0] for url in full if ':' in url and 'www.' not in url}
-            else:
-                # Technically not resolved in this case, which is not ideal
-                # You should always use dns resolve when doing screenshotting
-                output_logger.info('NOTE for future use cases you should only use screenshotting in tandem with DNS resolving')
-                unique_resolved_domains = set(all_hosts)
-            if len(unique_resolved_domains) > 0:
-                # First filter out ones that didn't resolve
-                output_logger.info('Attempting to visit unique resolved domains, this is ACTIVE RECON')
-                async with Pool(10) as pool:
-                    results = await pool.map(screen_shotter.visit, list(unique_resolved_domains))
-                    # Filter out domains that we couldn't connect to
-                    unique_resolved_domains_list = list(sorted({tup[0] for tup in results if len(tup[1]) > 0}))
-                    screenshot_hosts.extend(unique_resolved_domains_list)
-                async with Pool(3) as pool:
-                    output_logger.info(f'Length of unique resolved domains: {len(unique_resolved_domains_list)} chunking now!\n')
-                    # If you have the resources, you could make the function faster by increasing the chunk number
-                    chunk_number = 14
-                    for chunk in screen_shotter.chunk_list(unique_resolved_domains_list, chunk_number):
-                        try:
-                            screenshot_tups.extend(await pool.map(screen_shotter.take_screenshot, chunk))
-                        except Exception as ee:
-                            output_logger.info(f'An exception has occurred while mapping: {ee}')
-            end = time.perf_counter()
-            # There is probably an easier way to do this
-            total = int(end - start_time)
-            mon, sec = divmod(total, 60)
-            hr, mon = divmod(mon, 60)
-            total_time = f'{mon:02d}:{sec:02d}'
-            output_logger.info(f'Finished taking screenshots in {total_time} seconds')
-            output_logger.info('[+] Note there may be leftover chrome processes you may have to kill manually\n')
+        screenshot_error: Exception | None = None
+        try:
+            screen_shotter = ScreenShotter(screenshot_path)
+            path_exists = screen_shotter.verify_path()
+            # Verify the path exists, if not create it or if user does not create it skips screenshot
+            if path_exists:
+                await screen_shotter.verify_installation()
+                output_logger.info(f'\nScreenshots can be found in: {screen_shotter.output}{screen_shotter.slash}')
+                start_time = time.perf_counter()
+                output_logger.info('Filtering domains for ones we can reach')
+                if dnsresolve is None or len(final_dns_resolver_list) > 0:
+                    unique_resolved_domains = {url.split(':')[0] for url in full if ':' in url and 'www.' not in url}
+                else:
+                    # Technically not resolved in this case, which is not ideal
+                    # You should always use dns resolve when doing screenshotting
+                    output_logger.info(
+                        'NOTE for future use cases you should only use screenshotting in tandem with DNS resolving'
+                    )
+                    unique_resolved_domains = set(all_hosts)
+                if len(unique_resolved_domains) > 0:
+                    # First filter out ones that didn't resolve
+                    output_logger.info('Attempting to visit unique resolved domains, this is ACTIVE RECON')
+                    async with Pool(10) as pool:
+                        results = await pool.map(screen_shotter.visit, list(unique_resolved_domains))
+                        # Filter out domains that we couldn't connect to
+                        unique_resolved_domains_list = list(sorted({tup[0] for tup in results if len(tup[1]) > 0}))
+                    async with Pool(3) as pool:
+                        output_logger.info(
+                            f'Length of unique resolved domains: {len(unique_resolved_domains_list)} chunking now!\n'
+                        )
+                        # If you have the resources, you could make the function faster by increasing the chunk number
+                        chunk_number = 14
+                        for chunk in screen_shotter.chunk_list(unique_resolved_domains_list, chunk_number):
+                            try:
+                                screenshot_tups.extend(await pool.map(screen_shotter.take_screenshot, chunk))
+                                screenshot_hosts.extend(chunk)
+                            except Exception as ee:
+                                screenshot_error = ee
+                                output_logger.info(f'An exception has occurred while mapping: {ee}')
+                end = time.perf_counter()
+                # There is probably an easier way to do this
+                total = int(end - start_time)
+                mon, sec = divmod(total, 60)
+                hr, mon = divmod(mon, 60)
+                total_time = f'{mon:02d}:{sec:02d}'
+                output_logger.info(f'Finished taking screenshots in {total_time} seconds')
+                output_logger.info('[+] Note there may be leftover chrome processes you may have to kill manually\n')
+        except Exception as error:
+            screenshot_error = error
+            output_logger.info(f'[!] Screenshot stage failed: {error}')
         record_stage_result(
             'action:screenshot',
             stage_started,
             [StageFinding(StageFindingKind.SCREENSHOT, host) for host in screenshot_hosts],
+            screenshot_error,
         )
 
     # Shodan
@@ -1712,6 +1728,7 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                     # Check if the result is a string (error message)
                     if isinstance(shodandict[ip], str):
                         output_logger.info(f'{ip}: {shodandict[ip]}')
+                        shodan_errors.append(RuntimeError(shodandict[ip]))
                         continue
 
                     # Process the results if it's a dictionary
@@ -1730,8 +1747,6 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                                 ip,
                             )
                         )
-                        output_logger.info(ujson.dumps(shodandict[ip], indent=4, sort_keys=True))
-                        output_logger.info('\n')
                 except Exception as ip_error:
                     shodan_errors.append(ip_error)
                     output_logger.info(f'[SHODAN-error] Error searching {ip}: {ip_error}')
@@ -1790,37 +1805,13 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
             api_scanner = api_endpoints.SearchApiEndpoints(word=args.domain, wordlist=wordlist)
             await api_scanner.do_search()
 
-            # Print results
             endpoints_found = api_scanner.get_found_endpoints()
-            output_logger.info(f'\n[*] API Endpoints found: {len(endpoints_found)}')
-            for endpoint in endpoints_found:
-                output_logger.info(f'    - {endpoint}')
-
             interesting_endpoints = api_scanner.get_interesting_endpoints()
-            output_logger.info(f'\n[*] Interesting endpoints (200, 201, 202): {len(interesting_endpoints)}')
-            for endpoint in interesting_endpoints:
-                output_logger.info(f'    - {endpoint}')
-
             auth_required = api_scanner.get_auth_required()
-            output_logger.info(f'\n[*] Endpoints requiring authentication: {len(auth_required)}')
-            for endpoint in auth_required:
-                output_logger.info(f'    - {endpoint}')
-
             api_versions = api_scanner.get_api_versions()
-            output_logger.info(f'\n[*] Detected API versions: {len(api_versions)}')
-            for version in api_versions:
-                output_logger.info(f'    - {version}')
-
             rate_limits = api_scanner.get_rate_limits()
-            output_logger.info(f'\n[*] Rate limited endpoints: {len(rate_limits)}')
-            for endpoint, info in rate_limits.items():
-                output_logger.info(f'    - {endpoint} ({info.method})')
-
             methods = api_scanner.get_methods()
-            output_logger.info(f'\n[*] HTTP methods used: {", ".join(methods)}')
-
             status_codes = api_scanner.get_status_codes()
-            output_logger.info(f'\n[*] HTTP status codes encountered: {", ".join(map(str, status_codes))}')
 
             # Add results to storage
             db = stash.StashManager()
@@ -1846,8 +1837,25 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 'action:api-scan',
                 stage_started,
                 [
-                    StageFinding(StageFindingKind.API_ENDPOINT, endpoint, str(result.status_code))
-                    for endpoint, result in endpoints_found.items()
+                    *(
+                        StageFinding(StageFindingKind.API_ENDPOINT, endpoint, str(result.status_code))
+                        for endpoint, result in endpoints_found.items()
+                    ),
+                    *(
+                        StageFinding(StageFindingKind.INTERESTING_URL, endpoint, str(result.status_code))
+                        for endpoint, result in interesting_endpoints.items()
+                    ),
+                    *(
+                        StageFinding(StageFindingKind.API_AUTH_REQUIRED, endpoint, str(result.status_code))
+                        for endpoint, result in auth_required.items()
+                    ),
+                    *(StageFinding(StageFindingKind.API_VERSION, version) for version in sorted(api_versions)),
+                    *(
+                        StageFinding(StageFindingKind.API_RATE_LIMIT, endpoint, result.method)
+                        for endpoint, result in rate_limits.items()
+                    ),
+                    *(StageFinding(StageFindingKind.HTTP_METHOD, method) for method in sorted(methods)),
+                    *(StageFinding(StageFindingKind.HTTP_STATUS_CODE, str(status_code)) for status_code in sorted(status_codes)),
                 ],
             )
             output_logger.info('\n[+] API scanning completed successfully.')
@@ -1936,6 +1944,8 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
         output_logger.info('\n\n')
 
     if rest_args is not None:
+        if not rest_args.source and rest_args.dns_brute:
+            return (resolved_pair, completed_run_result) if return_evidence_run else resolved_pair
         all_hosts = sorted({host.replace('www.', '') for host in all_hosts})
         response = (
             total_asns,
@@ -1948,8 +1958,6 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
             all_emails,
             all_hosts,
         )
-        if not rest_args.source and rest_args.dns_brute and not return_evidence_run:
-            return resolved_pair
         return (*response, completed_run_result) if return_evidence_run else response
     sys.exit(0)
 

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -619,8 +619,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                             LegacyHostnameSource(
                                 name=source_spec.name,
                                 legacy_name='CRTsh',
-                                # ponytail: move families into SourceSpec when a second evidence source migrates.
-                                family='certificate-transparency',
+                                family=source_spec.family,
                                 search=crtsh_search,
                                 proxy=use_proxy,
                             )

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -104,6 +104,7 @@ from theHarvester.lib.run import (
     execute_run,
     legacy_dns_results,
     legacy_hostnames,
+    validate_run,
 )
 from theHarvester.lib.source_catalog import ResultRoute, get_source_spec
 from theHarvester.screenshot.screenshot import ScreenShotter
@@ -440,7 +441,9 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 else:
                     host_names = list(_normalize_hosts_for_storage(discovered_hosts, word))
             if not has_dns_validation:
-                if source != 'hackertarget' and source != 'pentesttools' and source != 'rapiddns':
+                if len(final_dns_resolver_list) == 3:
+                    full.extend(host_names)
+                elif source != 'hackertarget' and source != 'pentesttools' and source != 'rapiddns':
                     # If a source is inside this conditional, it means the hosts returned must be resolved to obtain ip
                     # This should only be checked if --dns-resolve has a wordlist
                     if dnsresolve is None or len(final_dns_resolver_list) > 0:
@@ -551,26 +554,24 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
 
     async def store_evidence_sources() -> None:
         nonlocal completed_run_result
+        run_result = await execute_run(word, tuple(evidence_sources))
+        completed_run_result = run_result
+        executions = {execution.source: execution for execution in run_result.source_executions}
+        for evidence_source in evidence_sources:
+            execution = executions[evidence_source.name]
+            if execution.status in (SourceStatus.SUCCEEDED, SourceStatus.EMPTY) or execution.observation_count:
+                await store(evidence_source.search, evidence_source.legacy_name, run_result)
+
+    async def validate_completed_run(result: RunResult) -> RunResult:
+        if len(final_dns_resolver_list) != 3 or not any(entity.addressability is None for entity in result.entities):
+            return result
         async with AsyncExitStack() as resolver_stack:
-            dns_validator = None
-            if len(final_dns_resolver_list) == 3:
-                vantages = []
-                for nameserver in final_dns_resolver_list:
-                    vantage = AioDnsResolverVantage(nameserver)
-                    vantages.append(vantage)
-                    resolver_stack.push_async_callback(vantage.close)
-                dns_validator = DnsValidator(tuple(vantages))
-            run_result = (
-                await execute_run(word, tuple(evidence_sources), dns_validator=dns_validator)
-                if dns_validator is not None
-                else await execute_run(word, tuple(evidence_sources))
-            )
-            completed_run_result = run_result
-            executions = {execution.source: execution for execution in run_result.source_executions}
-            for evidence_source in evidence_sources:
-                execution = executions[evidence_source.name]
-                if execution.status in (SourceStatus.SUCCEEDED, SourceStatus.EMPTY) or execution.observation_count:
-                    await store(evidence_source.search, evidence_source.legacy_name, run_result)
+            vantages = []
+            for nameserver in final_dns_resolver_list:
+                vantage = AioDnsResolverVantage(nameserver)
+                vantages.append(vantage)
+                resolver_stack.push_async_callback(vantage.close)
+            return await validate_run(result, DnsValidator(tuple(vantages)))
 
     if args.source is not None:
         engines = Core.expand_source_selection(args.source)
@@ -1492,6 +1493,12 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                     error_type='SourceDidNotStart',
                 )
             )
+    provider_stage_count = len(stage_results)
+    completed_run_result = complete_run(completed_run_result, stage_results)
+    completed_run_result = await validate_completed_run(completed_run_result)
+    if completed_run_result.dns_validations:
+        full, all_hosts, validated_ips = legacy_dns_results(completed_run_result)
+        all_ip.extend(validated_ips)
     total_asns = sorted_unique(total_asns)
     interesting_urls = sorted_unique(interesting_urls)
     twitter_people_list_tracker = sorted_unique(twitter_people_list_tracker)
@@ -1871,7 +1878,12 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
             output_logger.info('    Continuing with the rest of the scan...')
             traceback.print_exc()  # More detailed error information for developers
 
-    completed_run_result = complete_run(completed_run_result, stage_results)
+    completed_run_result = complete_run(completed_run_result, stage_results[provider_stage_count:])
+    completed_run_result = await validate_completed_run(completed_run_result)
+    if completed_run_result.dns_validations:
+        full, all_hosts, validated_ips = legacy_dns_results(completed_run_result)
+        all_ip.extend(validated_ips)
+        ip_list = sorted(set([*ip_list, *validated_ips]))
     await SQLiteRunStore().save(completed_run_result)
     output_logger.info(format_run_terminal(completed_run_result))
 

--- a/theHarvester/discovery/crtsh.py
+++ b/theHarvester/discovery/crtsh.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 from theHarvester.lib.core import AsyncFetcher
+from theHarvester.lib.run import SourceIncompleteError
 
 logger = logging.getLogger(__name__)
 
@@ -27,15 +28,16 @@ class SearchCrtsh:
                     await asyncio.sleep(2)
 
             if response is None:
-                logger.info(f'No valid response from crt.sh after {max_attempts} attempts.')
-                return []
+                raise SourceIncompleteError(f'No valid response from crt.sh after {max_attempts} attempts.')
 
             data = set([(dct['name_value'][2:] if dct['name_value'][:2] == '*.' else dct['name_value']) for dct in response])
             data = {domain for domain in data if (domain[0] != '*' and str(domain[0:4]).isnumeric() is False)}
-        except KeyError as ke:
-            logger.info(f'Missing expected key in response: {ke}')
-        except Exception as e:
-            logger.info(f'Unexpected error: {e}')
+        except SourceIncompleteError:
+            raise
+        except KeyError as error:
+            raise SourceIncompleteError(f'Missing expected key in crt.sh response: {error}') from error
+        except Exception as error:
+            raise SourceIncompleteError(f'Unexpected crt.sh error: {error}') from error
         clean: list = []
         for x in data:
             pre = x.split()

--- a/theHarvester/discovery/crtsh.py
+++ b/theHarvester/discovery/crtsh.py
@@ -14,7 +14,6 @@ class SearchCrtsh:
         self.proxy = False
 
     async def do_search(self) -> list:
-        data: set = set()
         url = f'https://crt.sh/?q=%25.{self.word}&exclude=expired&deduplicate=Y&output=json'
         response = None
         try:
@@ -30,20 +29,19 @@ class SearchCrtsh:
             if response is None:
                 raise SourceIncompleteError(f'No valid response from crt.sh after {max_attempts} attempts.')
 
-            data = set([(dct['name_value'][2:] if dct['name_value'][:2] == '*.' else dct['name_value']) for dct in response])
-            data = {domain for domain in data if (domain[0] != '*' and str(domain[0:4]).isnumeric() is False)}
+            clean: set[str] = set()
+            for item in response:
+                for name in item['name_value'].split():
+                    name = name.removeprefix('*.')
+                    if name and not name.startswith('*') and not name[:4].isnumeric():
+                        clean.add(name)
         except SourceIncompleteError:
             raise
         except KeyError as error:
             raise SourceIncompleteError(f'Missing expected key in crt.sh response: {error}') from error
         except Exception as error:
             raise SourceIncompleteError(f'Unexpected crt.sh error: {error}') from error
-        clean: list = []
-        for x in data:
-            pre = x.split()
-            for y in pre:
-                clean.append(y)
-        return clean
+        return list(clean)
 
     async def process(self, proxy: bool = False) -> None:
         self.proxy = proxy

--- a/theHarvester/discovery/dnsdb.py
+++ b/theHarvester/discovery/dnsdb.py
@@ -9,6 +9,7 @@ import aiohttp
 from theHarvester import __version__
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib.core import AsyncFetcher, Core
+from theHarvester.lib.run import SourceFinding, SourceIncompleteError, SourceRateLimitedError
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,9 @@ class SearchDNSDB:
             return hostname
         return None
 
+    def _partial_findings(self) -> tuple[SourceFinding, ...]:
+        return tuple(SourceFinding(hostname) for hostname in sorted(self.totalhosts))
+
     async def do_search(self) -> None:
         query = quote(f'*.{self.target_domain}', safe='*.')
         url = f'{self.BASE_URL}/{query}?limit=0'
@@ -59,7 +63,7 @@ class SearchDNSDB:
         async with await AsyncFetcher._build_session(headers, timeout, proxy_url, proxy_type) as session:
             async with session.get(url, proxy=proxy_url if proxy_type == 'http' else None) as response:
                 if response.status == 429:
-                    raise ConnectionError('DNSDB rate limit reached')
+                    raise SourceRateLimitedError('DNSDB rate limit reached')
                 if response.status in {401, 403}:
                     raise PermissionError('DNSDB authentication failed')
                 if response.status == 503:
@@ -72,28 +76,43 @@ class SearchDNSDB:
                     try:
                         record = json.loads(line)
                     except (UnicodeDecodeError, json.JSONDecodeError):
-                        logger.info('DNSDB returned malformed NDJSON; partial results were preserved.')
-                        return
+                        message = 'DNSDB returned malformed NDJSON; partial results were preserved.'
+                        logger.info(message)
+                        raise SourceIncompleteError(message, findings=self._partial_findings())
                     if not isinstance(record, dict):
-                        logger.info('DNSDB returned an invalid stream record; partial results were preserved.')
-                        return
+                        message = 'DNSDB returned an invalid stream record; partial results were preserved.'
+                        logger.info(message)
+                        raise SourceIncompleteError(message, findings=self._partial_findings())
                     if first_record:
                         first_record = False
                         if record.get('cond') != 'begin':
-                            logger.info('DNSDB stream did not begin correctly; no results were accepted.')
-                            return
+                            message = 'DNSDB stream did not begin correctly; no results were accepted.'
+                            logger.info(message)
+                            raise SourceIncompleteError(message)
                         continue
 
                     condition = record.get('cond')
                     if condition in {'succeeded', 'limited', 'failed'}:
-                        if condition != 'succeeded':
-                            logger.info(f'DNSDB stream ended with {condition}; partial results were preserved.')
+                        if condition == 'limited':
+                            message = 'DNSDB stream ended with limited; partial results were preserved.'
+                            logger.info(message)
+                            raise SourceRateLimitedError(message, findings=self._partial_findings())
+                        if condition == 'failed':
+                            message = 'DNSDB stream ended with failed; partial results were preserved.'
+                            logger.info(message)
+                            raise SourceIncompleteError(message, findings=self._partial_findings())
                         return
                     obj = record.get('obj')
-                    if isinstance(obj, dict) and (hostname := self._hostname(obj.get('rrname'))):
+                    if not isinstance(obj, dict) or not isinstance(obj.get('rrname'), str):
+                        message = 'DNSDB returned an invalid stream record; partial results were preserved.'
+                        logger.info(message)
+                        raise SourceIncompleteError(message, findings=self._partial_findings())
+                    if hostname := self._hostname(obj['rrname']):
                         self.totalhosts.add(hostname)
 
-                logger.info('DNSDB stream ended without a terminal condition; partial results were preserved.')
+                message = 'DNSDB stream ended without a terminal condition; partial results were preserved.'
+                logger.info(message)
+                raise SourceIncompleteError(message, findings=self._partial_findings())
 
     async def get_hostnames(self) -> set[str]:
         return self.totalhosts
@@ -103,4 +122,6 @@ class SearchDNSDB:
         try:
             await self.do_search()
         except (aiohttp.ClientError, TimeoutError) as error:
-            logger.info(f'DNSDB request failed with {type(error).__name__}; partial results were preserved.')
+            message = f'DNSDB request failed with {type(error).__name__}; partial results were preserved.'
+            logger.info(message)
+            raise SourceIncompleteError(message, findings=self._partial_findings()) from error

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -17,6 +17,7 @@ from starlette.staticfiles import StaticFiles
 
 from theHarvester import __main__
 from theHarvester.lib.api.additional_endpoints import router as additional_router
+from theHarvester.lib.output import legacy_json_result
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +48,7 @@ class QueryResponse(BaseModel):
     ips: list[str] = Field(default_factory=list, description='List of IPs')
     emails: list[str] = Field(default_factory=list, description='List of emails')
     hosts: list[str] = Field(default_factory=list, description='List of hosts')
+    evidence_run: dict[str, Any] | None = Field(None, description='Completed evidence run summary')
 
 
 class ErrorResponse(BaseModel):
@@ -340,6 +342,7 @@ async def query(
             aips,
             aemails,
             ahosts,
+            evidence_run,
         ) = await __main__.start(
             argparse.Namespace(
                 dns_brute=dns_brute,
@@ -358,23 +361,23 @@ async def query(
                 dns_resolve=dns_resolve,
                 quiet=False,
                 screenshot='',
-            )
+            ),
+            return_evidence_run=True,
         )
 
         # Return the results using the Pydantic model
-        return JSONResponse(
-            {
-                'asns': asns,
-                'interesting_urls': iurls,
-                'twitter_people': twitter_people_list,
-                'linkedin_people': linkedin_people_list,
-                'linkedin_links': linkedin_links,
-                'trello_urls': aurls,
-                'ips': aips,
-                'emails': aemails,
-                'hosts': ahosts,
-            }
-        )
+        response_data = {
+            'asns': asns,
+            'interesting_urls': iurls,
+            'twitter_people': twitter_people_list,
+            'linkedin_people': linkedin_people_list,
+            'linkedin_links': linkedin_links,
+            'trello_urls': aurls,
+            'ips': aips,
+            'emails': aemails,
+            'hosts': ahosts,
+        }
+        return JSONResponse(legacy_json_result(evidence_run, response_data))
     except HTTPException as e:
         # Re-raise HTTP exceptions
         raise e

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -201,6 +201,7 @@ async def getsources(request: Request) -> Response:
 # Define Pydantic model for DNS brute force response
 class DnsBruteResponse(BaseModel):
     dns_bruteforce: list[str] = Field(default_factory=list, description='List of DNS brute force results')
+    evidence_run: dict[str, Any] | None = None
 
 
 @app.get(
@@ -237,7 +238,7 @@ async def dnsbrute(
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Domain must be at least 3 characters long')
 
         # Call the main function with the provided parameters
-        dns_bruteforce = await __main__.start(
+        dns_bruteforce, evidence_run = await __main__.start(
             argparse.Namespace(
                 dns_brute=True,
                 dns_lookup=False,
@@ -255,10 +256,17 @@ async def dnsbrute(
                 wordlist='',
                 api_scan=False,
                 dns_resolve=dns_resolve,
-            )
+            ),
+            return_evidence_run=True,
         )
 
-        return JSONResponse({'dns_bruteforce': dns_bruteforce})
+        adapted = legacy_json_result(evidence_run, {'dns_bruteforce': dns_bruteforce})
+        return JSONResponse(
+            {
+                'dns_bruteforce': dns_bruteforce,
+                'evidence_run': adapted['evidence_run'],
+            }
+        )
 
     except HTTPException as e:
         # Re-raise HTTP exceptions

--- a/theHarvester/lib/dns_validation.py
+++ b/theHarvester/lib/dns_validation.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Protocol
+from uuid import uuid4
+
+import aiodns
+
+from theHarvester.lib.hostnames import normalize_hostname, normalize_scoped_hostname
+
+_RESOLVER_COUNT = 3
+_RESOLVER_QUORUM = 2
+_PROBES_PER_DEPTH = 3
+_DEFAULT_QUERY_TIMEOUT_SECONDS = 10.0
+
+
+class Addressability(StrEnum):
+    CURRENT = 'currently-addressable'
+    NOT_CURRENT = 'not-currently-addressable'
+    RESOLVER_DISPUTED = 'resolver-disputed'
+    WILDCARD_INDISTINGUISHABLE = 'wildcard-indistinguishable'
+
+
+@dataclass(frozen=True)
+class DnsResponse:
+    ipv4: tuple[str, ...] = ()
+    ipv6: tuple[str, ...] = ()
+    cnames: tuple[str, ...] = ()
+    rcode: str = 'NOERROR'
+    ttl: int | None = None
+    cname_chain: tuple[str, ...] = ()
+    error: str | None = None
+
+
+class ResolverVantage(Protocol):
+    name: str
+
+    async def query(self, hostname: str) -> DnsResponse: ...
+
+
+class AioDnsResolverVantage:
+    def __init__(self, nameserver: str) -> None:
+        self.name = nameserver
+        self._resolver = aiodns.DNSResolver(nameservers=[nameserver])
+
+    async def query(self, hostname: str) -> DnsResponse:
+        record_types = ('A', 'AAAA', 'CNAME')
+        ipv4: set[str] = set()
+        ipv6: set[str] = set()
+        cnames: list[str] = []
+        ttls: list[int] = []
+        dns_error_codes: list[int] = []
+        errors: list[str] = []
+        successful_query = False
+        query_name = normalize_hostname(hostname)
+        if query_name is None:
+            return DnsResponse(rcode='ERROR', error='invalid hostname')
+
+        results = await asyncio.gather(
+            *(self._resolver.query_dns(query_name, record_type) for record_type in record_types),
+            return_exceptions=True,
+        )
+        for result in results:
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            if isinstance(result, aiodns.error.DNSError):
+                code = result.args[0]
+                dns_error_codes.append(code)
+                if code not in {aiodns.error.ARES_ENOTFOUND, aiodns.error.ARES_ENODATA}:
+                    errors.append(f'{type(result).__name__}: {result}')
+                continue
+            if isinstance(result, BaseException):
+                raise result
+            successful_query = True
+            for record in result.answer:
+                if (ttl := getattr(record, 'ttl', None)) is not None:
+                    ttls.append(ttl)
+                if (address := getattr(record.data, 'addr', None)) is not None:
+                    try:
+                        parsed = ipaddress.ip_address(address)
+                    except ValueError:
+                        errors.append(f'invalid address: {address}')
+                    else:
+                        (ipv4 if parsed.version == 4 else ipv6).add(str(parsed))
+                if (cname := getattr(record.data, 'cname', None)) is not None:
+                    if (normalized := normalize_hostname(cname)) is not None and normalized not in cnames:
+                        cnames.append(normalized)
+
+        if successful_query:
+            rcode = 'NOERROR'
+        elif dns_error_codes and all(code == aiodns.error.ARES_ENOTFOUND for code in dns_error_codes):
+            rcode = 'NXDOMAIN'
+        elif dns_error_codes and all(
+            code in {aiodns.error.ARES_ENOTFOUND, aiodns.error.ARES_ENODATA} for code in dns_error_codes
+        ):
+            rcode = 'NODATA'
+        else:
+            rcode = 'ERROR'
+        return DnsResponse(
+            ipv4=tuple(sorted(ipv4)),
+            ipv6=tuple(sorted(ipv6)),
+            cnames=tuple(cnames),
+            rcode=rcode,
+            ttl=min(ttls, default=None),
+            cname_chain=tuple(cnames),
+            error='; '.join(errors) or None,
+        )
+
+    async def close(self) -> None:
+        await self._resolver.close()
+
+
+@dataclass(frozen=True)
+class DnsValidationObservation:
+    run_id: str
+    candidate: str | None
+    query_name: str
+    resolver: str
+    queried_at: datetime
+    ipv4: tuple[str, ...]
+    ipv6: tuple[str, ...]
+    cnames: tuple[str, ...]
+    rcode: str
+    ttl: int | None
+    cname_chain: tuple[str, ...]
+    latency_ms: float
+    error: str | None
+    is_wildcard_control: bool = False
+    wildcard_depth: str | None = None
+
+
+@dataclass(frozen=True)
+class CandidateClassification:
+    candidate: str
+    addressability: Addressability
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    observations: tuple[DnsValidationObservation, ...]
+    classifications: tuple[CandidateClassification, ...]
+
+
+def _normalize_response(response: DnsResponse) -> DnsResponse:
+    return DnsResponse(
+        ipv4=tuple(sorted({str(ipaddress.IPv4Address(value)) for value in response.ipv4})),
+        ipv6=tuple(sorted({str(ipaddress.IPv6Address(value)) for value in response.ipv6})),
+        cnames=tuple(sorted(normalized for value in response.cnames if (normalized := normalize_hostname(value)) is not None)),
+        rcode=response.rcode.upper(),
+        ttl=response.ttl,
+        cname_chain=tuple(normalized for value in response.cname_chain if (normalized := normalize_hostname(value)) is not None),
+        error=response.error,
+    )
+
+
+def _wildcard_depths(target: str, candidate: str) -> tuple[str, ...]:
+    target_labels = target.split('.')
+    candidate_labels = candidate.split('.')
+    extra_labels = len(candidate_labels) - len(target_labels)
+    return (target, *('.'.join(candidate_labels[index:]) for index in range(extra_labels - 1, 0, -1)))
+
+
+def _has_dns_evidence(observation: DnsValidationObservation) -> bool:
+    return bool(observation.ipv4 or observation.ipv6 or observation.cnames or observation.cname_chain)
+
+
+def _signature(observation: DnsValidationObservation) -> tuple[object, ...]:
+    return (
+        observation.rcode,
+        observation.ipv4,
+        observation.ipv6,
+        observation.cnames,
+        observation.cname_chain,
+    )
+
+
+def _record_presence_signature(observation: DnsValidationObservation) -> tuple[object, ...]:
+    return (
+        observation.rcode,
+        bool(observation.ipv4),
+        bool(observation.ipv6),
+        bool(observation.cnames or observation.cname_chain),
+    )
+
+
+def _overlaps_wildcard(
+    candidate_observations: tuple[DnsValidationObservation, ...],
+    controls: tuple[DnsValidationObservation, ...],
+) -> bool:
+    candidate_evidence = tuple(observation for observation in candidate_observations if _has_dns_evidence(observation))
+    control_evidence = tuple(observation for observation in controls if _has_dns_evidence(observation))
+    if not candidate_evidence or not control_evidence:
+        return False
+    signatures = {_signature(observation) for observation in control_evidence}
+    if any(_signature(observation) in signatures for observation in candidate_evidence):
+        return True
+    return len(signatures) > 1 and any(
+        _record_presence_signature(observation) in {_record_presence_signature(control) for control in control_evidence}
+        for observation in candidate_evidence
+    )
+
+
+def _classify(
+    candidate_observations: tuple[DnsValidationObservation, ...],
+    controls: tuple[DnsValidationObservation, ...],
+    *,
+    deterministic_exact: bool,
+) -> Addressability:
+    if not deterministic_exact and _overlaps_wildcard(candidate_observations, controls):
+        return Addressability.WILDCARD_INDISTINGUISHABLE
+    addressable = sum(
+        observation.rcode == 'NOERROR' and bool(observation.ipv4 or observation.ipv6) for observation in candidate_observations
+    )
+    not_addressable = sum(
+        observation.error is None
+        and not observation.ipv4
+        and not observation.ipv6
+        and observation.rcode in {'NOERROR', 'NXDOMAIN', 'NODATA'}
+        for observation in candidate_observations
+    )
+    if addressable >= _RESOLVER_QUORUM:
+        return Addressability.CURRENT
+    if not_addressable >= _RESOLVER_QUORUM:
+        return Addressability.NOT_CURRENT
+    return Addressability.RESOLVER_DISPUTED
+
+
+class DnsValidator:
+    def __init__(
+        self,
+        vantages: tuple[ResolverVantage, ...],
+        *,
+        timeout_seconds: float = _DEFAULT_QUERY_TIMEOUT_SECONDS,
+    ) -> None:
+        if len(vantages) != _RESOLVER_COUNT or len({vantage.name for vantage in vantages}) != _RESOLVER_COUNT:
+            raise ValueError('DNS validation requires exactly three distinct resolver vantages')
+        if timeout_seconds <= 0:
+            raise ValueError('DNS validation timeout must be positive')
+        self.vantages = vantages
+        self.timeout_seconds = timeout_seconds
+
+    async def _query(
+        self,
+        run_id: str,
+        query_name: str,
+        *,
+        candidate: str | None = None,
+        wildcard_depth: str | None = None,
+    ) -> tuple[DnsValidationObservation, ...]:
+        async def query(vantage: ResolverVantage) -> DnsValidationObservation:
+            queried_at = datetime.now(UTC)
+            started = time.perf_counter()
+            try:
+                async with asyncio.timeout(self.timeout_seconds):
+                    response = _normalize_response(await vantage.query(query_name))
+            except Exception as error:
+                response = DnsResponse(rcode='ERROR', error=f'{type(error).__name__}: {error}')
+            return DnsValidationObservation(
+                run_id=run_id,
+                candidate=candidate,
+                query_name=query_name,
+                resolver=vantage.name,
+                queried_at=queried_at,
+                ipv4=response.ipv4,
+                ipv6=response.ipv6,
+                cnames=response.cnames,
+                rcode=response.rcode,
+                ttl=response.ttl,
+                cname_chain=response.cname_chain,
+                latency_ms=(time.perf_counter() - started) * 1000,
+                error=response.error,
+                is_wildcard_control=wildcard_depth is not None,
+                wildcard_depth=wildcard_depth,
+            )
+
+        return tuple(await asyncio.gather(*(query(vantage) for vantage in self.vantages)))
+
+    async def validate(
+        self,
+        run_id: str,
+        target: str,
+        candidates: tuple[str, ...],
+        *,
+        deterministic_exact_names: tuple[str, ...] = (),
+    ) -> ValidationResult:
+        """Trust deterministic_exact_names only as caller-supplied exact-node evidence."""
+        normalized_target = normalize_hostname(target)
+        if normalized_target is None:
+            raise ValueError('target must be a hostname')
+        normalized_candidates = tuple(
+            dict.fromkeys(
+                normalized
+                for candidate in candidates
+                if (normalized := normalize_scoped_hostname(candidate, normalized_target)) is not None
+                and normalized != normalized_target
+            )
+        )
+        normalized_deterministic_exact_names = {
+            normalized
+            for name in deterministic_exact_names
+            if (normalized := normalize_scoped_hostname(name, normalized_target)) is not None
+        }
+
+        candidate_observations: dict[str, tuple[DnsValidationObservation, ...]] = {}
+        observations: list[DnsValidationObservation] = []
+        for candidate in normalized_candidates:
+            candidate_observations[candidate] = await self._query(run_id, candidate, candidate=candidate)
+            observations.extend(candidate_observations[candidate])
+
+        depths = tuple(
+            dict.fromkeys(
+                depth for candidate in normalized_candidates for depth in _wildcard_depths(normalized_target, candidate)
+            )
+        )
+        controls_by_depth: dict[str, list[DnsValidationObservation]] = {depth: [] for depth in depths}
+        for depth in depths:
+            for _ in range(_PROBES_PER_DEPTH):
+                query_name = f'th-{uuid4().hex}.{depth}'
+                controls = await self._query(run_id, query_name, wildcard_depth=depth)
+                controls_by_depth[depth].extend(controls)
+                observations.extend(controls)
+
+        classifications = []
+        for candidate in normalized_candidates:
+            closest_depth = _wildcard_depths(normalized_target, candidate)[-1]
+            classifications.append(
+                CandidateClassification(
+                    candidate,
+                    _classify(
+                        candidate_observations[candidate],
+                        tuple(controls_by_depth[closest_depth]),
+                        deterministic_exact=candidate in normalized_deterministic_exact_names,
+                    ),
+                )
+            )
+        return ValidationResult(tuple(observations), tuple(classifications))

--- a/theHarvester/lib/hostchecker.py
+++ b/theHarvester/lib/hostchecker.py
@@ -40,7 +40,9 @@ class Checker:
         try:
             # TODO add check for ipv6 addrs as well
             result = await resolver.getaddrinfo(host, socket.AF_INET)
-            addresses_list: list[str] = [r.addr[0] for r in result.nodes]
+            addresses_list = [
+                address.decode('ascii') if isinstance(address, bytes) else address for r in result.nodes if (address := r.addr[0])
+            ]
             if addresses_list == [] or addresses_list is None or result is None:
                 return f'{host}:'
             else:

--- a/theHarvester/lib/hostnames.py
+++ b/theHarvester/lib/hostnames.py
@@ -1,10 +1,18 @@
-def normalize_scoped_hostname(value: object, target: str) -> str | None:
-    """Return a canonical hostname when value is inside the target boundary."""
+def normalize_hostname(value: object) -> str | None:
+    """Return a canonical hostname, or None when the value is unusable."""
     if not isinstance(value, str):
         return None
     hostname = value.strip().lower().rstrip('.')
-    normalized_target = target.strip().lower().rstrip('.')
-    if not normalized_target:
+    if not hostname:
+        return None
+    return hostname
+
+
+def normalize_scoped_hostname(value: object, target: str) -> str | None:
+    """Return a canonical hostname when value is inside the target boundary."""
+    hostname = normalize_hostname(value)
+    normalized_target = normalize_hostname(target)
+    if hostname is None or normalized_target is None:
         return None
     if hostname == normalized_target or hostname.endswith(f'.{normalized_target}'):
         return hostname

--- a/theHarvester/lib/output.py
+++ b/theHarvester/lib/output.py
@@ -230,7 +230,9 @@ def legacy_json_result(result: RunResult, existing: Mapping[str, object] | None 
     adapted = dict(existing or {})
     existing_hosts = adapted.get('hosts', [])
     hosts = list(existing_hosts) if isinstance(existing_hosts, list) else []
-    adapted['hosts'] = list(dict.fromkeys([*hosts, *legacy_hostnames(result)]))
+    represented_hosts = {host.split(':', 1)[0] for host in hosts if isinstance(host, str)}
+    hosts.extend(host for host in legacy_hostnames(result) if host not in represented_hosts)
+    adapted['hosts'] = list(dict.fromkeys(hosts))
     adapted['evidence_run'] = {
         **_run_record(result),
         'source_executions': [execution.to_dict() for execution in result.source_executions],

--- a/theHarvester/lib/output.py
+++ b/theHarvester/lib/output.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
+import json
 import logging
 import sys
 from collections.abc import Hashable, Iterable, Sequence
-from typing import TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+from xml.etree.ElementTree import Element, SubElement, tostring
+
+from theHarvester.lib.dns_validation import Addressability
+from theHarvester.lib.run import ScopeClass, legacy_hostnames
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from theHarvester.lib.run import MergedEntity, RunResult, SelectedObservation
 
 T = TypeVar('T', bound=Hashable)
 
@@ -75,3 +85,137 @@ def print_linkedin_sections(
         output_logger.info(separator)
         for link in sorted_unique(links):
             output_logger.info(link)
+
+
+def _entity_line(entity: MergedEntity, selected: Sequence[SelectedObservation] = ()) -> str:
+    sources = ','.join(sorted({observation.source for observation in entity.observations}))
+    selected_status = ''.join(f'; {observation.kind}={observation.detail or "observed"}' for observation in selected)
+    return f'{entity.value} [status={entity.addressability}; sources={sources}{selected_status}]'
+
+
+def format_run_terminal(result: RunResult) -> str:
+    """Render one concise terminal report from a completed evidence run."""
+    primary = [
+        entity
+        for entity in result.entities
+        if ScopeClass.IN_SCOPE in entity.scope_classes and entity.addressability is Addressability.CURRENT
+    ]
+    primary_values = {entity.value for entity in primary}
+    secondary = [
+        entity
+        for entity in result.entities
+        if entity.value not in primary_values
+        and (
+            ScopeClass.EXTERNAL_RELATIONSHIP in entity.scope_classes
+            or (ScopeClass.IN_SCOPE in entity.scope_classes and entity.addressability is not Addressability.CURRENT)
+        )
+    ]
+    reported_values = primary_values | {entity.value for entity in secondary}
+    scope_extensions = [
+        entity
+        for entity in result.entities
+        if entity.value not in reported_values and ScopeClass.SCOPE_EXTENSION in entity.scope_classes
+    ]
+    entity_values = {entity.value for entity in result.entities}
+    selected_by_entity = {
+        value: tuple(observation for observation in result.selected_observations if observation.value == value)
+        for value in entity_values
+    }
+    standalone_selected = [observation for observation in result.selected_observations if observation.value not in entity_values]
+    sections = [
+        f'[*] Run status: {result.status}',
+        f'[*] Currently addressable subdomains ({len(primary)})',
+        *(_entity_line(entity, selected_by_entity[entity.value]) for entity in primary),
+        f'[*] Secondary evidence / needs review ({len(secondary)})',
+        *(_entity_line(entity, selected_by_entity[entity.value]) for entity in secondary),
+        f'[*] Scope-extension candidates ({len(scope_extensions)})',
+        *(_entity_line(entity, selected_by_entity[entity.value]) for entity in scope_extensions),
+        f'[*] Selected stage observations ({len(standalone_selected)})',
+        *(
+            f'{observation.value} [{observation.kind}={observation.detail or "observed"}; source={observation.source}]'
+            for observation in standalone_selected
+        ),
+        '[*] Source executions',
+        *(
+            f'{execution.source} [status={execution.status}; results={execution.result_count}; '
+            f'observations={execution.observation_count}]'
+            for execution in result.source_executions
+        ),
+    ]
+    return '\n'.join(sections)
+
+
+def run_result_jsonl(result: RunResult) -> str:
+    """Serialize a completed run as versioned, normalized evidence records."""
+    serialized = result.to_dict()
+    records: list[tuple[str, dict[str, Any]]] = [('run', _run_record(result))]
+    records.extend(('source_execution', item) for item in cast('list[dict[str, Any]]', serialized['source_executions']))
+    records.extend(('discovery_observation', item) for item in cast('list[dict[str, Any]]', serialized['observations']))
+    for item in cast('list[dict[str, Any]]', serialized['dns_validations']):
+        validation = dict(item)
+        validation['validated_at'] = validation.pop('queried_at')
+        records.append(('dns_validation_observation', validation))
+    for item in cast('list[dict[str, Any]]', serialized['entities']):
+        merged = dict(item)
+        merged['provenance'] = merged.pop('observations')
+        records.append(('merged_result', merged))
+    records.extend(('selected_observation', item) for item in cast('list[dict[str, Any]]', serialized['selected_observations']))
+    return '\n'.join(
+        json.dumps(
+            {
+                'schema_version': 'theharvester-evidence-v1',
+                'run_id': result.run_id,
+                'target': result.target,
+                'record_type': record_type,
+                'data': data,
+            }
+        )
+        for record_type, data in records
+    )
+
+
+def _run_record(result: RunResult) -> dict[str, object]:
+    return {
+        'run_id': result.run_id,
+        'target': result.target,
+        'status': result.status,
+        'started_at': result.started_at.isoformat(),
+        'completed_at': result.completed_at.isoformat(),
+        'record_counts': {
+            'source_executions': len(result.source_executions),
+            'discovery_observations': len(result.observations),
+            'dns_validation_observations': len(result.dns_validations),
+            'merged_results': len(result.entities),
+            'selected_observations': len(result.selected_observations),
+        },
+    }
+
+
+def legacy_json_result(result: RunResult, existing: Mapping[str, object] | None = None) -> dict[str, object]:
+    adapted = dict(existing or {})
+    existing_hosts = adapted.get('hosts', [])
+    hosts = list(existing_hosts) if isinstance(existing_hosts, list) else []
+    adapted['hosts'] = list(dict.fromkeys([*hosts, *legacy_hostnames(result)]))
+    adapted['evidence_run'] = {
+        **_run_record(result),
+        'source_executions': [execution.to_dict() for execution in result.source_executions],
+        'selected_observations': [observation.to_dict() for observation in result.selected_observations],
+    }
+    return adapted
+
+
+def evidence_xml_fragment(result: RunResult) -> str:
+    evidence_run = Element('evidence_run', run_id=result.run_id, status=result.status)
+    for execution in result.source_executions:
+        SubElement(evidence_run, 'source', name=execution.source, status=execution.status)
+    for observation in result.selected_observations:
+        attributes = {
+            'source': observation.source,
+            'kind': observation.kind,
+            'value': observation.value,
+            'collected_at': observation.collected_at.isoformat(),
+        }
+        if observation.detail is not None:
+            attributes['detail'] = observation.detail
+        SubElement(evidence_run, 'selected_observation', attributes)
+    return tostring(evidence_run, encoding='unicode')

--- a/theHarvester/lib/output.py
+++ b/theHarvester/lib/output.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 from xml.etree.ElementTree import Element, SubElement, tostring
 
 from theHarvester.lib.dns_validation import Addressability
-from theHarvester.lib.run import ScopeClass, legacy_hostnames
+from theHarvester.lib.run import ScopeClass, StageFindingKind, legacy_hostnames
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -90,7 +90,13 @@ def print_linkedin_sections(
 def _entity_line(entity: MergedEntity, selected: Sequence[SelectedObservation] = ()) -> str:
     sources = ','.join(sorted({observation.source for observation in entity.observations}))
     selected_status = ''.join(f'; {observation.kind}={observation.detail or "observed"}' for observation in selected)
-    return f'{entity.value} [status={entity.addressability}; sources={sources}{selected_status}]'
+    status = (
+        entity.addressability
+        or ('scope-extension-candidate' if ScopeClass.SCOPE_EXTENSION in entity.scope_classes else None)
+        or ('external-relationship' if ScopeClass.EXTERNAL_RELATIONSHIP in entity.scope_classes else None)
+        or 'needs-review'
+    )
+    return f'{entity.value} [status={status}; sources={sources}{selected_status}]'
 
 
 def format_run_terminal(result: RunResult) -> str:
@@ -122,6 +128,31 @@ def format_run_terminal(result: RunResult) -> str:
         for value in entity_values
     }
     standalone_selected = [observation for observation in result.selected_observations if observation.value not in entity_values]
+    selected_sections: list[str] = []
+    for kind, title in (
+        (StageFindingKind.EMAIL, 'Emails found'),
+        (StageFindingKind.IP_ADDRESS, 'IPs found'),
+        (StageFindingKind.ASN, 'ASNS found'),
+        (StageFindingKind.PERSON, 'People found'),
+        (StageFindingKind.URL, 'URLs found'),
+        (StageFindingKind.INTERESTING_URL, 'Interesting Urls found'),
+        (StageFindingKind.TAKEOVER, 'Takeover results'),
+        (StageFindingKind.SCREENSHOT, 'Screenshots captured'),
+        (StageFindingKind.SHODAN_RESULT, 'Shodan results'),
+        (StageFindingKind.API_ENDPOINT, 'API Endpoints found'),
+        (StageFindingKind.API_AUTH_REQUIRED, 'Endpoints requiring authentication'),
+        (StageFindingKind.API_VERSION, 'Detected API versions'),
+        (StageFindingKind.API_RATE_LIMIT, 'Rate limited endpoints'),
+        (StageFindingKind.HTTP_METHOD, 'HTTP methods used'),
+        (StageFindingKind.HTTP_STATUS_CODE, 'HTTP status codes encountered'),
+    ):
+        observations = [observation for observation in standalone_selected if observation.kind is kind]
+        if not observations:
+            continue
+        selected_sections.append(f'[*] {title}: {len(observations)}')
+        for observation in observations:
+            detail = f'; detail={observation.detail}' if observation.detail is not None else ''
+            selected_sections.append(f'{observation.value} [status=observed; sources={observation.source}{detail}]')
     sections = [
         f'[*] Run status: {result.status}',
         f'[*] Currently addressable subdomains ({len(primary)})',
@@ -130,16 +161,18 @@ def format_run_terminal(result: RunResult) -> str:
         *(_entity_line(entity, selected_by_entity[entity.value]) for entity in secondary),
         f'[*] Scope-extension candidates ({len(scope_extensions)})',
         *(_entity_line(entity, selected_by_entity[entity.value]) for entity in scope_extensions),
-        f'[*] Selected stage observations ({len(standalone_selected)})',
-        *(
-            f'{observation.value} [{observation.kind}={observation.detail or "observed"}; source={observation.source}]'
-            for observation in standalone_selected
-        ),
+        *selected_sections,
         '[*] Source executions',
         *(
             f'{execution.source} [status={execution.status}; results={execution.result_count}; '
             f'observations={execution.observation_count}]'
             for execution in result.source_executions
+        ),
+        '[*] Selected stage executions',
+        *(
+            f'{execution.stage} [status={execution.status}; results={execution.result_count}; '
+            f'observations={execution.observation_count}]'
+            for execution in result.stage_executions
         ),
     ]
     return '\n'.join(sections)
@@ -150,6 +183,7 @@ def run_result_jsonl(result: RunResult) -> str:
     serialized = result.to_dict()
     records: list[tuple[str, dict[str, Any]]] = [('run', _run_record(result))]
     records.extend(('source_execution', item) for item in cast('list[dict[str, Any]]', serialized['source_executions']))
+    records.extend(('stage_execution', item) for item in cast('list[dict[str, Any]]', serialized['stage_executions']))
     records.extend(('discovery_observation', item) for item in cast('list[dict[str, Any]]', serialized['observations']))
     for item in cast('list[dict[str, Any]]', serialized['dns_validations']):
         validation = dict(item)
@@ -183,6 +217,7 @@ def _run_record(result: RunResult) -> dict[str, object]:
         'completed_at': result.completed_at.isoformat(),
         'record_counts': {
             'source_executions': len(result.source_executions),
+            'stage_executions': len(result.stage_executions),
             'discovery_observations': len(result.observations),
             'dns_validation_observations': len(result.dns_validations),
             'merged_results': len(result.entities),
@@ -199,6 +234,8 @@ def legacy_json_result(result: RunResult, existing: Mapping[str, object] | None 
     adapted['evidence_run'] = {
         **_run_record(result),
         'source_executions': [execution.to_dict() for execution in result.source_executions],
+        'stage_executions': [execution.to_dict() for execution in result.stage_executions],
+        'merged_results': [entity.to_dict() for entity in result.entities],
         'selected_observations': [observation.to_dict() for observation in result.selected_observations],
     }
     return adapted
@@ -208,6 +245,17 @@ def evidence_xml_fragment(result: RunResult) -> str:
     evidence_run = Element('evidence_run', run_id=result.run_id, status=result.status)
     for execution in result.source_executions:
         SubElement(evidence_run, 'source', name=execution.source, status=execution.status)
+    for stage_execution in result.stage_executions:
+        SubElement(evidence_run, 'stage', name=stage_execution.stage, status=stage_execution.status)
+    for entity in result.entities:
+        attributes = {
+            'value': entity.value,
+            'scope_classes': ','.join(sorted(entity.scope_classes)),
+            'sources': ','.join(sorted({observation.source for observation in entity.observations})),
+        }
+        if entity.addressability is not None:
+            attributes['addressability'] = entity.addressability
+        SubElement(evidence_run, 'merged_result', attributes)
     for observation in result.selected_observations:
         attributes = {
             'source': observation.source,

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Protocol
 from uuid import uuid4
 
+from theHarvester.lib.dns_validation import (
+    Addressability,
+    DnsValidationObservation,
+    DnsValidator,
+)
 from theHarvester.lib.hostnames import normalize_hostname
 
 if TYPE_CHECKING:
@@ -111,6 +116,7 @@ class SourceExecution:
 class MergedEntity:
     value: str
     observations: tuple[DiscoveryObservation, ...]
+    addressability: Addressability | None = None
 
     @property
     def scope_classes(self) -> tuple[ScopeClass, ...]:
@@ -130,6 +136,7 @@ class RunResult:
     source_executions: tuple[SourceExecution, ...]
     observations: tuple[DiscoveryObservation, ...]
     entities: tuple[MergedEntity, ...]
+    dns_validations: tuple[DnsValidationObservation, ...] = ()
 
 
 def _classify_scope(target: str, value: str, derivation: Derivation) -> ScopeClass:
@@ -150,6 +157,9 @@ def _merge_observations(observations: Sequence[DiscoveryObservation]) -> tuple[M
 async def execute_run(
     target: str,
     sources: Sequence[PassiveSource],
+    *,
+    dns_validator: DnsValidator | None = None,
+    deterministic_exact_dns_names: tuple[str, ...] = (),
 ) -> RunResult:
     normalized_target = normalize_hostname(target)
     if normalized_target is None:
@@ -226,6 +236,21 @@ async def execute_run(
         logger.info(f'Source {source.name} completed with status {status}')
 
     merged_observations = tuple(observations)
+    entities = _merge_observations(merged_observations)
+    dns_validations: tuple[DnsValidationObservation, ...] = ()
+    if dns_validator is not None:
+        validation = await dns_validator.validate(
+            run_id,
+            normalized_target,
+            tuple(entity.value for entity in entities if ScopeClass.IN_SCOPE in entity.scope_classes),
+            deterministic_exact_names=deterministic_exact_dns_names,
+        )
+        classifications = {
+            classification.candidate: classification.addressability for classification in validation.classifications
+        }
+        entities = tuple(replace(entity, addressability=classifications.get(entity.value)) for entity in entities)
+        dns_validations = validation.observations
+
     result = RunResult(
         run_id=run_id,
         target=normalized_target,
@@ -233,13 +258,15 @@ async def execute_run(
         completed_at=datetime.now(UTC),
         source_executions=tuple(executions),
         observations=merged_observations,
-        entities=_merge_observations(merged_observations),
+        entities=entities,
+        dns_validations=dns_validations,
     )
     return result
 
 
 def legacy_hostnames(result: RunResult, source: str | None = None) -> list[str]:
     """Return the host list consumed by the existing CLI, REST, file, and stash paths."""
+    validated_hosts = {entity.value for entity in result.entities if entity.addressability is Addressability.CURRENT}
     return sorted(
         {
             observation.value
@@ -247,5 +274,18 @@ def legacy_hostnames(result: RunResult, source: str | None = None) -> list[str]:
             if observation.value != result.target
             and observation.scope_class is ScopeClass.IN_SCOPE
             and (source is None or observation.source == source)
+            and (not result.dns_validations or observation.value in validated_hosts)
         }
     )
+
+
+def legacy_dns_results(result: RunResult, source: str | None = None) -> tuple[list[str], list[str], list[str]]:
+    hosts = legacy_hostnames(result, source)
+    host_set = set(hosts)
+    addresses_by_host: dict[str, set[str]] = {host: set() for host in hosts}
+    for observation in result.dns_validations:
+        if not observation.is_wildcard_control and observation.candidate in host_set:
+            addresses_by_host[observation.candidate].update((*observation.ipv4, *observation.ipv6))
+    addresses = sorted({address for values in addresses_by_host.values() for address in values})
+    resolved = [f'{host}:{",".join(sorted(addresses_by_host[host]))}' if addresses_by_host[host] else host for host in hosts]
+    return resolved, hosts, addresses

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
@@ -69,6 +69,11 @@ class StageFindingKind(StrEnum):
     API_ENDPOINT = 'api-endpoint'
     SCREENSHOT = 'screenshot'
     SHODAN_RESULT = 'shodan-result'
+    API_AUTH_REQUIRED = 'api-auth-required'
+    API_VERSION = 'api-version'
+    API_RATE_LIMIT = 'api-rate-limit'
+    HTTP_METHOD = 'http-method'
+    HTTP_STATUS_CODE = 'http-status-code'
 
 
 @dataclass(frozen=True)
@@ -88,6 +93,8 @@ class StageResult:
     findings: tuple[StageFinding, ...] = ()
     source_family: str | None = None
     error_type: str | None = None
+    is_action: bool = False
+    completed_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
 
 class SourceIncompleteError(Exception):
@@ -186,6 +193,32 @@ class SourceExecution:
 
 
 @dataclass(frozen=True)
+class StageExecution:
+    run_id: str
+    stage: str
+    status: SourceStatus
+    duration_ms: float
+    result_count: int
+    observation_count: int
+    entity_count: int
+    completed_at: datetime
+    error_type: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            'run_id': self.run_id,
+            'stage': self.stage,
+            'status': self.status,
+            'duration_ms': self.duration_ms,
+            'result_count': self.result_count,
+            'observation_count': self.observation_count,
+            'entity_count': self.entity_count,
+            'completed_at': self.completed_at.isoformat(),
+            'error_type': self.error_type,
+        }
+
+
+@dataclass(frozen=True)
 class SelectedObservation:
     run_id: str
     source: str
@@ -242,13 +275,18 @@ class RunResult:
     entities: tuple[MergedEntity, ...]
     dns_validations: tuple[DnsValidationObservation, ...] = ()
     selected_observations: tuple[SelectedObservation, ...] = ()
+    stage_executions: tuple[StageExecution, ...] = ()
 
     @property
     def status(self) -> RunStatus:
+        statuses = [
+            *(execution.status for execution in self.source_executions),
+            *(execution.status for execution in self.stage_executions),
+        ]
         incomplete = {SourceStatus.FAILED, SourceStatus.RATE_LIMITED}
-        if self.source_executions and all(execution.status is SourceStatus.FAILED for execution in self.source_executions):
+        if statuses and all(status is SourceStatus.FAILED for status in statuses):
             return RunStatus.FAILED
-        if any(execution.status in incomplete for execution in self.source_executions):
+        if any(status in incomplete for status in statuses):
             return RunStatus.PARTIAL
         return RunStatus.COMPLETE
 
@@ -260,6 +298,7 @@ class RunResult:
             'completed_at': self.completed_at.isoformat(),
             'status': self.status,
             'source_executions': [execution.to_dict() for execution in self.source_executions],
+            'stage_executions': [execution.to_dict() for execution in self.stage_executions],
             'observations': [observation.to_dict() for observation in self.observations],
             'dns_validations': [
                 {
@@ -479,7 +518,6 @@ def legacy_dns_results(result: RunResult, source: str | None = None) -> tuple[li
 
 def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -> RunResult:
     """Merge selected stage results once and close the run."""
-    collected_at = datetime.now(UTC)
     stage_findings = tuple((stage, finding) for stage in stage_results for finding in dict.fromkeys(stage.findings))
     existing = {(item.source, item.value, item.derivation) for item in result.observations}
     added: list[DiscoveryObservation] = []
@@ -497,7 +535,7 @@ def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -
                 source=stage.source,
                 source_family=stage.source_family or stage.source,
                 derivation=finding.derivation,
-                collected_at=collected_at,
+                collected_at=stage.completed_at,
                 scope_class=_classify_scope(result.target, value, finding.derivation),
             )
         )
@@ -518,15 +556,44 @@ def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -
             value=finding.value,
             detail=finding.detail,
             derivation=finding.derivation,
-            collected_at=collected_at,
+            collected_at=stage.completed_at,
         )
         for stage, finding in stage_findings
         if finding.kind is not StageFindingKind.HOSTNAME
     )
     executions = list(result.source_executions)
+    stage_executions = list(result.stage_executions)
     recorded_sources = {execution.source.casefold(): index for index, execution in enumerate(executions)}
+    recorded_stages = {execution.stage.casefold(): index for index, execution in enumerate(stage_executions)}
     for stage in stage_results:
         source_key = stage.source.casefold()
+        findings = tuple(dict.fromkeys(stage.findings))
+        entity_count = len(
+            {
+                value
+                for finding in findings
+                if finding.kind is StageFindingKind.HOSTNAME
+                and (value := normalize_hostname(finding.value.split(':', 1)[0])) is not None
+            }
+        )
+        if stage.is_action:
+            stage_execution = StageExecution(
+                run_id=result.run_id,
+                stage=stage.source,
+                status=stage.status,
+                duration_ms=stage.duration_ms,
+                result_count=stage.result_count,
+                observation_count=len(findings),
+                entity_count=entity_count,
+                completed_at=stage.completed_at,
+                error_type=stage.error_type,
+            )
+            if source_key in recorded_stages:
+                stage_executions[recorded_stages[source_key]] = stage_execution
+            else:
+                recorded_stages[source_key] = len(stage_executions)
+                stage_executions.append(stage_execution)
+            continue
         if source_key in recorded_sources:
             index = recorded_sources[source_key]
             execution = executions[index]
@@ -537,7 +604,6 @@ def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -
                 error_type=stage.error_type or execution.error_type,
             )
             continue
-        findings = tuple(dict.fromkeys(stage.findings))
         executions.append(
             SourceExecution(
                 run_id=result.run_id,
@@ -547,14 +613,7 @@ def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -
                 duration_ms=stage.duration_ms,
                 result_count=stage.result_count,
                 observation_count=len(findings),
-                entity_count=len(
-                    {
-                        value
-                        for finding in findings
-                        if finding.kind is StageFindingKind.HOSTNAME
-                        and (value := normalize_hostname(finding.value.split(':', 1)[0])) is not None
-                    }
-                ),
+                entity_count=entity_count,
                 error_type=stage.error_type,
             )
         )
@@ -563,6 +622,7 @@ def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -
         result,
         completed_at=datetime.now(UTC),
         source_executions=tuple(executions),
+        stage_executions=tuple(stage_executions),
         observations=(*result.observations, *added),
         entities=entities,
         selected_observations=(*result.selected_observations, *selected),

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import json
 import logging
 import time
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from enum import StrEnum
+from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 from uuid import uuid4
+
+import aiosqlite
 
 from theHarvester.lib.dns_validation import (
     Addressability,
@@ -40,10 +44,50 @@ class SourceStatus(StrEnum):
     RATE_LIMITED = 'rate-limited'
 
 
+class RunStatus(StrEnum):
+    COMPLETE = 'complete'
+    PARTIAL = 'partial'
+    FAILED = 'failed'
+
+
 @dataclass(frozen=True)
 class SourceFinding:
     value: str
     derivation: Derivation = Derivation.PROVIDER
+    observed_at: datetime | None = None
+
+
+class StageFindingKind(StrEnum):
+    HOSTNAME = 'hostname'
+    EMAIL = 'email'
+    IP_ADDRESS = 'ip-address'
+    PERSON = 'person'
+    URL = 'url'
+    INTERESTING_URL = 'interesting-url'
+    ASN = 'asn'
+    TAKEOVER = 'takeover'
+    API_ENDPOINT = 'api-endpoint'
+    SCREENSHOT = 'screenshot'
+    SHODAN_RESULT = 'shodan-result'
+
+
+@dataclass(frozen=True)
+class StageFinding:
+    kind: StageFindingKind
+    value: str
+    detail: str | None = None
+    derivation: Derivation = Derivation.PROVIDER
+
+
+@dataclass(frozen=True)
+class StageResult:
+    source: str
+    status: SourceStatus
+    duration_ms: float
+    result_count: int
+    findings: tuple[StageFinding, ...] = ()
+    source_family: str | None = None
+    error_type: str | None = None
 
 
 class SourceIncompleteError(Exception):
@@ -97,6 +141,22 @@ class DiscoveryObservation:
     derivation: Derivation
     collected_at: datetime
     scope_class: ScopeClass
+    provider_observed_at: datetime | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {
+            'run_id': self.run_id,
+            'target': self.target,
+            'value': self.value,
+            'source': self.source,
+            'source_family': self.source_family,
+            'derivation': self.derivation,
+            'collected_at': self.collected_at.isoformat(),
+            'scope_class': self.scope_class,
+        }
+        if self.provider_observed_at is not None:
+            result['provider_observed_at'] = self.provider_observed_at.isoformat()
+        return result
 
 
 @dataclass(frozen=True)
@@ -110,6 +170,41 @@ class SourceExecution:
     observation_count: int
     entity_count: int
     error_type: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            'run_id': self.run_id,
+            'source': self.source,
+            'source_family': self.source_family,
+            'status': self.status,
+            'duration_ms': self.duration_ms,
+            'result_count': self.result_count,
+            'observation_count': self.observation_count,
+            'entity_count': self.entity_count,
+            'error_type': self.error_type,
+        }
+
+
+@dataclass(frozen=True)
+class SelectedObservation:
+    run_id: str
+    source: str
+    kind: StageFindingKind
+    value: str
+    detail: str | None
+    derivation: Derivation
+    collected_at: datetime
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            'run_id': self.run_id,
+            'source': self.source,
+            'kind': self.kind,
+            'value': self.value,
+            'detail': self.detail,
+            'derivation': self.derivation,
+            'collected_at': self.collected_at.isoformat(),
+        }
 
 
 @dataclass(frozen=True)
@@ -126,6 +221,15 @@ class MergedEntity:
     def independent_corroboration_count(self) -> int:
         return len({observation.source_family for observation in self.observations})
 
+    def to_dict(self) -> dict[str, object]:
+        return {
+            'value': self.value,
+            'addressability': self.addressability,
+            'scope_classes': list(self.scope_classes),
+            'independent_corroboration_count': self.independent_corroboration_count,
+            'observations': [observation.to_dict() for observation in self.observations],
+        }
+
 
 @dataclass(frozen=True)
 class RunResult:
@@ -137,6 +241,87 @@ class RunResult:
     observations: tuple[DiscoveryObservation, ...]
     entities: tuple[MergedEntity, ...]
     dns_validations: tuple[DnsValidationObservation, ...] = ()
+    selected_observations: tuple[SelectedObservation, ...] = ()
+
+    @property
+    def status(self) -> RunStatus:
+        incomplete = {SourceStatus.FAILED, SourceStatus.RATE_LIMITED}
+        if self.source_executions and all(execution.status is SourceStatus.FAILED for execution in self.source_executions):
+            return RunStatus.FAILED
+        if any(execution.status in incomplete for execution in self.source_executions):
+            return RunStatus.PARTIAL
+        return RunStatus.COMPLETE
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            'run_id': self.run_id,
+            'target': self.target,
+            'started_at': self.started_at.isoformat(),
+            'completed_at': self.completed_at.isoformat(),
+            'status': self.status,
+            'source_executions': [execution.to_dict() for execution in self.source_executions],
+            'observations': [observation.to_dict() for observation in self.observations],
+            'dns_validations': [
+                {
+                    'run_id': observation.run_id,
+                    'candidate': observation.candidate,
+                    'query_name': observation.query_name,
+                    'resolver': observation.resolver,
+                    'queried_at': observation.queried_at.isoformat(),
+                    'ipv4': list(observation.ipv4),
+                    'ipv6': list(observation.ipv6),
+                    'cnames': list(observation.cnames),
+                    'rcode': observation.rcode,
+                    'ttl': observation.ttl,
+                    'cname_chain': list(observation.cname_chain),
+                    'latency_ms': observation.latency_ms,
+                    'error': observation.error,
+                    'is_wildcard_control': observation.is_wildcard_control,
+                    'wildcard_depth': observation.wildcard_depth,
+                }
+                for observation in self.dns_validations
+            ],
+            'entities': [entity.to_dict() for entity in self.entities],
+            'selected_observations': [observation.to_dict() for observation in self.selected_observations],
+        }
+
+
+class SQLiteRunStore:
+    def __init__(self, database: str | Path | None = None) -> None:
+        self.database = Path(database) if database is not None else Path('~/.local/share/theHarvester/stash.sqlite').expanduser()
+
+    async def save(self, result: RunResult) -> None:
+        self.database.parent.mkdir(parents=True, exist_ok=True)
+        async with aiosqlite.connect(self.database) as database:
+            await database.execute(
+                """
+                CREATE TABLE IF NOT EXISTS evidence_runs (
+                    run_id TEXT PRIMARY KEY,
+                    target TEXT NOT NULL,
+                    completed_at TEXT NOT NULL,
+                    evidence_json TEXT NOT NULL
+                )
+                """
+            )
+            await database.execute(
+                'INSERT INTO evidence_runs (run_id, target, completed_at, evidence_json) VALUES (?, ?, ?, ?)',
+                (
+                    result.run_id,
+                    result.target,
+                    result.completed_at.isoformat(),
+                    json.dumps(result.to_dict()),
+                ),
+            )
+            await database.commit()
+
+    async def load(self, run_id: str) -> dict[str, object] | None:
+        async with aiosqlite.connect(self.database) as database:
+            cursor = await database.execute(
+                'SELECT evidence_json FROM evidence_runs WHERE run_id = ?',
+                (run_id,),
+            )
+            row = await cursor.fetchone()
+        return json.loads(row[0]) if row is not None else None
 
 
 def _classify_scope(target: str, value: str, derivation: Derivation) -> ScopeClass:
@@ -207,6 +392,7 @@ async def execute_run(
                         derivation=finding.derivation,
                         collected_at=collected_at,
                         scope_class=_classify_scope(normalized_target, value, finding.derivation),
+                        provider_observed_at=finding.observed_at,
                     )
                 )
             source_observations = tuple(normalized_observations)
@@ -289,3 +475,95 @@ def legacy_dns_results(result: RunResult, source: str | None = None) -> tuple[li
     addresses = sorted({address for values in addresses_by_host.values() for address in values})
     resolved = [f'{host}:{",".join(sorted(addresses_by_host[host]))}' if addresses_by_host[host] else host for host in hosts]
     return resolved, hosts, addresses
+
+
+def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -> RunResult:
+    """Merge selected stage results once and close the run."""
+    collected_at = datetime.now(UTC)
+    stage_findings = tuple((stage, finding) for stage in stage_results for finding in dict.fromkeys(stage.findings))
+    existing = {(item.source, item.value, item.derivation) for item in result.observations}
+    added: list[DiscoveryObservation] = []
+    for stage, finding in stage_findings:
+        if finding.kind is not StageFindingKind.HOSTNAME:
+            continue
+        value = normalize_hostname(finding.value.split(':', 1)[0])
+        if value is None or (stage.source, value, finding.derivation) in existing:
+            continue
+        added.append(
+            DiscoveryObservation(
+                run_id=result.run_id,
+                target=result.target,
+                value=value,
+                source=stage.source,
+                source_family=stage.source_family or stage.source,
+                derivation=finding.derivation,
+                collected_at=collected_at,
+                scope_class=_classify_scope(result.target, value, finding.derivation),
+            )
+        )
+        existing.add((stage.source, value, finding.derivation))
+
+    previous_entities = {entity.value: entity for entity in result.entities}
+    entities = tuple(
+        replace(entity, addressability=previous.addressability)
+        if (previous := previous_entities.get(entity.value)) is not None
+        else entity
+        for entity in _merge_observations((*result.observations, *added))
+    )
+    selected = tuple(
+        SelectedObservation(
+            run_id=result.run_id,
+            source=stage.source,
+            kind=finding.kind,
+            value=finding.value,
+            detail=finding.detail,
+            derivation=finding.derivation,
+            collected_at=collected_at,
+        )
+        for stage, finding in stage_findings
+        if finding.kind is not StageFindingKind.HOSTNAME
+    )
+    executions = list(result.source_executions)
+    recorded_sources = {execution.source.casefold(): index for index, execution in enumerate(executions)}
+    for stage in stage_results:
+        source_key = stage.source.casefold()
+        if source_key in recorded_sources:
+            index = recorded_sources[source_key]
+            execution = executions[index]
+            executions[index] = replace(
+                execution,
+                status=stage.status,
+                duration_ms=execution.duration_ms + stage.duration_ms,
+                error_type=stage.error_type or execution.error_type,
+            )
+            continue
+        findings = tuple(dict.fromkeys(stage.findings))
+        executions.append(
+            SourceExecution(
+                run_id=result.run_id,
+                source=stage.source,
+                source_family=stage.source_family or stage.source,
+                status=stage.status,
+                duration_ms=stage.duration_ms,
+                result_count=stage.result_count,
+                observation_count=len(findings),
+                entity_count=len(
+                    {
+                        value
+                        for finding in findings
+                        if finding.kind is StageFindingKind.HOSTNAME
+                        and (value := normalize_hostname(finding.value.split(':', 1)[0])) is not None
+                    }
+                ),
+                error_type=stage.error_type,
+            )
+        )
+        recorded_sources[source_key] = len(executions) - 1
+    return replace(
+        result,
+        completed_at=datetime.now(UTC),
+        source_executions=tuple(executions),
+        observations=(*result.observations, *added),
+        entities=entities,
+        selected_observations=(*result.selected_observations, *selected),
+    )

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -378,6 +378,36 @@ def _merge_observations(observations: Sequence[DiscoveryObservation]) -> tuple[M
     return tuple(MergedEntity(value, tuple(supporting)) for value, supporting in grouped.items())
 
 
+async def validate_run(
+    result: RunResult,
+    dns_validator: DnsValidator,
+    *,
+    deterministic_exact_dns_names: tuple[str, ...] = (),
+) -> RunResult:
+    candidates = tuple(
+        entity.value
+        for entity in result.entities
+        if ScopeClass.IN_SCOPE in entity.scope_classes and entity.addressability is None
+    )
+    if not candidates:
+        return result
+    validation = await dns_validator.validate(
+        result.run_id,
+        result.target,
+        candidates,
+        deterministic_exact_names=deterministic_exact_dns_names,
+    )
+    classifications = {classification.candidate: classification.addressability for classification in validation.classifications}
+    return replace(
+        result,
+        completed_at=datetime.now(UTC),
+        entities=tuple(
+            replace(entity, addressability=classifications.get(entity.value, entity.addressability)) for entity in result.entities
+        ),
+        dns_validations=(*result.dns_validations, *validation.observations),
+    )
+
+
 async def execute_run(
     target: str,
     sources: Sequence[PassiveSource],
@@ -462,20 +492,6 @@ async def execute_run(
 
     merged_observations = tuple(observations)
     entities = _merge_observations(merged_observations)
-    dns_validations: tuple[DnsValidationObservation, ...] = ()
-    if dns_validator is not None:
-        validation = await dns_validator.validate(
-            run_id,
-            normalized_target,
-            tuple(entity.value for entity in entities if ScopeClass.IN_SCOPE in entity.scope_classes),
-            deterministic_exact_names=deterministic_exact_dns_names,
-        )
-        classifications = {
-            classification.candidate: classification.addressability for classification in validation.classifications
-        }
-        entities = tuple(replace(entity, addressability=classifications.get(entity.value)) for entity in entities)
-        dns_validations = validation.observations
-
     result = RunResult(
         run_id=run_id,
         target=normalized_target,
@@ -484,9 +500,16 @@ async def execute_run(
         source_executions=tuple(executions),
         observations=merged_observations,
         entities=entities,
-        dns_validations=dns_validations,
     )
-    return result
+    return (
+        await validate_run(
+            result,
+            dns_validator,
+            deterministic_exact_dns_names=deterministic_exact_dns_names,
+        )
+        if dns_validator is not None
+        else result
+    )
 
 
 def legacy_hostnames(result: RunResult, source: str | None = None) -> list[str]:

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 from theHarvester.lib.hostnames import normalize_hostname
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Collection, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -32,12 +32,25 @@ class SourceStatus(StrEnum):
     SUCCEEDED = 'succeeded'
     EMPTY = 'empty'
     FAILED = 'failed'
+    RATE_LIMITED = 'rate-limited'
 
 
 @dataclass(frozen=True)
 class SourceFinding:
     value: str
     derivation: Derivation = Derivation.PROVIDER
+
+
+class SourceIncompleteError(Exception):
+    status = SourceStatus.FAILED
+
+    def __init__(self, message: str = '', *, findings: Sequence[SourceFinding] = ()) -> None:
+        super().__init__(message)
+        self.findings = tuple(findings)
+
+
+class SourceRateLimitedError(SourceIncompleteError):
+    status = SourceStatus.RATE_LIMITED
 
 
 class PassiveSource(Protocol):
@@ -53,7 +66,7 @@ class PassiveSource(Protocol):
 class LegacyHostnameSearch(Protocol):
     async def process(self, proxy: bool = False) -> None: ...
 
-    async def get_hostnames(self) -> Sequence[str]: ...
+    async def get_hostnames(self) -> Collection[str]: ...
 
 
 @dataclass(frozen=True)
@@ -153,10 +166,21 @@ async def execute_run(
         status = SourceStatus.FAILED
         result_count = 0
         error_type: str | None = None
+        findings: tuple[SourceFinding, ...] = ()
 
         try:
             findings = tuple(await source.collect(normalized_target))
-            result_count = len(findings)
+            status = SourceStatus.SUCCEEDED
+        except SourceIncompleteError as error:
+            findings = error.findings
+            status = error.status
+            error_type = type(error).__name__
+        except Exception as error:
+            error_type = type(error).__name__
+            logger.exception(f'Source {source.name} failed')
+
+        result_count = len(findings)
+        try:
             collected_at = datetime.now(UTC)
             normalized_observations = []
             for finding in findings:
@@ -176,8 +200,11 @@ async def execute_run(
                     )
                 )
             source_observations = tuple(normalized_observations)
-            status = SourceStatus.SUCCEEDED if source_observations else SourceStatus.EMPTY
+            if status is SourceStatus.SUCCEEDED and not source_observations:
+                status = SourceStatus.EMPTY
         except Exception as error:
+            source_observations = ()
+            status = SourceStatus.FAILED
             error_type = type(error).__name__
             logger.exception(f'Source {source.name} failed')
 

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING, Protocol
+from uuid import uuid4
+
+from theHarvester.lib.hostnames import normalize_hostname
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+logger = logging.getLogger(__name__)
+
+
+class Derivation(StrEnum):
+    PROVIDER = 'provider'
+    SCOPE_EXTENSION = 'scope-extension'
+    EXTERNAL_RELATIONSHIP = 'external-relationship'
+
+
+class ScopeClass(StrEnum):
+    IN_SCOPE = 'in-scope'
+    SCOPE_EXTENSION = 'scope-extension'
+    EXTERNAL_RELATIONSHIP = 'external-relationship'
+
+
+class SourceStatus(StrEnum):
+    SUCCEEDED = 'succeeded'
+    EMPTY = 'empty'
+    FAILED = 'failed'
+
+
+@dataclass(frozen=True)
+class SourceFinding:
+    value: str
+    derivation: Derivation = Derivation.PROVIDER
+
+
+class PassiveSource(Protocol):
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def family(self) -> str: ...
+
+    async def collect(self, target: str) -> Sequence[SourceFinding]: ...
+
+
+class LegacyHostnameSearch(Protocol):
+    async def process(self, proxy: bool = False) -> None: ...
+
+    async def get_hostnames(self) -> Sequence[str]: ...
+
+
+@dataclass(frozen=True)
+class LegacyHostnameSource:
+    name: str
+    legacy_name: str
+    family: str
+    search: LegacyHostnameSearch
+    proxy: bool = False
+
+    async def collect(self, _target: str) -> tuple[SourceFinding, ...]:
+        await self.search.process(self.proxy)
+        return tuple(SourceFinding(hostname) for hostname in await self.search.get_hostnames())
+
+
+@dataclass(frozen=True)
+class DiscoveryObservation:
+    run_id: str
+    target: str
+    value: str
+    source: str
+    source_family: str
+    derivation: Derivation
+    collected_at: datetime
+    scope_class: ScopeClass
+
+
+@dataclass(frozen=True)
+class SourceExecution:
+    run_id: str
+    source: str
+    source_family: str
+    status: SourceStatus
+    duration_ms: float
+    result_count: int
+    observation_count: int
+    entity_count: int
+    error_type: str | None = None
+
+
+@dataclass(frozen=True)
+class MergedEntity:
+    value: str
+    observations: tuple[DiscoveryObservation, ...]
+
+    @property
+    def scope_classes(self) -> tuple[ScopeClass, ...]:
+        return tuple(dict.fromkeys(observation.scope_class for observation in self.observations))
+
+    @property
+    def independent_corroboration_count(self) -> int:
+        return len({observation.source_family for observation in self.observations})
+
+
+@dataclass(frozen=True)
+class RunResult:
+    run_id: str
+    target: str
+    started_at: datetime
+    completed_at: datetime
+    source_executions: tuple[SourceExecution, ...]
+    observations: tuple[DiscoveryObservation, ...]
+    entities: tuple[MergedEntity, ...]
+
+
+def _classify_scope(target: str, value: str, derivation: Derivation) -> ScopeClass:
+    if value == target or value.endswith(f'.{target}'):
+        return ScopeClass.IN_SCOPE
+    if derivation is Derivation.EXTERNAL_RELATIONSHIP:
+        return ScopeClass.EXTERNAL_RELATIONSHIP
+    return ScopeClass.SCOPE_EXTENSION
+
+
+def _merge_observations(observations: Sequence[DiscoveryObservation]) -> tuple[MergedEntity, ...]:
+    grouped: dict[str, list[DiscoveryObservation]] = {}
+    for observation in observations:
+        grouped.setdefault(observation.value, []).append(observation)
+    return tuple(MergedEntity(value, tuple(supporting)) for value, supporting in grouped.items())
+
+
+async def execute_run(
+    target: str,
+    sources: Sequence[PassiveSource],
+) -> RunResult:
+    normalized_target = normalize_hostname(target)
+    if normalized_target is None:
+        raise ValueError('target must be a hostname')
+    run_id = str(uuid4())
+    started_at = datetime.now(UTC)
+    executions: list[SourceExecution] = []
+    observations: list[DiscoveryObservation] = []
+
+    for source in sources:
+        logger.info(f'Source {source.name} started')
+        source_started = time.perf_counter()
+        source_observations: tuple[DiscoveryObservation, ...] = ()
+        status = SourceStatus.FAILED
+        result_count = 0
+        error_type: str | None = None
+
+        try:
+            findings = tuple(await source.collect(normalized_target))
+            result_count = len(findings)
+            collected_at = datetime.now(UTC)
+            normalized_observations = []
+            for finding in findings:
+                value = normalize_hostname(finding.value)
+                if value is None:
+                    continue
+                normalized_observations.append(
+                    DiscoveryObservation(
+                        run_id=run_id,
+                        target=normalized_target,
+                        value=value,
+                        source=source.name,
+                        source_family=source.family,
+                        derivation=finding.derivation,
+                        collected_at=collected_at,
+                        scope_class=_classify_scope(normalized_target, value, finding.derivation),
+                    )
+                )
+            source_observations = tuple(normalized_observations)
+            status = SourceStatus.SUCCEEDED if source_observations else SourceStatus.EMPTY
+        except Exception as error:
+            error_type = type(error).__name__
+            logger.exception(f'Source {source.name} failed')
+
+        source_entities = _merge_observations(source_observations)
+        executions.append(
+            SourceExecution(
+                run_id=run_id,
+                source=source.name,
+                source_family=source.family,
+                status=status,
+                duration_ms=(time.perf_counter() - source_started) * 1000,
+                result_count=result_count,
+                observation_count=len(source_observations),
+                entity_count=len(source_entities),
+                error_type=error_type,
+            )
+        )
+        observations.extend(source_observations)
+        logger.info(f'Source {source.name} completed with status {status}')
+
+    merged_observations = tuple(observations)
+    result = RunResult(
+        run_id=run_id,
+        target=normalized_target,
+        started_at=started_at,
+        completed_at=datetime.now(UTC),
+        source_executions=tuple(executions),
+        observations=merged_observations,
+        entities=_merge_observations(merged_observations),
+    )
+    return result
+
+
+def legacy_hostnames(result: RunResult, source: str | None = None) -> list[str]:
+    """Return the host list consumed by the existing CLI, REST, file, and stash paths."""
+    return sorted(
+        {
+            observation.value
+            for observation in result.observations
+            if observation.value != result.target
+            and observation.scope_class is ScopeClass.IN_SCOPE
+            and (source is None or observation.source == source)
+        }
+    )

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -27,6 +27,7 @@ _ROUTE_CAPABILITIES = {
 class SourceSpec:
     name: str
     routes: frozenset[ResultRoute]
+    family: str
     queries_provider_descendants: bool = False
 
     @property
@@ -34,10 +35,16 @@ class SourceSpec:
         return frozenset(_ROUTE_CAPABILITIES[route] for route in self.routes)
 
 
-def _spec(name: str, *routes: ResultRoute, queries_provider_descendants: bool = False) -> SourceSpec:
+def _spec(
+    name: str,
+    *routes: ResultRoute,
+    family: str | None = None,
+    queries_provider_descendants: bool = False,
+) -> SourceSpec:
     return SourceSpec(
         name=name,
         routes=frozenset(routes),
+        family=family if family is not None else name,
         queries_provider_descendants=queries_provider_descendants,
     )
 
@@ -50,11 +57,16 @@ _SPECS = (
     _spec('bufferoverun', ResultRoute.HOSTS, ResultRoute.IPS, queries_provider_descendants=True),
     _spec('builtwith', ResultRoute.HOSTS, ResultRoute.INTERESTING_URLS),
     _spec('censys', ResultRoute.HOSTS, ResultRoute.EMAILS),
-    _spec('certspotter', ResultRoute.HOSTS, queries_provider_descendants=True),
-    _spec('chaos', ResultRoute.HOSTS, queries_provider_descendants=True),
+    _spec(
+        'certspotter',
+        ResultRoute.HOSTS,
+        family='certificate-transparency',
+        queries_provider_descendants=True,
+    ),
+    _spec('chaos', ResultRoute.HOSTS, family='projectdiscovery', queries_provider_descendants=True),
     _spec('commoncrawl', ResultRoute.HOSTS, queries_provider_descendants=True),
     _spec('criminalip', ResultRoute.HOSTS, ResultRoute.IPS, ResultRoute.ASNS, queries_provider_descendants=True),
-    _spec('crtsh', ResultRoute.HOSTS, queries_provider_descendants=True),
+    _spec('crtsh', ResultRoute.HOSTS, family='certificate-transparency', queries_provider_descendants=True),
     _spec('dehashed', ResultRoute.IPS),
     _spec('dnsdb', ResultRoute.HOSTS, queries_provider_descendants=True),
     _spec('dnsdumpster', ResultRoute.HOSTS, ResultRoute.IPS, queries_provider_descendants=True),
@@ -85,7 +97,7 @@ _SPECS = (
     _spec('securityscorecard', ResultRoute.HOSTS, ResultRoute.IPS),
     _spec('sherlockeye', ResultRoute.HOSTS, ResultRoute.EMAILS, ResultRoute.IPS),
     _spec('shodan', ResultRoute.HOSTS),
-    _spec('shodanInternetDB', ResultRoute.HOSTS, ResultRoute.IPS),
+    _spec('shodanInternetDB', ResultRoute.HOSTS, ResultRoute.IPS, family='shodan'),
     _spec('subdomaincenter', ResultRoute.HOSTS, queries_provider_descendants=True),
     _spec('subdomainfinderc99', ResultRoute.HOSTS, queries_provider_descendants=True),
     _spec('thc', ResultRoute.HOSTS, queries_provider_descendants=True),


### PR DESCRIPTION
## Summary

- complete every selected run stage before persistence and reporting
- expose one completed `RunResult` through terminal output, versioned JSONL, legacy JSON and XML, REST, and SQLite
- preserve typed observations, DNS validation evidence, source and stage status, provenance, and timestamps
- keep partial and failed source states visible
- normalize malformed multiline crt.sh wildcard names found during live verification

## Operator impact

Operators receive one consistent completed-run view after all selected stages finish. Terminal output groups unique names by addressability and scope, while JSONL retains the typed evidence needed for later analysis without changing legacy output fields.

## Stack status

This draft is based on `feature/provider-descendant-queries` from #2435 because that is the latest branch currently published in the upstream stack.

The reviewed intermediate evidence-run, source-catalog, DNSDB-evidence, and DNS-consensus branches currently exist only on `NotoriousRebel/theHarvester`. Until those bases are represented upstream, this pull request temporarily includes their commits. Restack this pull request before review or merge.

This change does not consume `SourceSpec.queries_provider_descendants`. PR #2435 should remain draft or be folded into the first provider-recursion change that uses that metadata.

## Verification

- focused completed-output, run, host-checker, and crt.sh tests: 39 passed
- full suite: 299 passed, 6 skipped
- `ruff check .`
- `ruff format --check .`
- `mypy theHarvester`
- `git diff --check`
- zero em dashes in the diff
- Standards review: pass, zero findings
- Spec review against NotoriousRebel/theHarvester#63: pass, zero findings
- live keyless crt.sh run against `tesla.com`: 321 findings, 1,740 DNS observations across three resolvers, 321 merged results, 114 currently addressable names

Tracking issue: https://github.com/NotoriousRebel/theHarvester/issues/63
