### PR TITLE
feat: record subdomain collection outcomes

### DIFF
--- a/tests/discovery/test_builtwith.py
+++ b/tests/discovery/test_builtwith.py
@@ -79,6 +79,7 @@ async def test_process_accepts_text_json_content_type(monkeypatch) -> None:
     await search.process()
 
     assert await search.get_hostnames() == {'sub.example.com'}
+    assert await search.get_interestingurls() == {'https://example.com/login'}
     assert await search.get_interesting_urls() == {'https://example.com/login'}
     assert await search.get_frameworks() == {'Django'}
     assert await search.get_languages() == {'Python'}
@@ -88,7 +89,7 @@ async def test_process_accepts_text_json_content_type(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_process_handles_non_200_status(monkeypatch) -> None:
+async def test_process_reports_non_200_status(monkeypatch) -> None:
     monkeypatch.setattr(builtwith.Core, 'builtwith_key', lambda: 'dummy-key')
 
     class _FakeResponse:
@@ -116,7 +117,5 @@ async def test_process_handles_non_200_status(monkeypatch) -> None:
     monkeypatch.setattr(builtwith.aiohttp, 'ClientSession', _FakeSession)
 
     search = builtwith.SearchBuiltWith('example.com')
-    await search.process()
-
-    assert await search.get_hostnames() == set()
-    assert await search.get_tech_stack() == {}
+    with pytest.raises(RuntimeError, match='BuiltWith returned HTTP 403'):
+        await search.process()

--- a/tests/discovery/test_builtwith.py
+++ b/tests/discovery/test_builtwith.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import types
 
@@ -28,8 +29,7 @@ async def test_missing_key_raises(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_process_accepts_text_json_content_type(monkeypatch) -> None:
-    """BuiltWith API returns 'text/json' content-type; response.json(content_type=None)
-    must be used so aiohttp does not raise a ContentTypeError."""
+    """BuiltWith text/json payloads must be decoded without MIME enforcement."""
     monkeypatch.setattr(builtwith.Core, 'builtwith_key', lambda: 'dummy-key')
 
     api_payload = {
@@ -44,39 +44,16 @@ async def test_process_accepts_text_json_content_type(monkeypatch) -> None:
         ],
     }
 
-    class _FakeResponse:
-        status = 200
+    async def fake_fetch(**kwargs):
+        assert kwargs['json'] is False
+        assert kwargs['fail_on_http_error'] is True
+        assert kwargs['follow_redirects'] is False
+        return json.dumps(api_payload)
 
-        async def json(self, **kwargs):
-            # Simulate aiohttp accepting content_type=None for 'text/json' responses
-            assert kwargs.get('content_type') is None, (
-                'content_type=None must be passed to accept non-standard MIME types like text/json'
-            )
-            return api_payload
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            pass
-
-    class _FakeSession:
-        def __init__(self, **_kwargs):
-            pass
-
-        def get(self, *_args, **_kwargs):
-            return _FakeResponse()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            pass
-
-    monkeypatch.setattr(builtwith.aiohttp, 'ClientSession', _FakeSession)
+    monkeypatch.setattr(builtwith.AsyncFetcher, 'fetch', fake_fetch)
 
     search = builtwith.SearchBuiltWith('example.com')
-    await search.process()
+    await search.process(proxy=True)
 
     assert await search.get_hostnames() == {'sub.example.com'}
     assert await search.get_interestingurls() == {'https://example.com/login'}
@@ -92,30 +69,42 @@ async def test_process_accepts_text_json_content_type(monkeypatch) -> None:
 async def test_process_reports_non_200_status(monkeypatch) -> None:
     monkeypatch.setattr(builtwith.Core, 'builtwith_key', lambda: 'dummy-key')
 
-    class _FakeResponse:
-        status = 403
+    async def fake_fetch(**_kwargs):
+        raise RuntimeError('HTTP 403')
 
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            pass
-
-    class _FakeSession:
-        def __init__(self, **_kwargs):
-            pass
-
-        def get(self, *_args, **_kwargs):
-            return _FakeResponse()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            pass
-
-    monkeypatch.setattr(builtwith.aiohttp, 'ClientSession', _FakeSession)
+    monkeypatch.setattr(builtwith.AsyncFetcher, 'fetch', fake_fetch)
 
     search = builtwith.SearchBuiltWith('example.com')
     with pytest.raises(RuntimeError, match='BuiltWith returned HTTP 403'):
+        await search.process()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('payload', ['', '{"error": "unauthorized"}'])
+async def test_proxy_failure_is_not_reported_as_empty(monkeypatch, payload) -> None:
+    monkeypatch.setattr(builtwith.Core, 'builtwith_key', lambda: 'dummy-key')
+
+    async def fake_fetch(**kwargs):
+        assert kwargs['fail_on_http_error'] is True
+        assert kwargs['json'] is False
+        return payload
+
+    monkeypatch.setattr(builtwith.AsyncFetcher, 'fetch', fake_fetch)
+
+    search = builtwith.SearchBuiltWith('example.com')
+    with pytest.raises(ValueError, match='BuiltWith returned an invalid payload'):
+        await search.process(proxy=True)
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload_is_not_reported_as_empty(monkeypatch) -> None:
+    monkeypatch.setattr(builtwith.Core, 'builtwith_key', lambda: 'dummy-key')
+
+    async def fake_fetch(**_kwargs):
+        return '[]'
+
+    monkeypatch.setattr(builtwith.AsyncFetcher, 'fetch', fake_fetch)
+
+    search = builtwith.SearchBuiltWith('example.com')
+    with pytest.raises(ValueError, match='BuiltWith returned an invalid payload'):
         await search.process()

--- a/tests/discovery/test_crtsh.py
+++ b/tests/discovery/test_crtsh.py
@@ -100,15 +100,28 @@ class TestCrtshSearch:
         assert await search.get_hostnames() == ['api.example.com']
 
     @pytest.mark.asyncio
-    async def test_missing_name_value_key_is_handled(self, monkeypatch):
+    async def test_invalid_responses_raise_after_retries(self, monkeypatch):
+        fetches = _patch_fetch(monkeypatch, '')
+        delays = _patch_sleep(monkeypatch)
+        search = crtsh.SearchCrtsh('example.com')
+
+        with pytest.raises(ValueError, match=r'No valid response from crt\.sh after 3 attempts'):
+            await search.process()
+
+        assert len(fetches) == 3
+        assert delays == [2, 2]
+
+    @pytest.mark.asyncio
+    async def test_missing_name_value_key_is_reported_as_failure(self, monkeypatch):
         fetches = _patch_fetch(monkeypatch, [{'issuer_ca_id': 1}])
         delays = _patch_sleep(monkeypatch)
         search = crtsh.SearchCrtsh('example.com')
-        await search.process()
+
+        with pytest.raises(KeyError, match='name_value'):
+            await search.process()
 
         assert len(fetches) == 1
         assert delays == []
-        assert await search.get_hostnames() == []
 
 
 class TestCrtshIntegration:

--- a/tests/discovery/test_securityscorecard.py
+++ b/tests/discovery/test_securityscorecard.py
@@ -1,0 +1,36 @@
+import pytest
+
+from theHarvester.discovery import securityscorecard
+
+
+@pytest.mark.asyncio
+async def test_process_reports_non_200_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(securityscorecard.Core, 'securityscorecard_key', lambda: 'dummy-key')
+
+    class FakeResponse:
+        status = 503
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            pass
+
+    class FakeSession:
+        def __init__(self, **_kwargs):
+            pass
+
+        def get(self, *_args, **_kwargs):
+            return FakeResponse()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            pass
+
+    monkeypatch.setattr(securityscorecard.aiohttp, 'ClientSession', FakeSession)
+
+    search = securityscorecard.SearchSecurityScorecard('example.com')
+    with pytest.raises(RuntimeError, match='SecurityScorecard returned HTTP 503'):
+        await search.process()

--- a/tests/discovery/test_securityscorecard.py
+++ b/tests/discovery/test_securityscorecard.py
@@ -7,30 +7,63 @@ from theHarvester.discovery import securityscorecard
 async def test_process_reports_non_200_status(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(securityscorecard.Core, 'securityscorecard_key', lambda: 'dummy-key')
 
-    class FakeResponse:
-        status = 503
+    async def fake_fetch(**_kwargs):
+        raise RuntimeError('HTTP 503')
 
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            pass
-
-    class FakeSession:
-        def __init__(self, **_kwargs):
-            pass
-
-        def get(self, *_args, **_kwargs):
-            return FakeResponse()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            pass
-
-    monkeypatch.setattr(securityscorecard.aiohttp, 'ClientSession', FakeSession)
+    monkeypatch.setattr(securityscorecard.AsyncFetcher, 'fetch', fake_fetch)
 
     search = securityscorecard.SearchSecurityScorecard('example.com')
     with pytest.raises(RuntimeError, match='SecurityScorecard returned HTTP 503'):
         await search.process()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('payload', ['', {'error': 'unauthorized'}])
+async def test_proxy_failure_is_not_reported_as_empty(
+    monkeypatch: pytest.MonkeyPatch, payload: object
+) -> None:
+    monkeypatch.setattr(securityscorecard.Core, 'securityscorecard_key', lambda: 'dummy-key')
+
+    async def fake_fetch(**kwargs):
+        assert kwargs['fail_on_http_error'] is True
+        assert kwargs['json'] is True
+        return payload
+
+    monkeypatch.setattr(securityscorecard.AsyncFetcher, 'fetch', fake_fetch)
+
+    search = securityscorecard.SearchSecurityScorecard('example.com')
+    with pytest.raises(ValueError, match='SecurityScorecard returned an invalid payload'):
+        await search.process(proxy=True)
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload_is_not_reported_as_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(securityscorecard.Core, 'securityscorecard_key', lambda: 'dummy-key')
+
+    async def fake_fetch(**_kwargs):
+        return []
+
+    monkeypatch.setattr(securityscorecard.AsyncFetcher, 'fetch', fake_fetch)
+
+    search = securityscorecard.SearchSecurityScorecard('example.com')
+    with pytest.raises(ValueError, match='SecurityScorecard returned an invalid payload'):
+        await search.process()
+
+
+@pytest.mark.asyncio
+async def test_process_uses_shared_transport_without_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(securityscorecard.Core, 'securityscorecard_key', lambda: 'dummy-key')
+
+    async def fake_fetch(**kwargs):
+        assert kwargs['proxy'] is False
+        assert kwargs['json'] is True
+        assert kwargs['fail_on_http_error'] is True
+        assert kwargs['follow_redirects'] is False
+        return {'domains': []}
+
+    monkeypatch.setattr(securityscorecard.AsyncFetcher, 'fetch', fake_fetch)
+
+    search = securityscorecard.SearchSecurityScorecard('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == set()

--- a/tests/lib/test_core.py
+++ b/tests/lib/test_core.py
@@ -131,9 +131,10 @@ def test_read_config_copies_default_to_home(name: str, capsys):
 
 
 class DummyResponse:
-    def __init__(self, text_value: str = 'response-text', json_value: Any = None):
+    def __init__(self, text_value: str = 'response-text', json_value: Any = None, status: int = 200):
         self.text_value = text_value
         self.json_value = {'ok': True} if json_value is None else json_value
+        self.status = status
 
     async def __aenter__(self):
         return self
@@ -279,6 +280,24 @@ async def test_fetch_uses_http_proxy_when_enabled(monkeypatch) -> None:
     assert session.requests == [
         ('GET', 'https://example.com', {'ssl': 'ssl-context', 'proxy': 'http://proxy.local:8080'})
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('status', [302, 503])
+async def test_fetch_can_report_http_errors(monkeypatch, status: int) -> None:
+    class ErrorSession(DummySession):
+        def request(self, method: str, url: str, **kwargs):
+            self.requests.append((method, url, kwargs))
+            return DummyResponse(status=status)
+
+    reset_dummy_sessions()
+    monkeypatch.setattr(core_module.aiohttp, 'ClientSession', ErrorSession)
+    monkeypatch.setattr(core_module.ssl, 'create_default_context', lambda cafile=None: 'ssl-context')
+    monkeypatch.setattr(core_module.certifi, 'where', lambda: '/tmp/cacert.pem')
+    monkeypatch.setattr(core_module.asyncio, 'sleep', fake_sleep)
+
+    with pytest.raises(RuntimeError, match=f'HTTP {status}'):
+        await AsyncFetcher.fetch(url='https://example.com', fail_on_http_error=True)
 
 
 @pytest.mark.asyncio

--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import pytest
+
+from theHarvester.lib.run import (
+    LegacyHostnameSource,
+    ScopeClass,
+    SourceStatus,
+    execute_collection,
+    legacy_subdomains,
+)
+
+
+class FakeHostnameSearch:
+    def __init__(self, values: list[str]) -> None:
+        self.values = values
+        self.process_calls: list[bool] = []
+
+    async def process(self, proxy: bool = False) -> None:
+        self.process_calls.append(proxy)
+
+    async def get_hostnames(self) -> list[str]:
+        return self.values
+
+
+class FailingHostnameSearch:
+    async def process(self, proxy: bool = False) -> None:
+        raise RuntimeError('provider unavailable')
+
+    async def get_hostnames(self) -> list[str]:
+        raise AssertionError('failed sources have no results')
+
+
+@pytest.mark.asyncio
+async def test_collection_normalizes_scope_and_preserves_www_target_behavior() -> None:
+    search = FakeHostnameSearch(
+        [
+            'API.Example.COM.',
+            'BÜCHER.Example.COM.',
+            'example.com',
+            'example.com.attacker.test',
+            '',
+        ]
+    )
+
+    result = await execute_collection(
+        'WWW.Example.COM.',
+        LegacyHostnameSource(name='fixture', search=search, proxy=True),
+    )
+
+    assert result.target == 'example.com'
+    assert search.process_calls == [True]
+    assert result.outcome.status is SourceStatus.SUCCEEDED
+    assert result.outcome.process_succeeded is True
+    assert result.outcome.error_type is None
+    assert [(observation.value, observation.scope_class) for observation in result.observations] == [
+        ('api.example.com', ScopeClass.IN_SCOPE),
+        ('xn--bcher-kva.example.com', ScopeClass.IN_SCOPE),
+        ('example.com', ScopeClass.IN_SCOPE),
+        ('example.com.attacker.test', ScopeClass.OUT_OF_SCOPE),
+    ]
+    assert legacy_subdomains(result) == ['api.example.com', 'xn--bcher-kva.example.com']
+
+
+@pytest.mark.asyncio
+async def test_collection_records_a_valid_empty_source() -> None:
+    result = await execute_collection(
+        'example.com',
+        LegacyHostnameSource(name='fixture', search=FakeHostnameSearch([])),
+    )
+
+    assert result.outcome.status is SourceStatus.EMPTY
+    assert result.outcome.process_succeeded is True
+    assert result.outcome.error_type is None
+    assert result.observations == ()
+
+
+@pytest.mark.asyncio
+async def test_collection_reports_nonempty_unusable_results_as_failure() -> None:
+    result = await execute_collection(
+        'example.com',
+        LegacyHostnameSource(
+            name='fixture',
+            search=FakeHostnameSearch(['', '...', 'bad host', 'https://api.example.com']),
+        ),
+    )
+
+    assert result.outcome.status is SourceStatus.FAILED
+    assert result.outcome.process_succeeded is True
+    assert result.outcome.error_type == 'ValueError'
+    assert result.observations == ()
+
+
+@pytest.mark.asyncio
+async def test_collection_records_source_failures_without_results() -> None:
+    result = await execute_collection(
+        'example.com',
+        LegacyHostnameSource(name='fixture', search=FailingHostnameSearch()),
+    )
+
+    assert result.outcome.status is SourceStatus.FAILED
+    assert result.outcome.process_succeeded is False
+    assert result.outcome.error_type == 'RuntimeError'
+    assert result.observations == ()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,16 +1,118 @@
+import argparse
+import logging
+
 import pytest
 
 from theHarvester import __main__ as theharvester_main
 
 
-@pytest.mark.parametrize('target', ['Example.COM.', 'WWW.Example.COM.'])
-def test_normalize_hosts_for_storage_uses_the_parser_scope(target: str) -> None:
-    discovered_hosts: set[object] = {
-        'API.Example.COM.',
-        'example.com',
-        'badexample.com',
-        'example.com.attacker.test',
-        123,
-    }
+def _start_args(source: str = 'crtsh') -> argparse.Namespace:
+    return argparse.Namespace(
+        api_scan=False,
+        dns_brute=False,
+        dns_lookup=False,
+        dns_resolve='',
+        dns_server=None,
+        domain='example.com',
+        filename='',
+        limit=500,
+        proxies=False,
+        quiet=True,
+        shodan=False,
+        source=source,
+        start=0,
+        take_over=False,
+        wordlist='',
+    )
 
-    assert theharvester_main._normalize_hosts_for_storage(discovered_hosts, target) == {'api.example.com'}
+
+def _patch_stash(monkeypatch: pytest.MonkeyPatch, stored: list[tuple[str, tuple[str, ...], str, str]]) -> None:
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, domain: str, values: list[str], result_type: str, source: str) -> None:
+            stored.append((domain, tuple(values), result_type, source))
+
+    monkeypatch.setattr(theharvester_main.stash, 'StashManager', FakeStashManager)
+
+
+@pytest.mark.asyncio
+async def test_crtsh_collection_executes_once_and_feeds_legacy_storage(monkeypatch: pytest.MonkeyPatch) -> None:
+    process_calls: list[bool] = []
+    stored: list[tuple[str, tuple[str, ...], str, str]] = []
+
+    class FakeCrtshSearch:
+        def __init__(self, target: str) -> None:
+            assert target == 'example.com'
+
+        async def process(self, proxy: bool = False) -> None:
+            process_calls.append(proxy)
+
+        async def get_hostnames(self) -> list[str]:
+            return ['WWW.EXAMPLE.COM.', 'api.example.com', 'example.com.evil.test']
+
+    monkeypatch.setattr(theharvester_main.crtsh, 'SearchCrtsh', FakeCrtshSearch)
+    _patch_stash(monkeypatch, stored)
+
+    await theharvester_main.start(_start_args())
+
+    assert process_calls == [False]
+    assert stored == [('example.com', ('api.example.com', 'www.example.com'), 'host', 'CRTsh')]
+
+
+@pytest.mark.asyncio
+async def test_crtsh_collection_reports_provider_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    process_calls: list[bool] = []
+    stored: list[tuple[str, tuple[str, ...], str, str]] = []
+
+    class FailingCrtshSearch:
+        def __init__(self, target: str) -> None:
+            assert target == 'example.com'
+
+        async def process(self, proxy: bool = False) -> None:
+            process_calls.append(proxy)
+            raise RuntimeError('provider unavailable')
+
+        async def get_hostnames(self) -> list[str]:
+            raise AssertionError('failed sources have no results')
+
+    monkeypatch.setattr(theharvester_main.crtsh, 'SearchCrtsh', FailingCrtshSearch)
+    _patch_stash(monkeypatch, stored)
+    caplog.set_level(logging.INFO, logger='theHarvester.output')
+
+    await theharvester_main.start(_start_args())
+
+    assert process_calls == [False]
+    assert stored == []
+    assert 'Source CRTsh failed: RuntimeError' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_invalid_subdomains_do_not_suppress_other_source_routes(monkeypatch: pytest.MonkeyPatch) -> None:
+    process_calls: list[bool] = []
+    stored: list[tuple[str, tuple[str, ...], str, str]] = []
+
+    class FakeBaiduSearch:
+        def __init__(self, target: str, limit: int) -> None:
+            assert (target, limit) == ('example.com', 500)
+
+        async def process(self, proxy: bool = False) -> None:
+            process_calls.append(proxy)
+
+        async def get_hostnames(self) -> list[str]:
+            return ['bad host']
+
+        async def get_emails(self) -> list[str]:
+            return ['ops@example.com']
+
+    monkeypatch.setattr(theharvester_main.baidusearch, 'SearchBaidu', FakeBaiduSearch)
+    _patch_stash(monkeypatch, stored)
+
+    await theharvester_main.start(_start_args('baidu'))
+
+    assert process_calls == [False]
+    assert stored == [('example.com', ('ops@example.com',), 'email', 'baidu')]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import sys
 
 import pytest
 
@@ -116,3 +117,55 @@ async def test_invalid_subdomains_do_not_suppress_other_source_routes(monkeypatc
 
     assert process_calls == [False]
     assert stored == [('example.com', ('ops@example.com',), 'email', 'baidu')]
+
+
+@pytest.mark.asyncio
+async def test_selected_sources_execute_once_through_central_routes(monkeypatch: pytest.MonkeyPatch) -> None:
+    process_calls = {'builtwith': 0, 'securityscorecard': 0}
+    stored: list[tuple[str, tuple[str, ...], str, str]] = []
+
+    class FakeBuiltWithSearch:
+        def __init__(self, target: str) -> None:
+            assert target == 'example.com'
+
+        async def process(self, proxy: bool = False) -> None:
+            assert proxy is False
+            process_calls['builtwith'] += 1
+
+        async def get_hostnames(self) -> list[str]:
+            return ['app.example.com']
+
+        async def get_interestingurls(self) -> list[str]:
+            return ['https://example.com/login']
+
+    class FakeSecurityScorecardSearch:
+        def __init__(self, target: str) -> None:
+            assert target == 'example.com'
+
+        async def process(self, proxy: bool = False) -> None:
+            assert proxy is False
+            process_calls['securityscorecard'] += 1
+
+        async def get_hostnames(self) -> list[str]:
+            return ['score.example.com']
+
+        async def get_ips(self) -> list[str]:
+            return ['192.0.2.10']
+
+    monkeypatch.setattr(theharvester_main.builtwith, 'SearchBuiltWith', FakeBuiltWithSearch)
+    monkeypatch.setattr(theharvester_main.securityscorecard, 'SearchSecurityScorecard', FakeSecurityScorecardSearch)
+    _patch_stash(monkeypatch, stored)
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['theHarvester', '-d', 'example.com', '-b', 'builtwith,securityscorecard', '--quiet'],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    assert process_calls == {'builtwith': 1, 'securityscorecard': 1}
+    assert ('example.com', ('https://example.com/login',), 'interestingurls', 'builtwith') in stored
+    assert ('example.com', ('192.0.2.10',), 'ip', 'securityscorecard') in stored

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -8,7 +8,6 @@ import string
 import sys
 import time
 import traceback
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 import anyio
@@ -80,8 +79,8 @@ from theHarvester.discovery import (
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib import hostchecker, stash
 from theHarvester.lib.core import DATA_DIR, Core, show_default_error_message
-from theHarvester.lib.hostnames import normalize_scoped_hostname
 from theHarvester.lib.output import configure_logging, output_logger, print_linkedin_sections, print_section, sorted_unique
+from theHarvester.lib.run import LegacyHostnameSource, SourceStatus, execute_collection, legacy_subdomains
 from theHarvester.lib.source_catalog import ResultRoute, get_source_spec
 from theHarvester.screenshot.screenshot import ScreenShotter
 
@@ -89,15 +88,6 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable
 
 logger = logging.getLogger(__name__)
-
-
-def _normalize_hosts_for_storage(discovered_hosts: Iterable[object], target: str) -> set[str]:
-    normalized_target = target.strip().lower().removeprefix('www.').rstrip('.')
-    return {
-        normalized
-        for host in discovered_hosts
-        if (normalized := normalize_scoped_hostname(host, normalized_target)) and normalized != normalized_target
-    }
 
 
 def sanitize_for_xml(text: str) -> str:
@@ -348,21 +338,35 @@ async def start(rest_args: argparse.Namespace | None = None):
         :param search_engine: search engine to fetch details from
         :param source: source against which the details (corresponding to the search engine) need to be persisted
         """
-        logger.info(f'Source {source} started')
-        try:
-            await search_engine.process(use_proxy)
-        except Exception:
-            logger.exception(f'Source {source} failed')
-            raise
-        db_stash = stash.StashManager()
         routes = get_source_spec(source).routes
+        logger.info(f'Source {source} started')
+        collection_result = None
+        if ResultRoute.SUBDOMAINS in routes:
+            collection_result = await execute_collection(
+                word,
+                LegacyHostnameSource(get_source_spec(source).name, search_engine, use_proxy),
+            )
+            if collection_result.outcome.status is SourceStatus.FAILED:
+                if collection_result.outcome.process_succeeded:
+                    output_logger.info(
+                        f'\n[!] Source {source} subdomain collection failed: {collection_result.outcome.error_type}\n'
+                    )
+                else:
+                    output_logger.info(f'\n[!] Source {source} failed: {collection_result.outcome.error_type}\n')
+                    return
+        else:
+            try:
+                await search_engine.process(use_proxy)
+            except Exception:
+                logger.exception(f'Source {source} failed')
+                raise
+        db_stash = stash.StashManager()
 
         if source:
             output_logger.info(f'[*] Searching {source[0].upper() + source[1:]}. ')
 
-        if ResultRoute.SUBDOMAINS in routes:
-            discovered_hosts = await search_engine.get_hostnames()
-            host_names = list(_normalize_hosts_for_storage(discovered_hosts, word))
+        if collection_result is not None and collection_result.outcome.status is not SourceStatus.FAILED:
+            host_names = legacy_subdomains(collection_result)
             if source != 'hackertarget' and source != 'pentesttools' and source != 'rapiddns':
                 # If a source is inside this conditional, it means the hosts returned must be resolved to obtain ip
                 # This should only be checked if --dns-resolve has a wordlist

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -1799,60 +1799,6 @@ async def start(rest_args: argparse.Namespace | None = None):
             output_logger.info('    Continuing with the rest of the scan...')
             traceback.print_exc()  # More detailed error information for developers
 
-    if 'securityscorecard' in engines:
-        try:
-            output_logger.info('\n[*] Performing SecurityScorecard scan...')
-            securityscorecard_scanner = securityscorecard.SearchSecurityScorecard(word)
-            await securityscorecard_scanner.process(use_proxy)
-
-            # Use the existing API to get results
-            hosts = await securityscorecard_scanner.get_hostnames()
-            if hosts:
-                output_logger.info(f'\n[*] SecurityScorecard results: {len(hosts)} hosts found')
-                for host in hosts:
-                    output_logger.info(f'    - {host}')
-
-                all_hosts.extend(hosts)
-
-            ips = await securityscorecard_scanner.get_ips()
-            if ips:
-                output_logger.info(f'\n[*] SecurityScorecard IPs found: {len(ips)}')
-                for ip in ips:
-                    output_logger.info(f'    - {ip}')
-                all_ip.extend(ips)
-
-        except Exception as e:
-            output_logger.info(f'An exception has occurred in SecurityScorecard scanning: {e}')
-
-    if 'builtwith' in engines:
-        try:
-            output_logger.info('\n[*] Performing BuiltWith scan...')
-            builtwith_scanner = builtwith.SearchBuiltWith(word)
-            await builtwith_scanner.process(use_proxy)
-
-            hosts = await builtwith_scanner.get_hostnames()
-            if hosts:
-                output_logger.info(f'\n[*] BuiltWith results: {len(hosts)} hosts found')
-                for host in hosts:
-                    output_logger.info(f'    - {host}')
-
-                # Add results to the main host list
-                all_hosts.extend(hosts)
-
-            urls = list(await builtwith_scanner.get_interesting_urls())
-            if urls:
-                output_logger.info(f'\n[*] BuiltWith interesting URLs found: {len(urls)}')
-                for url in urls:
-                    output_logger.info(f'    - {url}')
-                interesting_urls.extend(urls)
-
-        except Exception as e:
-            if isinstance(e, MissingKey):
-                if not args.quiet:
-                    output_logger.info(MissingKey('BuiltWith'))
-                else:
-                    output_logger.info(f'An exception has occurred in BuiltWith scanning: {e}')
-
     if rest_args is not None:
         all_hosts = sorted({host.replace('www.', '') for host in all_hosts})
         return (

--- a/theHarvester/discovery/builtwith.py
+++ b/theHarvester/discovery/builtwith.py
@@ -1,6 +1,5 @@
+import json
 from typing import Any
-
-import aiohttp
 
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib.core import AsyncFetcher, Core
@@ -25,25 +24,31 @@ class SearchBuiltWith:
 
     async def process(self, proxy: bool = False) -> None:
         """Get technology stack information for a domain."""
-        if proxy:
+        try:
             response = await AsyncFetcher.fetch(
-                session=None, url=f'{self.base_url}?KEY={self.api_key}&LOOKUP={self.word}', headers=self.headers, proxy=proxy
+                session=None,
+                url=f'{self.base_url}?KEY={self.api_key}&LOOKUP={self.word}',
+                headers=self.headers,
+                proxy=proxy,
+                json=False,
+                fail_on_http_error=True,
+                follow_redirects=False,
             )
-            if response is None:
-                raise RuntimeError('BuiltWith returned no response')
-            self.tech_stack = response
-            self._extract_data()
-            return
-
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with session.get(f'{self.base_url}?KEY={self.api_key}&LOOKUP={self.word}') as response:
-                if response.status != 200:
-                    raise RuntimeError(f'BuiltWith returned HTTP {response.status}')
-                self.tech_stack = await response.json(content_type=None)
-                self._extract_data()
+        except RuntimeError as error:
+            raise RuntimeError(f'BuiltWith returned {error}') from error
+        try:
+            payload = json.loads(response)
+        except (json.JSONDecodeError, TypeError) as error:
+            raise ValueError('BuiltWith returned an invalid payload') from error
+        if not isinstance(payload, dict):
+            raise ValueError('BuiltWith returned an invalid payload')
+        self.tech_stack = payload
+        self._extract_data()
 
     def _extract_data(self) -> None:
         """Extract and categorize technology information."""
+        if self.tech_stack.keys().isdisjoint({'domains', 'paths', 'technologies'}):
+            raise ValueError('BuiltWith returned an invalid payload')
         if 'domains' in self.tech_stack:
             self.hosts.update(self.tech_stack['domains'])
         if 'paths' in self.tech_stack:

--- a/theHarvester/discovery/builtwith.py
+++ b/theHarvester/discovery/builtwith.py
@@ -1,12 +1,9 @@
-import logging
 from typing import Any
 
 import aiohttp
 
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib.core import AsyncFetcher, Core
-
-logger = logging.getLogger(__name__)
 
 
 class SearchBuiltWith:
@@ -28,23 +25,22 @@ class SearchBuiltWith:
 
     async def process(self, proxy: bool = False) -> None:
         """Get technology stack information for a domain."""
-        try:
-            if proxy:
-                response = await AsyncFetcher.fetch(
-                    session=None, url=f'{self.base_url}?KEY={self.api_key}&LOOKUP={self.word}', headers=self.headers, proxy=proxy
-                )
-                if response:
-                    self.tech_stack = response
-                    self._extract_data()
-            else:
-                async with aiohttp.ClientSession(headers=self.headers) as session:
-                    async with session.get(f'{self.base_url}?KEY={self.api_key}&LOOKUP={self.word}') as response:
-                        if response.status == 200:
-                            data = await response.json(content_type=None)
-                            self.tech_stack = data
-                            self._extract_data()
-        except Exception as e:
-            logger.info(f'Error in BuiltWith search: {e}')
+        if proxy:
+            response = await AsyncFetcher.fetch(
+                session=None, url=f'{self.base_url}?KEY={self.api_key}&LOOKUP={self.word}', headers=self.headers, proxy=proxy
+            )
+            if response is None:
+                raise RuntimeError('BuiltWith returned no response')
+            self.tech_stack = response
+            self._extract_data()
+            return
+
+        async with aiohttp.ClientSession(headers=self.headers) as session:
+            async with session.get(f'{self.base_url}?KEY={self.api_key}&LOOKUP={self.word}') as response:
+                if response.status != 200:
+                    raise RuntimeError(f'BuiltWith returned HTTP {response.status}')
+                self.tech_stack = await response.json(content_type=None)
+                self._extract_data()
 
     def _extract_data(self) -> None:
         """Extract and categorize technology information."""
@@ -74,7 +70,11 @@ class SearchBuiltWith:
     async def get_tech_stack(self) -> dict:
         return self.tech_stack
 
+    async def get_interestingurls(self) -> set[str]:
+        return self.interesting_urls
+
     async def get_interesting_urls(self) -> set[str]:
+        """Return interesting URLs for existing direct consumers."""
         return self.interesting_urls
 
     async def get_frameworks(self) -> set[str]:

--- a/theHarvester/discovery/crtsh.py
+++ b/theHarvester/discovery/crtsh.py
@@ -1,9 +1,6 @@
 import asyncio
-import logging
 
 from theHarvester.lib.core import AsyncFetcher
-
-logger = logging.getLogger(__name__)
 
 
 class SearchCrtsh:
@@ -13,29 +10,22 @@ class SearchCrtsh:
         self.proxy = False
 
     async def do_search(self) -> list:
-        data: set = set()
         url = f'https://crt.sh/?q=%25.{self.word}&exclude=expired&deduplicate=Y&output=json'
         response = None
-        try:
-            max_attempts = 3
-            for attempt in range(max_attempts):
-                responses = await AsyncFetcher.fetch_all([url], json=True, proxy=self.proxy)
-                if responses and isinstance(responses[0], list):
-                    response = responses[0]
-                    break
-                if attempt < max_attempts - 1:
-                    await asyncio.sleep(2)
+        max_attempts = 3
+        for attempt in range(max_attempts):
+            responses = await AsyncFetcher.fetch_all([url], json=True, proxy=self.proxy)
+            if responses and isinstance(responses[0], list):
+                response = responses[0]
+                break
+            if attempt < max_attempts - 1:
+                await asyncio.sleep(2)
 
-            if response is None:
-                logger.info(f'No valid response from crt.sh after {max_attempts} attempts.')
-                return []
+        if response is None:
+            raise ValueError(f'No valid response from crt.sh after {max_attempts} attempts')
 
-            data = set([(dct['name_value'][2:] if dct['name_value'][:2] == '*.' else dct['name_value']) for dct in response])
-            data = {domain for domain in data if (domain[0] != '*' and str(domain[0:4]).isnumeric() is False)}
-        except KeyError as ke:
-            logger.info(f'Missing expected key in response: {ke}')
-        except Exception as e:
-            logger.info(f'Unexpected error: {e}')
+        data = {(dct['name_value'][2:] if dct['name_value'][:2] == '*.' else dct['name_value']) for dct in response}
+        data = {domain for domain in data if domain[0] != '*' and not str(domain[0:4]).isnumeric()}
         clean: list = []
         for x in data:
             pre = x.split()

--- a/theHarvester/discovery/securityscorecard.py
+++ b/theHarvester/discovery/securityscorecard.py
@@ -1,5 +1,3 @@
-import aiohttp
-
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib.core import AsyncFetcher, Core
 
@@ -22,23 +20,38 @@ class SearchSecurityScorecard:
 
     async def process(self, proxy: bool = False) -> None:
         """Get security scorecard information for a domain."""
-        if proxy:
-            response = await AsyncFetcher.fetch(
-                session=None, url=f'{self.base_url}/companies/{self.word}', headers=self.headers, proxy=proxy
+        try:
+            payload = await AsyncFetcher.fetch(
+                session=None,
+                url=f'{self.base_url}/companies/{self.word}',
+                headers=self.headers,
+                proxy=proxy,
+                json=True,
+                fail_on_http_error=True,
+                follow_redirects=False,
             )
-            if response is None:
-                raise RuntimeError('SecurityScorecard returned no response')
-            self._extract_data(response)
-            return
-
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with session.get(f'{self.base_url}/companies/{self.word}') as response:
-                if response.status != 200:
-                    raise RuntimeError(f'SecurityScorecard returned HTTP {response.status}')
-                self._extract_data(await response.json())
+        except RuntimeError as error:
+            raise RuntimeError(f'SecurityScorecard returned {error}') from error
+        if not isinstance(payload, dict):
+            raise ValueError('SecurityScorecard returned an invalid payload')
+        self._extract_data(payload)
 
     def _extract_data(self, data: dict) -> None:
         """Extract and categorize security scorecard information."""
+        if data.keys().isdisjoint(
+            {
+                'grade',
+                'factor_grades',
+                'issues',
+                'recommendations',
+                'history',
+                'domains',
+                'ips',
+                'ip_addresses',
+                'associated_ips',
+            }
+        ):
+            raise ValueError('SecurityScorecard returned an invalid payload')
         if 'grade' in data:
             self.score = data.get('grade', 0)
 

--- a/theHarvester/discovery/securityscorecard.py
+++ b/theHarvester/discovery/securityscorecard.py
@@ -1,11 +1,7 @@
-import logging
-
 import aiohttp
 
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib.core import AsyncFetcher, Core
-
-logger = logging.getLogger(__name__)
 
 
 class SearchSecurityScorecard:
@@ -26,21 +22,20 @@ class SearchSecurityScorecard:
 
     async def process(self, proxy: bool = False) -> None:
         """Get security scorecard information for a domain."""
-        try:
-            if proxy:
-                response = await AsyncFetcher.fetch(
-                    session=None, url=f'{self.base_url}/companies/{self.word}', headers=self.headers, proxy=proxy
-                )
-                if response:
-                    self._extract_data(response)
-            else:
-                async with aiohttp.ClientSession(headers=self.headers) as session:
-                    async with session.get(f'{self.base_url}/companies/{self.word}') as response:
-                        if response.status == 200:
-                            data = await response.json()
-                            self._extract_data(data)
-        except Exception as e:
-            logger.info(f'Error in SecurityScorecard search: {e}')
+        if proxy:
+            response = await AsyncFetcher.fetch(
+                session=None, url=f'{self.base_url}/companies/{self.word}', headers=self.headers, proxy=proxy
+            )
+            if response is None:
+                raise RuntimeError('SecurityScorecard returned no response')
+            self._extract_data(response)
+            return
+
+        async with aiohttp.ClientSession(headers=self.headers) as session:
+            async with session.get(f'{self.base_url}/companies/{self.word}') as response:
+                if response.status != 200:
+                    raise RuntimeError(f'SecurityScorecard returned HTTP {response.status}')
+                self._extract_data(await response.json())
 
     def _extract_data(self, data: dict) -> None:
         """Extract and categorize security scorecard information."""

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -490,7 +490,11 @@ class AsyncFetcher:
         return aiohttp.ClientSession(headers=headers, timeout=client_timeout, connector=connector)
 
     @staticmethod
-    async def _read_response(response: aiohttp.ClientResponse, *, json: bool, delay: int) -> Any:
+    async def _read_response(
+        response: aiohttp.ClientResponse, *, json: bool, delay: int, fail_on_http_error: bool = False
+    ) -> Any:
+        if fail_on_http_error and not 200 <= response.status < 300:
+            raise RuntimeError(f'HTTP {response.status}')
         await asyncio.sleep(delay)
         return await response.text() if json is False else await response.json()
 
@@ -504,15 +508,16 @@ class AsyncFetcher:
         json: bool = False,
         delay: int = 5,
         request_timeout: int | None = None,
+        fail_on_http_error: bool = False,
         **request_kwargs: Any,
     ) -> Any:
         if request_timeout:
             async with asyncio.timeout(request_timeout):
                 async with session.request(method.upper(), url, **request_kwargs) as response:
-                    return await cls._read_response(response, json=json, delay=delay)
+                    return await cls._read_response(response, json=json, delay=delay, fail_on_http_error=fail_on_http_error)
 
         async with session.request(method.upper(), url, **request_kwargs) as response:
-            return await cls._read_response(response, json=json, delay=delay)
+            return await cls._read_response(response, json=json, delay=delay, fail_on_http_error=fail_on_http_error)
 
     @staticmethod
     def _get_random_proxy(proxy_dict: dict) -> tuple[str | None, str | None]:
@@ -624,11 +629,13 @@ class AsyncFetcher:
         verify: bool | None = None,
         follow_redirects: bool | None = None,
         request_timeout: int | None = None,
+        fail_on_http_error: bool = False,
     ) -> Any:
         """Generic HTTP request helper.
         - If a session is not provided, one will be created and closed automatically.
         - Supports optional headers, method selection, proxy, ssl verification, redirects and timeout.
         - Returns response text or json depending on `json` flag.
+        - Raises RuntimeError for non-2xx responses when `fail_on_http_error` is enabled.
         """
         try:
             ssl_arg = cls._ssl_context(verify)
@@ -665,6 +672,7 @@ class AsyncFetcher:
                     json=json,
                     delay=5,
                     request_timeout=request_timeout,
+                    fail_on_http_error=fail_on_http_error,
                     **request_kwargs,
                 )
             finally:

--- a/theHarvester/lib/hostnames.py
+++ b/theHarvester/lib/hostnames.py
@@ -1,10 +1,29 @@
-def normalize_scoped_hostname(value: object, target: str) -> str | None:
-    """Return a canonical hostname when value is inside the target boundary."""
+import re
+
+_HOSTNAME_LABEL = re.compile(r'(?!-)[a-z0-9-]{1,63}(?<!-)\Z')
+
+
+def normalize_hostname(value: object) -> str | None:
+    """Return a canonical hostname, or ``None`` for an unusable value."""
     if not isinstance(value, str):
         return None
     hostname = value.strip().lower().rstrip('.')
-    normalized_target = target.strip().lower().rstrip('.')
-    if not normalized_target:
+    if not hostname:
+        return None
+    try:
+        hostname = hostname.encode('idna').decode('ascii')
+    except UnicodeError:
+        return None
+    if len(hostname) > 253 or any(_HOSTNAME_LABEL.fullmatch(label) is None for label in hostname.split('.')):
+        return None
+    return hostname
+
+
+def normalize_scoped_hostname(value: object, target: str) -> str | None:
+    """Return a canonical hostname when value is inside the target boundary."""
+    hostname = normalize_hostname(value)
+    normalized_target = normalize_hostname(target)
+    if hostname is None or normalized_target is None:
         return None
     if hostname == normalized_target or hostname.endswith(f'.{normalized_target}'):
         return hostname

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Protocol
+
+from theHarvester.lib.hostnames import normalize_hostname
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+class ScopeClass(StrEnum):
+    IN_SCOPE = 'in-scope'
+    OUT_OF_SCOPE = 'out-of-scope'
+
+
+class SourceStatus(StrEnum):
+    SUCCEEDED = 'succeeded'
+    EMPTY = 'empty'
+    FAILED = 'failed'
+
+
+class LegacyHostnameSearch(Protocol):
+    async def process(self, proxy: bool = False) -> None: ...
+
+    async def get_hostnames(self) -> Iterable[str]: ...
+
+
+@dataclass(frozen=True)
+class LegacyHostnameSource:
+    name: str
+    search: LegacyHostnameSearch
+    proxy: bool = False
+
+
+@dataclass(frozen=True)
+class DiscoveryObservation:
+    value: str
+    source: str
+    scope_class: ScopeClass
+
+
+@dataclass(frozen=True)
+class SourceOutcome:
+    source: str
+    status: SourceStatus
+    process_succeeded: bool
+    error_type: str | None = None
+
+
+@dataclass(frozen=True)
+class CollectionResult:
+    target: str
+    outcome: SourceOutcome
+    observations: tuple[DiscoveryObservation, ...]
+
+
+async def execute_collection(target: str, source: LegacyHostnameSource) -> CollectionResult:
+    normalized_target = normalize_hostname(target)
+    if normalized_target is None:
+        raise ValueError('target must be a hostname')
+    normalized_target = normalized_target.removeprefix('www.')
+    process_succeeded = False
+    try:
+        await source.search.process(source.proxy)
+        process_succeeded = True
+        candidates = tuple(await source.search.get_hostnames())
+        observations = tuple(
+            DiscoveryObservation(
+                value=value,
+                source=source.name,
+                scope_class=(
+                    ScopeClass.IN_SCOPE
+                    if value == normalized_target or value.endswith(f'.{normalized_target}')
+                    else ScopeClass.OUT_OF_SCOPE
+                ),
+            )
+            for candidate in candidates
+            if (value := normalize_hostname(candidate)) is not None
+        )
+        if candidates and not observations:
+            raise ValueError('source returned no usable hostnames')
+        status = SourceStatus.SUCCEEDED if observations else SourceStatus.EMPTY
+        return CollectionResult(normalized_target, SourceOutcome(source.name, status, True), observations)
+    except Exception as error:
+        logger.exception(f'Source {source.name} failed')
+        return CollectionResult(
+            normalized_target,
+            SourceOutcome(source.name, SourceStatus.FAILED, process_succeeded, type(error).__name__),
+            (),
+        )
+
+
+def legacy_subdomains(result: CollectionResult) -> list[str]:
+    """Return in-scope descendants for existing host-compatible consumers."""
+    return sorted(
+        {
+            observation.value
+            for observation in result.observations
+            if observation.scope_class is ScopeClass.IN_SCOPE and observation.value != result.target
+        }
+    )


### PR DESCRIPTION
## Summary

- route every declared `SUBDOMAINS` source through one collection seam
- normalize and validate IDNA hostnames, retain neutral in-scope and out-of-scope observations, and preserve legacy `host` storage
- record completed adapters as succeeded or empty, and record propagated adapter exceptions as failed
- make crt.sh, BuiltWith, and SecurityScorecard propagate transport, non-2xx, redirect, and parsing failures instead of presenting them as valid empty results
- preserve non-host routes when only subdomain collection is unusable

## Operator impact

Malformed hostnames are not silently stored. Failures surfaced by an adapter remain visible, including crt.sh, BuiltWith, and SecurityScorecard provider failures. Existing CLI, REST, file, and stash consumers continue receiving legacy in-scope subdomain values. No DNS resolution is enabled by this change.

## Adapter boundary

The collection seam cannot infer failures that a legacy adapter catches internally. Updating every provider adapter is intentionally outside this focused layer; those adapters must propagate their own failures before the seam can label them failed.

## Scope

This is a source collection layer, not a completed enumeration run. It intentionally excludes run IDs, timestamps, source families, corroboration, merged entities, new persistence, and output formats.

Based directly on merged #2451 and supersedes the original #2439 implementation.

Fork tracking: https://github.com/NotoriousRebel/theHarvester/issues/63

## Verification

- focused tests: 31 passed
- full suite: 262 passed, 6 skipped
- Ruff, formatting, mypy, and git diff checks passed
- zero em dashes
- parallel Standards and Spec reviews passed against `d5628110` at `2d89437`