### PR TITLE
fix: preserve incomplete DNSDB evidence

### DIFF
--- a/tests/discovery/test_dnsdb.py
+++ b/tests/discovery/test_dnsdb.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import pytest
 
 from theHarvester.discovery import dnsdb
 from theHarvester.discovery.constants import MissingKey
+from theHarvester.lib.run import (
+    LegacyHostnameSource,
+    SourceIncompleteError,
+    SourceRateLimitedError,
+    SourceStatus,
+    execute_run,
+)
 
 
 def _install_response(
@@ -13,7 +21,7 @@ def _install_response(
     lines: tuple[bytes, ...],
     *,
     status: int = 200,
-    stream_error: Exception | None = None,
+    stream_error: BaseException | None = None,
 ) -> dict[str, object]:
     requested: dict[str, object] = {}
     lines_left = list(lines)
@@ -133,10 +141,10 @@ async def test_process_uses_configured_proxy_when_enabled(monkeypatch: pytest.Mo
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ('last_line', 'expected_message'),
+    ('last_line', 'expected_message', 'expected_error'),
     [
-        (b'{"cond":"limited"}\n', 'ended with limited'),
-        (b'not-json\n', 'malformed NDJSON'),
+        (b'{"cond":"limited"}\n', 'ended with limited', SourceRateLimitedError),
+        (b'not-json\n', 'malformed NDJSON', SourceIncompleteError),
     ],
 )
 async def test_process_preserves_partial_results(
@@ -144,6 +152,7 @@ async def test_process_preserves_partial_results(
     caplog: pytest.LogCaptureFixture,
     last_line: bytes,
     expected_message: str,
+    expected_error: type[Exception],
 ) -> None:
     caplog.set_level(logging.INFO, logger=dnsdb.__name__)
     monkeypatch.setattr(dnsdb.Core, 'dnsdb_key', lambda: 'dnsdb-test-key')
@@ -157,10 +166,91 @@ async def test_process_preserves_partial_results(
     )
 
     search = dnsdb.SearchDNSDB('example.com')
-    await search.process()
+    with pytest.raises(expected_error):
+        await search.process()
 
     assert await search.get_hostnames() == {'first.example.com'}
     assert any(expected_message in message for message in caplog.messages)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('lines', 'expected_message'),
+    [
+        (
+            (
+                b'{"cond":"begin"}\n',
+                b'{"obj":{"rrname":"first.example.com."}}\n',
+                b'{"obj":[]}\n',
+                b'{"cond":"succeeded"}\n',
+            ),
+            'invalid stream record',
+        ),
+        (
+            (
+                b'{"cond":"begin"}\n',
+                b'{"obj":{"rrname":"first.example.com."}}\n',
+            ),
+            'without a terminal condition',
+        ),
+    ],
+)
+async def test_process_rejects_incomplete_stream_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    lines: tuple[bytes, ...],
+    expected_message: str,
+) -> None:
+    caplog.set_level(logging.INFO, logger=dnsdb.__name__)
+    monkeypatch.setattr(dnsdb.Core, 'dnsdb_key', lambda: 'dnsdb-test-key')
+    _install_response(monkeypatch, lines)
+    search = dnsdb.SearchDNSDB('example.com')
+
+    with pytest.raises(SourceIncompleteError):
+        await search.process()
+
+    assert await search.get_hostnames() == {'first.example.com'}
+    assert any(expected_message in message for message in caplog.messages)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('last_line', 'expected_status'),
+    [
+        (b'{"cond":"limited"}\n', SourceStatus.RATE_LIMITED),
+        (b'{"cond":"failed"}\n', SourceStatus.FAILED),
+    ],
+)
+async def test_incomplete_stream_status_keeps_partial_results_in_run(
+    monkeypatch: pytest.MonkeyPatch,
+    last_line: bytes,
+    expected_status: SourceStatus,
+) -> None:
+    monkeypatch.setattr(dnsdb.Core, 'dnsdb_key', lambda: 'dnsdb-test-key')
+    _install_response(
+        monkeypatch,
+        (
+            b'{"cond":"begin"}\n',
+            b'{"obj":{"rrname":"first.example.com."}}\n',
+            last_line,
+        ),
+    )
+    search = dnsdb.SearchDNSDB('example.com')
+
+    result = await execute_run(
+        'example.com',
+        (
+            LegacyHostnameSource(
+                name='dnsdb',
+                legacy_name='dnsdb',
+                family='dnsdb',
+                search=search,
+            ),
+        ),
+    )
+
+    assert {observation.value for observation in result.observations} == {'first.example.com'}
+    assert result.source_executions[0].status is expected_status
 
 
 @pytest.mark.asyncio
@@ -180,10 +270,24 @@ async def test_process_preserves_partial_results_on_midstream_timeout(
     )
 
     search = dnsdb.SearchDNSDB('example.com')
-    await search.process()
+    with pytest.raises(SourceIncompleteError):
+        await search.process()
 
     assert await search.get_hostnames() == {'first.example.com'}
     assert any('request failed' in message for message in caplog.messages)
+
+
+@pytest.mark.asyncio
+async def test_process_propagates_cancellation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dnsdb.Core, 'dnsdb_key', lambda: 'dnsdb-test-key')
+    _install_response(
+        monkeypatch,
+        (b'{"cond":"begin"}\n',),
+        stream_error=asyncio.CancelledError(),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await dnsdb.SearchDNSDB('example.com').process()
 
 
 @pytest.mark.asyncio
@@ -191,7 +295,7 @@ async def test_process_preserves_partial_results_on_midstream_timeout(
     ('status', 'expected_error'),
     [
         (401, PermissionError),
-        (429, ConnectionError),
+        (429, SourceRateLimitedError),
         (503, ConnectionError),
     ],
 )

--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import replace
 from uuid import UUID
 
@@ -9,6 +10,7 @@ from theHarvester.lib.run import (
     Derivation,
     ScopeClass,
     SourceFinding,
+    SourceRateLimitedError,
     SourceStatus,
     execute_run,
     legacy_hostnames,
@@ -27,6 +29,19 @@ class FakePassiveSource:
             SourceFinding('example.com.evil.test', Derivation.SCOPE_EXTENSION),
             SourceFinding('cdn.vendor.test', Derivation.EXTERNAL_RELATIONSHIP),
         ]
+
+
+@pytest.mark.asyncio
+async def test_execute_run_propagates_cancellation() -> None:
+    class CancelledSource:
+        name = 'cancelled'
+        family = 'cancelled'
+
+        async def collect(self, _target: str) -> list[SourceFinding]:
+            raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await execute_run('example.com', (CancelledSource(),))
 
 
 @pytest.mark.asyncio
@@ -219,3 +234,69 @@ async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch
     assert {observation.source_family for observation in captured[0].observations} == {'catalog-family'}
     assert legacy_hostnames(captured[0]) == ['www.example.com']
     assert stored == [('example.com', ('www.example.com',), 'host', 'CRTsh')]
+
+
+@pytest.mark.asyncio
+async def test_dnsdb_bridge_preserves_partial_results_and_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    import argparse
+
+    import theHarvester.__main__ as main_module
+    import theHarvester.lib.run as run_module
+
+    class FakeDNSDBSearch:
+        def __init__(self, target: str) -> None:
+            assert target == 'example.com'
+
+        async def process(self, _proxy: bool = False) -> None:
+            raise SourceRateLimitedError(
+                'DNSDB result limit reached',
+                findings=(SourceFinding('partial.example.com'),),
+            )
+
+        async def get_hostnames(self) -> list[str]:
+            raise AssertionError('partial findings must come from the incomplete source result')
+
+    stored: list[tuple[str, tuple[str, ...], str, str]] = []
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, domain: str, items: list[str], result_type: str, source: str) -> None:
+            stored.append((domain, tuple(items), result_type, source))
+
+    captured: list[run_module.RunResult] = []
+
+    async def capture_run(target, sources):
+        result = await run_module.execute_run(target, sources)
+        captured.append(result)
+        return result
+
+    monkeypatch.setattr(main_module.dnsdb, 'SearchDNSDB', FakeDNSDBSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'execute_run', capture_run, raising=True)
+
+    await main_module.start(
+        argparse.Namespace(
+            api_scan=False,
+            dns_brute=False,
+            dns_lookup=False,
+            dns_resolve='',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=500,
+            proxies=False,
+            quiet=True,
+            shodan=False,
+            source='dnsdb',
+            start=0,
+            take_over=False,
+            wordlist='',
+        )
+    )
+
+    assert len(captured) == 1
+    assert captured[0].source_executions[0].status is SourceStatus.RATE_LIMITED
+    assert {observation.value for observation in captured[0].observations} == {'partial.example.com'}
+    assert stored == [('example.com', ('partial.example.com',), 'host', 'dnsdb')]

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -438,7 +438,8 @@ async def start(rest_args: argparse.Namespace | None = None):
         run_result = await execute_run(word, tuple(evidence_sources))
         executions = {execution.source: execution for execution in run_result.source_executions}
         for evidence_source in evidence_sources:
-            if executions[evidence_source.name].status in (SourceStatus.SUCCEEDED, SourceStatus.EMPTY):
+            execution = executions[evidence_source.name]
+            if execution.status in (SourceStatus.SUCCEEDED, SourceStatus.EMPTY) or execution.observation_count:
                 await store(evidence_source.search, evidence_source.legacy_name, run_result)
 
     if args.source is not None:
@@ -646,7 +647,16 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'dnsdb':
                     try:
                         dnsdb_search = dnsdb.SearchDNSDB(word)
-                        stor_lst.append(store(dnsdb_search, engineitem))
+                        source_spec = get_source_spec(engineitem)
+                        evidence_sources.append(
+                            LegacyHostnameSource(
+                                name=source_spec.name,
+                                legacy_name='dnsdb',
+                                family=source_spec.family,
+                                search=dnsdb_search,
+                                proxy=use_proxy,
+                            )
+                        )
                     except MissingKey as e:
                         if not args.quiet:
                             output_logger.info(e)

--- a/theHarvester/discovery/dnsdb.py
+++ b/theHarvester/discovery/dnsdb.py
@@ -9,6 +9,7 @@ import aiohttp
 from theHarvester import __version__
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib.core import AsyncFetcher, Core
+from theHarvester.lib.run import SourceFinding, SourceIncompleteError, SourceRateLimitedError
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,9 @@ class SearchDNSDB:
             return hostname
         return None
 
+    def _partial_findings(self) -> tuple[SourceFinding, ...]:
+        return tuple(SourceFinding(hostname) for hostname in sorted(self.totalhosts))
+
     async def do_search(self) -> None:
         query = quote(f'*.{self.target_domain}', safe='*.')
         url = f'{self.BASE_URL}/{query}?limit=0'
@@ -59,7 +63,7 @@ class SearchDNSDB:
         async with await AsyncFetcher._build_session(headers, timeout, proxy_url, proxy_type) as session:
             async with session.get(url, proxy=proxy_url if proxy_type == 'http' else None) as response:
                 if response.status == 429:
-                    raise ConnectionError('DNSDB rate limit reached')
+                    raise SourceRateLimitedError('DNSDB rate limit reached')
                 if response.status in {401, 403}:
                     raise PermissionError('DNSDB authentication failed')
                 if response.status == 503:
@@ -72,28 +76,43 @@ class SearchDNSDB:
                     try:
                         record = json.loads(line)
                     except (UnicodeDecodeError, json.JSONDecodeError):
-                        logger.info('DNSDB returned malformed NDJSON; partial results were preserved.')
-                        return
+                        message = 'DNSDB returned malformed NDJSON; partial results were preserved.'
+                        logger.info(message)
+                        raise SourceIncompleteError(message, findings=self._partial_findings())
                     if not isinstance(record, dict):
-                        logger.info('DNSDB returned an invalid stream record; partial results were preserved.')
-                        return
+                        message = 'DNSDB returned an invalid stream record; partial results were preserved.'
+                        logger.info(message)
+                        raise SourceIncompleteError(message, findings=self._partial_findings())
                     if first_record:
                         first_record = False
                         if record.get('cond') != 'begin':
-                            logger.info('DNSDB stream did not begin correctly; no results were accepted.')
-                            return
+                            message = 'DNSDB stream did not begin correctly; no results were accepted.'
+                            logger.info(message)
+                            raise SourceIncompleteError(message)
                         continue
 
                     condition = record.get('cond')
                     if condition in {'succeeded', 'limited', 'failed'}:
-                        if condition != 'succeeded':
-                            logger.info(f'DNSDB stream ended with {condition}; partial results were preserved.')
+                        if condition == 'limited':
+                            message = 'DNSDB stream ended with limited; partial results were preserved.'
+                            logger.info(message)
+                            raise SourceRateLimitedError(message, findings=self._partial_findings())
+                        if condition == 'failed':
+                            message = 'DNSDB stream ended with failed; partial results were preserved.'
+                            logger.info(message)
+                            raise SourceIncompleteError(message, findings=self._partial_findings())
                         return
                     obj = record.get('obj')
-                    if isinstance(obj, dict) and (hostname := self._hostname(obj.get('rrname'))):
+                    if not isinstance(obj, dict) or not isinstance(obj.get('rrname'), str):
+                        message = 'DNSDB returned an invalid stream record; partial results were preserved.'
+                        logger.info(message)
+                        raise SourceIncompleteError(message, findings=self._partial_findings())
+                    if hostname := self._hostname(obj['rrname']):
                         self.totalhosts.add(hostname)
 
-                logger.info('DNSDB stream ended without a terminal condition; partial results were preserved.')
+                message = 'DNSDB stream ended without a terminal condition; partial results were preserved.'
+                logger.info(message)
+                raise SourceIncompleteError(message, findings=self._partial_findings())
 
     async def get_hostnames(self) -> set[str]:
         return self.totalhosts
@@ -103,4 +122,6 @@ class SearchDNSDB:
         try:
             await self.do_search()
         except (aiohttp.ClientError, TimeoutError) as error:
-            logger.info(f'DNSDB request failed with {type(error).__name__}; partial results were preserved.')
+            message = f'DNSDB request failed with {type(error).__name__}; partial results were preserved.'
+            logger.info(message)
+            raise SourceIncompleteError(message, findings=self._partial_findings()) from error

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 from theHarvester.lib.hostnames import normalize_hostname
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Collection, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -32,12 +32,25 @@ class SourceStatus(StrEnum):
     SUCCEEDED = 'succeeded'
     EMPTY = 'empty'
     FAILED = 'failed'
+    RATE_LIMITED = 'rate-limited'
 
 
 @dataclass(frozen=True)
 class SourceFinding:
     value: str
     derivation: Derivation = Derivation.PROVIDER
+
+
+class SourceIncompleteError(Exception):
+    status = SourceStatus.FAILED
+
+    def __init__(self, message: str = '', *, findings: Sequence[SourceFinding] = ()) -> None:
+        super().__init__(message)
+        self.findings = tuple(findings)
+
+
+class SourceRateLimitedError(SourceIncompleteError):
+    status = SourceStatus.RATE_LIMITED
 
 
 class PassiveSource(Protocol):
@@ -53,7 +66,7 @@ class PassiveSource(Protocol):
 class LegacyHostnameSearch(Protocol):
     async def process(self, proxy: bool = False) -> None: ...
 
-    async def get_hostnames(self) -> Sequence[str]: ...
+    async def get_hostnames(self) -> Collection[str]: ...
 
 
 @dataclass(frozen=True)
@@ -153,10 +166,21 @@ async def execute_run(
         status = SourceStatus.FAILED
         result_count = 0
         error_type: str | None = None
+        findings: tuple[SourceFinding, ...] = ()
 
         try:
             findings = tuple(await source.collect(normalized_target))
-            result_count = len(findings)
+            status = SourceStatus.SUCCEEDED
+        except SourceIncompleteError as error:
+            findings = error.findings
+            status = error.status
+            error_type = type(error).__name__
+        except Exception as error:
+            error_type = type(error).__name__
+            logger.exception(f'Source {source.name} failed')
+
+        result_count = len(findings)
+        try:
             collected_at = datetime.now(UTC)
             normalized_observations = []
             for finding in findings:
@@ -176,8 +200,11 @@ async def execute_run(
                     )
                 )
             source_observations = tuple(normalized_observations)
-            status = SourceStatus.SUCCEEDED if source_observations else SourceStatus.EMPTY
+            if status is SourceStatus.SUCCEEDED and not source_observations:
+                status = SourceStatus.EMPTY
         except Exception as error:
+            source_observations = ()
+            status = SourceStatus.FAILED
             error_type = type(error).__name__
             logger.exception(f'Source {source.name} failed')
 


### PR DESCRIPTION
## Summary

- retain DNSDB findings returned before a provider failure
- classify incomplete source execution explicitly
- adapt the existing DNSDB public seam without requiring a live API key in routine tests

## Operator impact

Operators keep useful partial findings and can see that the provider run was incomplete instead of mistaking partial evidence for a complete query.

## Stack

Layer 3 of 10. Base: feature/evidence-source-families.

Fork tracking: https://github.com/NotoriousRebel/theHarvester/issues/63

## Verification

Routine tests use fake HTTP responses. DNSDB live testing remains unavailable without an API key. The complete stack passed all required offline checks.