### PR TITLE
feat: classify evidence source families

### DIFF
--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from uuid import UUID
 
 import pytest
@@ -184,6 +185,12 @@ async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch
     monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
     monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
     monkeypatch.setattr(main_module, 'execute_run', execute_with_temporary_store, raising=True)
+    crtsh_spec = main_module.get_source_spec('crtsh')
+    monkeypatch.setattr(
+        main_module,
+        'get_source_spec',
+        lambda _name: replace(crtsh_spec, family='catalog-family'),
+    )
 
     await main_module.start(
         argparse.Namespace(
@@ -209,5 +216,6 @@ async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch
     assert len(captured) == 1
     assert captured[0].source_executions[0].status is SourceStatus.SUCCEEDED
     assert captured[0].source_executions[0].source == 'crtsh'
+    assert {observation.source_family for observation in captured[0].observations} == {'catalog-family'}
     assert legacy_hostnames(captured[0]) == ['www.example.com']
     assert stored == [('example.com', ('www.example.com',), 'host', 'CRTsh')]

--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from theHarvester.lib.run import (
+    Derivation,
+    ScopeClass,
+    SourceFinding,
+    SourceStatus,
+    execute_run,
+    legacy_hostnames,
+)
+
+
+class FakePassiveSource:
+    name = 'fixture'
+    family = 'certificate-transparency'
+
+    async def collect(self, target: str) -> list[SourceFinding]:
+        assert target == 'example.com'
+        return [
+            SourceFinding('WWW.Example.COM.', Derivation.PROVIDER),
+            SourceFinding('www.example.com', Derivation.PROVIDER),
+            SourceFinding('example.com.evil.test', Derivation.SCOPE_EXTENSION),
+            SourceFinding('cdn.vendor.test', Derivation.EXTERNAL_RELATIONSHIP),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_execute_run_records_scoped_normalized_evidence_end_to_end() -> None:
+    result = await execute_run('Example.COM.', (FakePassiveSource(),))
+    next_result = await execute_run('example.com', (FakePassiveSource(),))
+
+    assert UUID(result.run_id)
+    assert result.run_id != next_result.run_id
+    assert result.target == 'example.com'
+    assert len(result.source_executions) == 1
+    execution = result.source_executions[0]
+    assert execution.status is SourceStatus.SUCCEEDED
+    assert execution.duration_ms >= 0
+    assert execution.result_count == 4
+    assert execution.observation_count == 4
+    assert execution.entity_count == 3
+
+    assert [(item.value, item.scope_class) for item in result.observations] == [
+        ('www.example.com', ScopeClass.IN_SCOPE),
+        ('www.example.com', ScopeClass.IN_SCOPE),
+        ('example.com.evil.test', ScopeClass.SCOPE_EXTENSION),
+        ('cdn.vendor.test', ScopeClass.EXTERNAL_RELATIONSHIP),
+    ]
+    assert all(item.target == 'example.com' for item in result.observations)
+    assert all(item.source == 'fixture' for item in result.observations)
+    assert all(item.source_family == 'certificate-transparency' for item in result.observations)
+    assert all(item.collected_at.tzinfo is not None for item in result.observations)
+    assert [item.derivation for item in result.observations] == [
+        Derivation.PROVIDER,
+        Derivation.PROVIDER,
+        Derivation.SCOPE_EXTENSION,
+        Derivation.EXTERNAL_RELATIONSHIP,
+    ]
+
+    merged = {item.value: item for item in result.entities}
+    assert len(merged['www.example.com'].observations) == 2
+    assert merged['www.example.com'].independent_corroboration_count == 1
+    assert merged['www.example.com'].scope_classes == (ScopeClass.IN_SCOPE,)
+    assert legacy_hostnames(result) == ['www.example.com']
+
+
+@pytest.mark.asyncio
+async def test_execute_run_does_not_persist_implicitly(monkeypatch: pytest.MonkeyPatch) -> None:
+    import theHarvester.lib.run as run_module
+
+    def fail_on_stash_access():
+        raise AssertionError('execute_run must remain an in-memory operation')
+
+    monkeypatch.setattr(run_module, 'StashManager', fail_on_stash_access, raising=False)
+
+    result = await execute_run('example.com', (FakePassiveSource(),))
+
+    assert result.target == 'example.com'
+
+
+class OutcomeSource:
+    name = 'outcome'
+    family = 'fixture-family'
+
+    def __init__(self, outcome: list[SourceFinding] | Exception) -> None:
+        self.outcome = outcome
+
+    async def collect(self, _target: str) -> list[SourceFinding]:
+        if isinstance(self.outcome, Exception):
+            raise self.outcome
+        return self.outcome
+
+
+@pytest.mark.parametrize(
+    ('outcome', 'expected'),
+    [
+        ([], SourceStatus.EMPTY),
+        (RuntimeError('provider failed'), SourceStatus.FAILED),
+    ],
+)
+@pytest.mark.asyncio
+async def test_execute_run_records_non_success_source_outcomes(
+    caplog: pytest.LogCaptureFixture,
+    outcome: list[SourceFinding] | Exception,
+    expected: SourceStatus,
+) -> None:
+    result = await execute_run('example.com', (OutcomeSource(outcome),))
+
+    assert len(result.source_executions) == 1
+    execution = result.source_executions[0]
+    assert execution.status is expected
+    assert execution.duration_ms >= 0
+    assert execution.result_count == 0
+    assert execution.observation_count == 0
+    assert execution.entity_count == 0
+    assert result.observations == ()
+    assert result.entities == ()
+    if expected is SourceStatus.FAILED:
+        assert 'Source outcome failed' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_execute_run_groups_multiple_sources_under_one_run() -> None:
+    class CorroboratingSource:
+        name = 'corroborating'
+        family = 'passive-dns'
+
+        async def collect(self, _target: str) -> list[SourceFinding]:
+            return [SourceFinding('www.example.com'), SourceFinding('example.com'), SourceFinding('')]
+
+    result = await execute_run('example.com', (FakePassiveSource(), CorroboratingSource()))
+
+    assert [execution.source for execution in result.source_executions] == ['fixture', 'corroborating']
+    assert {execution.run_id for execution in result.source_executions} == {result.run_id}
+    assert {observation.run_id for observation in result.observations} == {result.run_id}
+    corroborating_execution = result.source_executions[1]
+    assert corroborating_execution.status is SourceStatus.SUCCEEDED
+    assert corroborating_execution.result_count == 3
+    assert corroborating_execution.observation_count == 2
+    merged = {entity.value: entity for entity in result.entities}
+    assert merged['www.example.com'].independent_corroboration_count == 2
+    assert legacy_hostnames(result) == ['www.example.com']
+
+
+@pytest.mark.asyncio
+async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch: pytest.MonkeyPatch) -> None:
+    import argparse
+
+    import theHarvester.__main__ as main_module
+    import theHarvester.lib.run as run_module
+
+    process_calls: list[bool] = []
+
+    class FakeCrtshSearch:
+        def __init__(self, target: str) -> None:
+            assert target == 'example.com'
+
+        async def process(self, proxy: bool = False) -> None:
+            process_calls.append(proxy)
+
+        async def get_hostnames(self) -> list[str]:
+            return ['WWW.EXAMPLE.COM.', 'www.example.com', 'example.com.evil.test']
+
+    stored: list[tuple[str, tuple[str, ...], str, str]] = []
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, domain: str, items: list[str], result_type: str, source: str) -> None:
+            stored.append((domain, tuple(items), result_type, source))
+
+    captured: list[run_module.RunResult] = []
+
+    async def execute_with_temporary_store(target, sources):
+        result = await run_module.execute_run(target, sources)
+        captured.append(result)
+        return result
+
+    monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'execute_run', execute_with_temporary_store, raising=True)
+
+    await main_module.start(
+        argparse.Namespace(
+            api_scan=False,
+            dns_brute=False,
+            dns_lookup=False,
+            dns_resolve='',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=500,
+            proxies=False,
+            quiet=True,
+            shodan=False,
+            source='crtsh',
+            start=0,
+            take_over=False,
+            wordlist='',
+        )
+    )
+
+    assert process_calls == [False]
+    assert len(captured) == 1
+    assert captured[0].source_executions[0].status is SourceStatus.SUCCEEDED
+    assert captured[0].source_executions[0].source == 'crtsh'
+    assert legacy_hostnames(captured[0]) == ['www.example.com']
+    assert stored == [('example.com', ('www.example.com',), 'host', 'CRTsh')]

--- a/tests/lib/test_source_catalog.py
+++ b/tests/lib/test_source_catalog.py
@@ -37,9 +37,24 @@ def test_source_capabilities_are_derived_from_result_routes() -> None:
                 ResultRoute.INTERESTING_URLS,
             }
         ),
+        family='example',
     )
 
     assert spec.capabilities == frozenset({'subdomains', 'urls'})
+
+
+def test_source_specs_define_evidence_families() -> None:
+    shared_families = {
+        'certspotter': 'certificate-transparency',
+        'chaos': 'projectdiscovery',
+        'crtsh': 'certificate-transparency',
+        'projectdiscovery': 'projectdiscovery',
+        'shodan': 'shodan',
+        'shodanInternetDB': 'shodan',
+    }
+    expected = {name: shared_families.get(name, name) for name in SOURCE_SPECS}
+
+    assert {name: spec.family for name, spec in SOURCE_SPECS.items()} == expected
 
 
 def test_source_specs_describe_consolidated_routes_not_getter_presence() -> None:

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -82,6 +82,7 @@ from theHarvester.lib import hostchecker, stash
 from theHarvester.lib.core import DATA_DIR, Core, show_default_error_message
 from theHarvester.lib.hostnames import normalize_scoped_hostname
 from theHarvester.lib.output import configure_logging, output_logger, print_linkedin_sections, print_section, sorted_unique
+from theHarvester.lib.run import LegacyHostnameSource, RunResult, SourceStatus, execute_run, legacy_hostnames
 from theHarvester.lib.source_catalog import ResultRoute, get_source_spec
 from theHarvester.screenshot.screenshot import ScreenShotter
 
@@ -342,30 +343,37 @@ async def start(rest_args: argparse.Namespace | None = None):
     async def store(
         search_engine: Any,
         source: str,
+        run_result: RunResult | None = None,
     ) -> None:
         """Process a source and persist its declared consolidated result routes.
 
         :param search_engine: search engine to fetch details from
         :param source: source against which the details (corresponding to the search engine) need to be persisted
+        :param run_result: optional completed evidence run for a migrated source
         """
-        logger.info(f'Source {source} started')
-        try:
-            await search_engine.process(use_proxy)
-        except Exception:
-            logger.exception(f'Source {source} failed')
-            raise
+        if run_result is None:
+            logger.info(f'Source {source} started')
+            try:
+                await search_engine.process(use_proxy)
+            except Exception:
+                logger.exception(f'Source {source} failed')
+                raise
         db_stash = stash.StashManager()
-        routes = get_source_spec(source).routes
+        source_spec = get_source_spec(source)
+        routes = source_spec.routes
 
         if source:
             output_logger.info(f'[*] Searching {source[0].upper() + source[1:]}. ')
 
         if ResultRoute.HOSTS in routes:
-            discovered_hosts = await search_engine.get_hostnames()
-            if source == 'intelx':
-                host_names = list(discovered_hosts)
+            if run_result is not None:
+                host_names = legacy_hostnames(run_result, source_spec.name)
             else:
-                host_names = list(_normalize_hosts_for_storage(discovered_hosts, word))
+                discovered_hosts = await search_engine.get_hostnames()
+                if source == 'intelx':
+                    host_names = list(discovered_hosts)
+                else:
+                    host_names = list(_normalize_hosts_for_storage(discovered_hosts, word))
             if source != 'hackertarget' and source != 'pentesttools' and source != 'rapiddns':
                 # If a source is inside this conditional, it means the hosts returned must be resolved to obtain ip
                 # This should only be checked if --dns-resolve has a wordlist
@@ -420,9 +428,19 @@ async def start(rest_args: argparse.Namespace | None = None):
             total_asns.extend(fasns)
             if len(fasns) > 0:
                 await db.store_all(word, fasns, 'asns', source)
-        logger.info(f'Source {source} completed')
+        if run_result is None:
+            logger.info(f'Source {source} completed')
 
     stor_lst = []
+    evidence_sources: list[LegacyHostnameSource] = []
+
+    async def store_evidence_sources() -> None:
+        run_result = await execute_run(word, tuple(evidence_sources))
+        executions = {execution.source: execution for execution in run_result.source_executions}
+        for evidence_source in evidence_sources:
+            if executions[evidence_source.name].status in (SourceStatus.SUCCEEDED, SourceStatus.EMPTY):
+                await store(evidence_source.search, evidence_source.legacy_name, run_result)
+
     if args.source is not None:
         engines = Core.expand_source_selection(args.source)
         # Iterate through search engines in order
@@ -596,7 +614,17 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'crtsh':
                     try:
                         crtsh_search = crtsh.SearchCrtsh(word)
-                        stor_lst.append(store(crtsh_search, 'CRTsh'))
+                        source_spec = get_source_spec(engineitem)
+                        evidence_sources.append(
+                            LegacyHostnameSource(
+                                name=source_spec.name,
+                                legacy_name='CRTsh',
+                                # ponytail: move families into SourceSpec when a second evidence source migrates.
+                                family='certificate-transparency',
+                                search=crtsh_search,
+                                proxy=use_proxy,
+                            )
+                        )
                     except Exception as e:
                         output_logger.info(f'[!] A timeout occurred with crtsh, cannot find {args.domain}\n {e}')
 
@@ -1253,6 +1281,9 @@ async def start(rest_args: argparse.Namespace | None = None):
                         if isinstance(e, MissingKey):
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in zoomeye: {e}')
+
+            if evidence_sources:
+                stor_lst.append(store_evidence_sources())
 
         elif rest_args is not None:
             try:

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -619,8 +619,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                             LegacyHostnameSource(
                                 name=source_spec.name,
                                 legacy_name='CRTsh',
-                                # ponytail: move families into SourceSpec when a second evidence source migrates.
-                                family='certificate-transparency',
+                                family=source_spec.family,
                                 search=crtsh_search,
                                 proxy=use_proxy,
                             )

--- a/theHarvester/lib/hostnames.py
+++ b/theHarvester/lib/hostnames.py
@@ -1,10 +1,18 @@
-def normalize_scoped_hostname(value: object, target: str) -> str | None:
-    """Return a canonical hostname when value is inside the target boundary."""
+def normalize_hostname(value: object) -> str | None:
+    """Return a canonical hostname, or None when the value is unusable."""
     if not isinstance(value, str):
         return None
     hostname = value.strip().lower().rstrip('.')
-    normalized_target = target.strip().lower().rstrip('.')
-    if not normalized_target:
+    if not hostname:
+        return None
+    return hostname
+
+
+def normalize_scoped_hostname(value: object, target: str) -> str | None:
+    """Return a canonical hostname when value is inside the target boundary."""
+    hostname = normalize_hostname(value)
+    normalized_target = normalize_hostname(target)
+    if hostname is None or normalized_target is None:
         return None
     if hostname == normalized_target or hostname.endswith(f'.{normalized_target}'):
         return hostname

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING, Protocol
+from uuid import uuid4
+
+from theHarvester.lib.hostnames import normalize_hostname
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+logger = logging.getLogger(__name__)
+
+
+class Derivation(StrEnum):
+    PROVIDER = 'provider'
+    SCOPE_EXTENSION = 'scope-extension'
+    EXTERNAL_RELATIONSHIP = 'external-relationship'
+
+
+class ScopeClass(StrEnum):
+    IN_SCOPE = 'in-scope'
+    SCOPE_EXTENSION = 'scope-extension'
+    EXTERNAL_RELATIONSHIP = 'external-relationship'
+
+
+class SourceStatus(StrEnum):
+    SUCCEEDED = 'succeeded'
+    EMPTY = 'empty'
+    FAILED = 'failed'
+
+
+@dataclass(frozen=True)
+class SourceFinding:
+    value: str
+    derivation: Derivation = Derivation.PROVIDER
+
+
+class PassiveSource(Protocol):
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def family(self) -> str: ...
+
+    async def collect(self, target: str) -> Sequence[SourceFinding]: ...
+
+
+class LegacyHostnameSearch(Protocol):
+    async def process(self, proxy: bool = False) -> None: ...
+
+    async def get_hostnames(self) -> Sequence[str]: ...
+
+
+@dataclass(frozen=True)
+class LegacyHostnameSource:
+    name: str
+    legacy_name: str
+    family: str
+    search: LegacyHostnameSearch
+    proxy: bool = False
+
+    async def collect(self, _target: str) -> tuple[SourceFinding, ...]:
+        await self.search.process(self.proxy)
+        return tuple(SourceFinding(hostname) for hostname in await self.search.get_hostnames())
+
+
+@dataclass(frozen=True)
+class DiscoveryObservation:
+    run_id: str
+    target: str
+    value: str
+    source: str
+    source_family: str
+    derivation: Derivation
+    collected_at: datetime
+    scope_class: ScopeClass
+
+
+@dataclass(frozen=True)
+class SourceExecution:
+    run_id: str
+    source: str
+    source_family: str
+    status: SourceStatus
+    duration_ms: float
+    result_count: int
+    observation_count: int
+    entity_count: int
+    error_type: str | None = None
+
+
+@dataclass(frozen=True)
+class MergedEntity:
+    value: str
+    observations: tuple[DiscoveryObservation, ...]
+
+    @property
+    def scope_classes(self) -> tuple[ScopeClass, ...]:
+        return tuple(dict.fromkeys(observation.scope_class for observation in self.observations))
+
+    @property
+    def independent_corroboration_count(self) -> int:
+        return len({observation.source_family for observation in self.observations})
+
+
+@dataclass(frozen=True)
+class RunResult:
+    run_id: str
+    target: str
+    started_at: datetime
+    completed_at: datetime
+    source_executions: tuple[SourceExecution, ...]
+    observations: tuple[DiscoveryObservation, ...]
+    entities: tuple[MergedEntity, ...]
+
+
+def _classify_scope(target: str, value: str, derivation: Derivation) -> ScopeClass:
+    if value == target or value.endswith(f'.{target}'):
+        return ScopeClass.IN_SCOPE
+    if derivation is Derivation.EXTERNAL_RELATIONSHIP:
+        return ScopeClass.EXTERNAL_RELATIONSHIP
+    return ScopeClass.SCOPE_EXTENSION
+
+
+def _merge_observations(observations: Sequence[DiscoveryObservation]) -> tuple[MergedEntity, ...]:
+    grouped: dict[str, list[DiscoveryObservation]] = {}
+    for observation in observations:
+        grouped.setdefault(observation.value, []).append(observation)
+    return tuple(MergedEntity(value, tuple(supporting)) for value, supporting in grouped.items())
+
+
+async def execute_run(
+    target: str,
+    sources: Sequence[PassiveSource],
+) -> RunResult:
+    normalized_target = normalize_hostname(target)
+    if normalized_target is None:
+        raise ValueError('target must be a hostname')
+    run_id = str(uuid4())
+    started_at = datetime.now(UTC)
+    executions: list[SourceExecution] = []
+    observations: list[DiscoveryObservation] = []
+
+    for source in sources:
+        logger.info(f'Source {source.name} started')
+        source_started = time.perf_counter()
+        source_observations: tuple[DiscoveryObservation, ...] = ()
+        status = SourceStatus.FAILED
+        result_count = 0
+        error_type: str | None = None
+
+        try:
+            findings = tuple(await source.collect(normalized_target))
+            result_count = len(findings)
+            collected_at = datetime.now(UTC)
+            normalized_observations = []
+            for finding in findings:
+                value = normalize_hostname(finding.value)
+                if value is None:
+                    continue
+                normalized_observations.append(
+                    DiscoveryObservation(
+                        run_id=run_id,
+                        target=normalized_target,
+                        value=value,
+                        source=source.name,
+                        source_family=source.family,
+                        derivation=finding.derivation,
+                        collected_at=collected_at,
+                        scope_class=_classify_scope(normalized_target, value, finding.derivation),
+                    )
+                )
+            source_observations = tuple(normalized_observations)
+            status = SourceStatus.SUCCEEDED if source_observations else SourceStatus.EMPTY
+        except Exception as error:
+            error_type = type(error).__name__
+            logger.exception(f'Source {source.name} failed')
+
+        source_entities = _merge_observations(source_observations)
+        executions.append(
+            SourceExecution(
+                run_id=run_id,
+                source=source.name,
+                source_family=source.family,
+                status=status,
+                duration_ms=(time.perf_counter() - source_started) * 1000,
+                result_count=result_count,
+                observation_count=len(source_observations),
+                entity_count=len(source_entities),
+                error_type=error_type,
+            )
+        )
+        observations.extend(source_observations)
+        logger.info(f'Source {source.name} completed with status {status}')
+
+    merged_observations = tuple(observations)
+    result = RunResult(
+        run_id=run_id,
+        target=normalized_target,
+        started_at=started_at,
+        completed_at=datetime.now(UTC),
+        source_executions=tuple(executions),
+        observations=merged_observations,
+        entities=_merge_observations(merged_observations),
+    )
+    return result
+
+
+def legacy_hostnames(result: RunResult, source: str | None = None) -> list[str]:
+    """Return the host list consumed by the existing CLI, REST, file, and stash paths."""
+    return sorted(
+        {
+            observation.value
+            for observation in result.observations
+            if observation.value != result.target
+            and observation.scope_class is ScopeClass.IN_SCOPE
+            and (source is None or observation.source == source)
+        }
+    )

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -27,14 +27,23 @@ _ROUTE_CAPABILITIES = {
 class SourceSpec:
     name: str
     routes: frozenset[ResultRoute]
+    family: str
 
     @property
     def capabilities(self) -> frozenset[str]:
         return frozenset(_ROUTE_CAPABILITIES[route] for route in self.routes)
 
 
-def _spec(name: str, *routes: ResultRoute) -> SourceSpec:
-    return SourceSpec(name=name, routes=frozenset(routes))
+def _spec(
+    name: str,
+    *routes: ResultRoute,
+    family: str | None = None,
+) -> SourceSpec:
+    return SourceSpec(
+        name=name,
+        routes=frozenset(routes),
+        family=family if family is not None else name,
+    )
 
 
 _SPECS = (
@@ -45,11 +54,11 @@ _SPECS = (
     _spec('bufferoverun', ResultRoute.HOSTS, ResultRoute.IPS),
     _spec('builtwith', ResultRoute.HOSTS, ResultRoute.INTERESTING_URLS),
     _spec('censys', ResultRoute.HOSTS, ResultRoute.EMAILS),
-    _spec('certspotter', ResultRoute.HOSTS),
-    _spec('chaos', ResultRoute.HOSTS),
+    _spec('certspotter', ResultRoute.HOSTS, family='certificate-transparency'),
+    _spec('chaos', ResultRoute.HOSTS, family='projectdiscovery'),
     _spec('commoncrawl', ResultRoute.HOSTS),
     _spec('criminalip', ResultRoute.HOSTS, ResultRoute.IPS, ResultRoute.ASNS),
-    _spec('crtsh', ResultRoute.HOSTS),
+    _spec('crtsh', ResultRoute.HOSTS, family='certificate-transparency'),
     _spec('dehashed', ResultRoute.IPS),
     _spec('dnsdb', ResultRoute.HOSTS),
     _spec('dnsdumpster', ResultRoute.HOSTS, ResultRoute.IPS),
@@ -80,7 +89,7 @@ _SPECS = (
     _spec('securityscorecard', ResultRoute.HOSTS, ResultRoute.IPS),
     _spec('sherlockeye', ResultRoute.HOSTS, ResultRoute.EMAILS, ResultRoute.IPS),
     _spec('shodan', ResultRoute.HOSTS),
-    _spec('shodanInternetDB', ResultRoute.HOSTS, ResultRoute.IPS),
+    _spec('shodanInternetDB', ResultRoute.HOSTS, ResultRoute.IPS, family='shodan'),
     _spec('subdomaincenter', ResultRoute.HOSTS),
     _spec('subdomainfinderc99', ResultRoute.HOSTS),
     _spec('thc', ResultRoute.HOSTS),


### PR DESCRIPTION
## Summary

- declare the underlying source family for normalized observations
- keep provider credit while grouping correlated datasets
- prevent correlated providers from inflating independent corroboration

## Operator impact

Corroboration counts reflect genuinely independent evidence instead of counting two views of the same collection as separate witnesses.

## Stack

Layer 2 of 10. Base: feature/evidence-runs.

Fork tracking: https://github.com/NotoriousRebel/theHarvester/issues/63

## Verification

The complete stack at d7a38459 passed 308 tests with 6 skipped, Ruff, formatting, mypy, git diff --check, zero em dashes, and parallel Standards and Spec reviews.