### PR TITLE
feat: classify DNS evidence with resolver consensus

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,7 +8,12 @@ The definitions state intended semantics; they do not imply that every discovery
 
 **Currently addressable subdomain**:
 A normalized, in-scope subdomain with current resolver consensus evidence of an A or AAAA record, or a permitted CNAME chain ending in one, that is neither wildcard-indistinguishable nor resolver-disputed.
+A candidate backed by deterministic exact-node evidence is distinguishable even when its DNS response overlaps the learned wildcard distribution.
 _Avoid_: Valid subdomain, live host, resolved host
+
+**Not currently addressable**:
+An in-scope candidate for which resolver consensus within one validation window reports no A or AAAA address and no CNAME chain ending in one. It remains secondary subdomain evidence.
+_Avoid_: Invalid subdomain, dead host
 
 **Secondary subdomain evidence**:
 An in-scope DNS-existing, historical, dangling-alias, or indeterminate name observation retained for defensive and investigative use but excluded from the primary currently addressable yield count.

--- a/tests/lib/test_dns_validation.py
+++ b/tests/lib/test_dns_validation.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from types import SimpleNamespace
+
+import pytest
+
+from theHarvester.lib.dns_validation import (
+    Addressability,
+    AioDnsResolverVantage,
+    DnsResponse,
+    DnsValidator,
+)
+
+
+class RuleVantage:
+    def __init__(self, name: str, handler: Callable[[str], DnsResponse]) -> None:
+        self.name = name
+        self.handler = handler
+
+    async def query(self, hostname: str) -> DnsResponse:
+        return self.handler(hostname)
+
+
+def _vantages(handler: Callable[[str], DnsResponse]) -> tuple[RuleVantage, ...]:
+    return tuple(RuleVantage(f'resolver-{suffix}', handler) for suffix in ('a', 'b', 'c'))
+
+
+@pytest.mark.asyncio
+async def test_validator_records_two_of_three_consensus_without_identical_addresses() -> None:
+    candidate = 'api.example.com'
+    responses = {
+        'resolver-a': DnsResponse(
+            ipv4=('192.0.2.10',),
+            cnames=('Edge.Example.NET.',),
+            rcode='noerror',
+            ttl=300,
+            cname_chain=('Edge.Example.NET.',),
+        ),
+        'resolver-b': DnsResponse(ipv6=('2001:0db8::10',), ttl=120),
+        'resolver-c': DnsResponse(rcode='NXDOMAIN'),
+    }
+    vantages = tuple(
+        RuleVantage(name, lambda hostname, name=name: responses[name] if hostname == candidate else DnsResponse(rcode='NXDOMAIN'))
+        for name in responses
+    )
+
+    result = await DnsValidator(vantages).validate('run-id', 'example.com', (candidate,))
+
+    assert result.classifications[0].addressability is Addressability.CURRENT
+    candidate_observations = [observation for observation in result.observations if not observation.is_wildcard_control]
+    assert len(candidate_observations) == 3
+    assert candidate_observations[0].candidate == candidate
+    assert candidate_observations[0].query_name == candidate
+    assert candidate_observations[0].resolver == 'resolver-a'
+    assert candidate_observations[0].ipv4 == ('192.0.2.10',)
+    assert candidate_observations[0].cnames == ('edge.example.net',)
+    assert candidate_observations[0].cname_chain == ('edge.example.net',)
+    assert candidate_observations[0].rcode == 'NOERROR'
+    assert candidate_observations[0].ttl == 300
+    assert candidate_observations[0].queried_at.tzinfo is not None
+    assert candidate_observations[0].latency_ms >= 0
+    assert candidate_observations[1].ipv6 == ('2001:db8::10',)
+
+
+@pytest.mark.asyncio
+async def test_validator_keeps_resolver_disagreement_secondary() -> None:
+    candidate = 'api.example.com'
+    responses = iter(
+        (
+            DnsResponse(ipv4=('192.0.2.10',)),
+            DnsResponse(rcode='NXDOMAIN'),
+            DnsResponse(rcode='ERROR', error='timeout'),
+        )
+    )
+    vantages = tuple(
+        RuleVantage(f'resolver-{suffix}', lambda hostname: next(responses) if hostname == candidate else DnsResponse(rcode='NXDOMAIN'))
+        for suffix in ('a', 'b', 'c')
+    )
+
+    result = await DnsValidator(vantages).validate('run-id', 'example.com', (candidate,))
+
+    assert result.classifications[0].addressability is Addressability.RESOLVER_DISPUTED
+
+
+@pytest.mark.asyncio
+async def test_validator_records_resolver_error_observation() -> None:
+    candidate = 'api.example.com'
+
+    class ErrorVantage:
+        name = 'resolver-error'
+
+        async def query(self, _hostname: str) -> DnsResponse:
+            raise RuntimeError('resolver unavailable')
+
+    validator = DnsValidator(
+        (
+            ErrorVantage(),
+            RuleVantage('resolver-a', lambda _hostname: DnsResponse(rcode='NXDOMAIN')),
+            RuleVantage('resolver-b', lambda _hostname: DnsResponse(rcode='NXDOMAIN')),
+        )
+    )
+
+    result = await validator.validate('run-id', 'example.com', (candidate,))
+
+    error_observation = next(
+        observation
+        for observation in result.observations
+        if observation.candidate == candidate and observation.resolver == 'resolver-error'
+    )
+    assert error_observation.rcode == 'ERROR'
+    assert error_observation.error == 'RuntimeError: resolver unavailable'
+    assert result.classifications[0].addressability is Addressability.NOT_CURRENT
+
+
+@pytest.mark.asyncio
+async def test_validator_times_out_a_stalled_resolver() -> None:
+    candidate = 'api.example.com'
+
+    class StalledVantage:
+        name = 'resolver-stalled'
+
+        async def query(self, _hostname: str) -> DnsResponse:
+            await asyncio.Event().wait()
+            raise AssertionError('unreachable')
+
+    validator = DnsValidator(
+        (
+            StalledVantage(),
+            RuleVantage('resolver-a', lambda _hostname: DnsResponse(rcode='NXDOMAIN')),
+            RuleVantage('resolver-b', lambda _hostname: DnsResponse(rcode='NXDOMAIN')),
+        ),
+        timeout_seconds=0.01,
+    )
+
+    result = await validator.validate('run-id', 'example.com', (candidate,))
+
+    error_observation = next(
+        observation
+        for observation in result.observations
+        if observation.candidate == candidate and observation.resolver == 'resolver-stalled'
+    )
+    assert error_observation.error is not None
+    assert error_observation.error.startswith('TimeoutError')
+    assert result.classifications[0].addressability is Addressability.NOT_CURRENT
+
+
+@pytest.mark.asyncio
+async def test_validator_retains_empty_nonterminal_as_secondary_evidence() -> None:
+    result = await DnsValidator(_vantages(lambda _hostname: DnsResponse())).validate(
+        'run-id',
+        'example.com',
+        ('branch.example.com',),
+    )
+
+    assert result.classifications[0].addressability is Addressability.NOT_CURRENT
+
+
+@pytest.mark.asyncio
+async def test_validator_never_queries_out_of_scope_candidates() -> None:
+    queried: list[str] = []
+
+    def handler(hostname: str) -> DnsResponse:
+        queried.append(hostname)
+        return DnsResponse(rcode='NXDOMAIN')
+
+    result = await DnsValidator(_vantages(handler)).validate(
+        'run-id',
+        'example.com',
+        ('api.example.com', 'outside.test'),
+    )
+
+    assert [classification.candidate for classification in result.classifications] == ['api.example.com']
+    assert 'outside.test' not in queried
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('candidate_address', 'deterministic_exact_names', 'expected'),
+    [
+        ('192.0.2.20', (), Addressability.CURRENT),
+        ('192.0.2.10', (), Addressability.WILDCARD_INDISTINGUISHABLE),
+        ('192.0.2.10', ('api.example.com',), Addressability.CURRENT),
+    ],
+)
+async def test_validator_compares_stable_wildcard_distribution(
+    candidate_address: str,
+    deterministic_exact_names: tuple[str, ...],
+    expected: Addressability,
+) -> None:
+    candidate = 'api.example.com'
+
+    def handler(hostname: str) -> DnsResponse:
+        return DnsResponse(ipv4=(candidate_address if hostname == candidate else '192.0.2.10',))
+
+    result = await DnsValidator(_vantages(handler)).validate(
+        'run-id',
+        'example.com',
+        (candidate,),
+        deterministic_exact_names=deterministic_exact_names,
+    )
+
+    assert result.classifications[0].addressability is expected
+
+
+@pytest.mark.asyncio
+async def test_validator_detects_nested_wildcard_distribution() -> None:
+    candidate = 'api.stage.example.com'
+
+    def handler(hostname: str) -> DnsResponse:
+        if hostname == candidate or hostname.endswith('.stage.example.com'):
+            return DnsResponse(ipv4=('192.0.2.20',))
+        return DnsResponse(rcode='NXDOMAIN')
+
+    result = await DnsValidator(_vantages(handler)).validate('run-id', 'example.com', (candidate,))
+
+    assert result.classifications[0].addressability is Addressability.WILDCARD_INDISTINGUISHABLE
+
+
+@pytest.mark.asyncio
+async def test_validator_detects_wildcard_cname_distribution() -> None:
+    response = DnsResponse(
+        cnames=('wildcard.example.net',),
+        cname_chain=('wildcard.example.net',),
+    )
+
+    result = await DnsValidator(_vantages(lambda _hostname: response)).validate(
+        'run-id',
+        'example.com',
+        ('alias.example.com',),
+    )
+
+    assert result.classifications[0].addressability is Addressability.WILDCARD_INDISTINGUISHABLE
+
+
+@pytest.mark.asyncio
+async def test_validator_detects_rotating_a_aaaa_and_cname_wildcards() -> None:
+    candidate = 'www.example.com'
+    control_responses = (
+        DnsResponse(ipv4=('192.0.2.1',)),
+        DnsResponse(ipv6=('2001:db8::1',)),
+        DnsResponse(cnames=('wildcard.example.net',)),
+    )
+
+    class RotatingVantage:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.index = 0
+
+        async def query(self, hostname: str) -> DnsResponse:
+            if hostname == candidate:
+                return DnsResponse(ipv4=('192.0.2.90',))
+            response = control_responses[self.index % len(control_responses)]
+            self.index += 1
+            return response
+
+    result = await DnsValidator(tuple(RotatingVantage(f'resolver-{index}') for index in range(3))).validate(
+        'run-id',
+        'example.com',
+        (candidate,),
+    )
+
+    assert result.classifications[0].addressability is Addressability.WILDCARD_INDISTINGUISHABLE
+    controls = [observation for observation in result.observations if observation.is_wildcard_control]
+    assert {address for observation in controls for address in observation.ipv4} == {'192.0.2.1'}
+    assert {address for observation in controls for address in observation.ipv6} == {'2001:db8::1'}
+    assert {cname for observation in controls for cname in observation.cnames} == {'wildcard.example.net'}
+
+
+@pytest.mark.asyncio
+async def test_validator_uses_deepest_control_and_never_promotes_probes() -> None:
+    candidate = 'api.stage.dev.example.com'
+
+    def handler(hostname: str) -> DnsResponse:
+        if hostname == candidate:
+            return DnsResponse(ipv4=('192.0.2.20',))
+        if hostname.endswith('.stage.dev.example.com'):
+            return DnsResponse(rcode='NXDOMAIN')
+        return DnsResponse(ipv4=('192.0.2.20',))
+
+    result = await DnsValidator(_vantages(handler)).validate('run-id', 'example.com', (candidate,))
+
+    assert result.classifications[0].addressability is Addressability.CURRENT
+    controls = [observation for observation in result.observations if observation.is_wildcard_control]
+    assert {observation.wildcard_depth for observation in controls} == {
+        'example.com',
+        'dev.example.com',
+        'stage.dev.example.com',
+    }
+    assert all(observation.candidate is None for observation in controls)
+    assert candidate not in {observation.query_name for observation in controls}
+
+
+def test_validator_requires_three_distinct_vantages() -> None:
+    handler = lambda _hostname: DnsResponse(rcode='NXDOMAIN')
+
+    with pytest.raises(ValueError, match='exactly three distinct'):
+        DnsValidator((RuleVantage('same', handler), RuleVantage('same', handler), RuleVantage('other', handler)))
+
+
+@pytest.mark.asyncio
+async def test_validator_propagates_cancellation() -> None:
+    class CancelledVantage:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        async def query(self, _hostname: str) -> DnsResponse:
+            raise asyncio.CancelledError
+
+    validator = DnsValidator(tuple(CancelledVantage(f'resolver-{index}') for index in range(3)))
+
+    with pytest.raises(asyncio.CancelledError):
+        await validator.validate('run-id', 'example.com', ('api.example.com',))
+
+
+@pytest.mark.asyncio
+async def test_aiodns_vantage_follows_cname_chain_and_retains_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    import theHarvester.lib.dns_validation as validation_module
+
+    closed: list[bool] = []
+    queried: list[tuple[str, str]] = []
+
+    class FakeResolver:
+        def __init__(self, *, nameservers: list[str]) -> None:
+            assert nameservers == ['192.0.2.53']
+
+        async def query_dns(self, hostname: str, record_type: str):
+            queried.append((hostname, record_type))
+            if record_type == 'A' and hostname == 'alias.example.com':
+                return SimpleNamespace(
+                    answer=[
+                        SimpleNamespace(ttl=90, data=SimpleNamespace(cname='Edge.Example.NET.')),
+                        SimpleNamespace(ttl=60, data=SimpleNamespace(cname='Origin.Example.NET.')),
+                        SimpleNamespace(ttl=30, data=SimpleNamespace(addr='192.0.2.10')),
+                    ]
+                )
+            raise validation_module.aiodns.error.DNSError(validation_module.aiodns.error.ARES_ENODATA, 'no data')
+
+        async def close(self) -> None:
+            closed.append(True)
+
+    monkeypatch.setattr(validation_module.aiodns, 'DNSResolver', FakeResolver)
+    vantage = AioDnsResolverVantage('192.0.2.53')
+
+    response = await vantage.query('alias.example.com')
+    await vantage.close()
+
+    assert response.ipv4 == ('192.0.2.10',)
+    assert response.cnames == ('edge.example.net', 'origin.example.net')
+    assert response.cname_chain == ('edge.example.net', 'origin.example.net')
+    assert response.ttl == 30
+    assert response.rcode == 'NOERROR'
+    assert response.error is None
+    assert closed == [True]
+    assert queried == [
+        ('alias.example.com', 'A'),
+        ('alias.example.com', 'AAAA'),
+        ('alias.example.com', 'CNAME'),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_aiodns_vantage_records_nxdomain(monkeypatch: pytest.MonkeyPatch) -> None:
+    import theHarvester.lib.dns_validation as validation_module
+
+    class FakeResolver:
+        def __init__(self, *, nameservers: list[str]) -> None:
+            assert nameservers == ['192.0.2.53']
+
+        async def query_dns(self, _hostname: str, _record_type: str):
+            raise validation_module.aiodns.error.DNSError(validation_module.aiodns.error.ARES_ENOTFOUND, 'not found')
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(validation_module.aiodns, 'DNSResolver', FakeResolver)
+
+    response = await AioDnsResolverVantage('192.0.2.53').query('missing.example.com')
+
+    assert response.rcode == 'NXDOMAIN'
+    assert response.ipv4 == ()
+    assert response.ipv6 == ()
+    assert response.error is None

--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 import pytest
 
+from theHarvester.lib.dns_validation import Addressability, DnsResponse, DnsValidator
 from theHarvester.lib.run import (
     Derivation,
     ScopeClass,
@@ -13,6 +14,7 @@ from theHarvester.lib.run import (
     SourceRateLimitedError,
     SourceStatus,
     execute_run,
+    legacy_dns_results,
     legacy_hostnames,
 )
 
@@ -163,6 +165,49 @@ async def test_execute_run_groups_multiple_sources_under_one_run() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_run_classifies_once_and_bridges_current_dns_results() -> None:
+    candidate = 'api.example.com'
+
+    class CandidateSource:
+        name = 'fixture'
+        family = 'fixture'
+
+        async def collect(self, _target: str) -> list[SourceFinding]:
+            return [SourceFinding(candidate)]
+
+    class Vantage:
+        def __init__(self, name: str, address: str) -> None:
+            self.name = name
+            self.address = address
+
+        async def query(self, hostname: str) -> DnsResponse:
+            return DnsResponse(ipv4=(self.address,)) if hostname == candidate else DnsResponse(rcode='NXDOMAIN')
+
+    validator = DnsValidator(
+        (
+            Vantage('resolver-a', '192.0.2.10'),
+            Vantage('resolver-b', '192.0.2.11'),
+            Vantage('resolver-c', '192.0.2.12'),
+        )
+    )
+
+    result = await execute_run('example.com', (CandidateSource(),), dns_validator=validator)
+
+    assert result.entities[0].addressability is Addressability.CURRENT
+    assert legacy_hostnames(result, 'fixture') == [candidate]
+    assert legacy_dns_results(result, 'fixture') == (
+        ['api.example.com:192.0.2.10,192.0.2.11,192.0.2.12'],
+        [candidate],
+        ['192.0.2.10', '192.0.2.11', '192.0.2.12'],
+    )
+    control_names = {
+        observation.query_name for observation in result.dns_validations if observation.is_wildcard_control
+    }
+    assert not control_names.intersection(observation.value for observation in result.observations)
+    assert not control_names.intersection(entity.value for entity in result.entities)
+
+
+@pytest.mark.asyncio
 async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch: pytest.MonkeyPatch) -> None:
     import argparse
 
@@ -234,6 +279,93 @@ async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch
     assert {observation.source_family for observation in captured[0].observations} == {'catalog-family'}
     assert legacy_hostnames(captured[0]) == ['www.example.com']
     assert stored == [('example.com', ('www.example.com',), 'host', 'CRTsh')]
+
+
+@pytest.mark.asyncio
+async def test_crtsh_bridge_uses_three_resolvers_without_legacy_requery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import theHarvester.__main__ as main_module
+    import theHarvester.lib.run as run_module
+
+    candidate = 'www.example.com'
+
+    class FakeCrtshSearch:
+        def __init__(self, target: str) -> None:
+            assert target == 'example.com'
+
+        async def process(self, _proxy: bool = False) -> None:
+            return None
+
+        async def get_hostnames(self) -> list[str]:
+            return [candidate]
+
+    created: list[str] = []
+    closed: list[str] = []
+
+    class FakeVantage:
+        def __init__(self, nameserver: str) -> None:
+            self.name = nameserver
+            created.append(nameserver)
+
+        async def query(self, hostname: str) -> DnsResponse:
+            return DnsResponse(ipv4=('192.0.2.10',)) if hostname == candidate else DnsResponse(rcode='NXDOMAIN')
+
+        async def close(self) -> None:
+            closed.append(self.name)
+
+    class FailOnLegacyChecker:
+        def __init__(self, *_args, **_kwargs) -> None:
+            raise AssertionError('validated evidence must not be queried again')
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args: object) -> None:
+            return None
+
+        async def store(self, *_args: object) -> None:
+            return None
+
+    captured: list[run_module.RunResult] = []
+    output: list[object] = []
+
+    async def capture_run(target, sources, **kwargs):
+        result = await run_module.execute_run(target, sources, **kwargs)
+        captured.append(result)
+        return result
+
+    monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
+    monkeypatch.setattr(main_module, 'AioDnsResolverVantage', FakeVantage, raising=False)
+    monkeypatch.setattr(main_module.hostchecker, 'Checker', FailOnLegacyChecker)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'execute_run', capture_run, raising=True)
+    monkeypatch.setattr(main_module.output_logger, 'info', output.append)
+
+    monkeypatch.setattr(
+        main_module.sys,
+        'argv',
+        [
+            'theHarvester',
+            '-d',
+            'example.com',
+            '-b',
+            'crtsh',
+            '-r',
+            '192.0.2.53,192.0.2.54,192.0.2.55',
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await main_module.start()
+
+    assert exit_info.value.code == 0
+    assert set(created) == {'192.0.2.53', '192.0.2.54', '192.0.2.55'}
+    assert set(closed) == set(created)
+    assert captured[0].entities[0].addressability is Addressability.CURRENT
+    assert output.count(f'{candidate}:192.0.2.10') == 1
+    assert candidate not in output
 
 
 @pytest.mark.asyncio

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -9,6 +9,7 @@ import sys
 import time
 import traceback
 from collections.abc import Iterable
+from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING, Any
 
 import anyio
@@ -80,9 +81,17 @@ from theHarvester.discovery import (
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib import hostchecker, stash
 from theHarvester.lib.core import DATA_DIR, Core, show_default_error_message
+from theHarvester.lib.dns_validation import AioDnsResolverVantage, DnsValidator
 from theHarvester.lib.hostnames import normalize_scoped_hostname
 from theHarvester.lib.output import configure_logging, output_logger, print_linkedin_sections, print_section, sorted_unique
-from theHarvester.lib.run import LegacyHostnameSource, RunResult, SourceStatus, execute_run, legacy_hostnames
+from theHarvester.lib.run import (
+    LegacyHostnameSource,
+    RunResult,
+    SourceStatus,
+    execute_run,
+    legacy_dns_results,
+    legacy_hostnames,
+)
 from theHarvester.lib.source_catalog import ResultRoute, get_source_spec
 from theHarvester.screenshot.screenshot import ScreenShotter
 
@@ -177,7 +186,10 @@ async def start(rest_args: argparse.Namespace | None = None):
     parser.add_argument(
         '-r',
         '--dns-resolve',
-        help='Perform DNS resolution on subdomains with a resolver list or passed in resolvers, default False.',
+        help=(
+            'Perform DNS resolution on subdomains with a resolver list or passed in resolvers. '
+            'Exactly three distinct resolvers enable consensus and wildcard validation for migrated sources.'
+        ),
         default='',
         type=str,
         nargs='?',
@@ -310,7 +322,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                     output_logger.info(f'Passed DNS resolver is invalid, skipping: {item} ({e})')
 
         # if for some reason, there are duplicates
-        final_dns_resolver_list = list(set(final_dns_resolver_list))
+        final_dns_resolver_list = list(dict.fromkeys(final_dns_resolver_list))
         if len(final_dns_resolver_list) == 0:
             output_logger.info('No valid DNS resolvers were parsed from --dns-resolve; continuing without custom resolvers.')
 
@@ -366,7 +378,12 @@ async def start(rest_args: argparse.Namespace | None = None):
             output_logger.info(f'[*] Searching {source[0].upper() + source[1:]}. ')
 
         if ResultRoute.HOSTS in routes:
-            if run_result is not None:
+            has_dns_validation = run_result is not None and bool(run_result.dns_validations)
+            if run_result is not None and run_result.dns_validations:
+                resolved_pair, host_names, temp_ips = legacy_dns_results(run_result, source_spec.name)
+                all_ip.extend(temp_ips)
+                full.extend(resolved_pair)
+            elif run_result is not None:
                 host_names = legacy_hostnames(run_result, source_spec.name)
             else:
                 discovered_hosts = await search_engine.get_hostnames()
@@ -374,25 +391,26 @@ async def start(rest_args: argparse.Namespace | None = None):
                     host_names = list(discovered_hosts)
                 else:
                     host_names = list(_normalize_hosts_for_storage(discovered_hosts, word))
-            if source != 'hackertarget' and source != 'pentesttools' and source != 'rapiddns':
-                # If a source is inside this conditional, it means the hosts returned must be resolved to obtain ip
-                # This should only be checked if --dns-resolve has a wordlist
-                if dnsresolve is None or len(final_dns_resolver_list) > 0:
-                    # indicates that -r was passed in if dnsresolve is None
-                    full_hosts_checker = hostchecker.Checker(host_names, final_dns_resolver_list)
-                    # If full, this is only getting resolved hosts
-                    (
-                        resolved_pair,
-                        _temp_hosts,
-                        temp_ips,
-                    ) = await full_hosts_checker.check()
-                    all_ip.extend(temp_ips)
-                    full.extend(resolved_pair)
-                    # full.extend(temp_hosts)
+            if not has_dns_validation:
+                if source != 'hackertarget' and source != 'pentesttools' and source != 'rapiddns':
+                    # If a source is inside this conditional, it means the hosts returned must be resolved to obtain ip
+                    # This should only be checked if --dns-resolve has a wordlist
+                    if dnsresolve is None or len(final_dns_resolver_list) > 0:
+                        # indicates that -r was passed in if dnsresolve is None
+                        full_hosts_checker = hostchecker.Checker(host_names, final_dns_resolver_list)
+                        # If full, this is only getting resolved hosts
+                        (
+                            resolved_pair,
+                            _temp_hosts,
+                            temp_ips,
+                        ) = await full_hosts_checker.check()
+                        all_ip.extend(temp_ips)
+                        full.extend(resolved_pair)
+                        # full.extend(temp_hosts)
+                    else:
+                        full.extend(host_names)
                 else:
                     full.extend(host_names)
-            else:
-                full.extend(host_names)
             all_hosts.extend(host_names)
             await db_stash.store_all(word, all_hosts, 'host', source)
 
@@ -435,12 +453,25 @@ async def start(rest_args: argparse.Namespace | None = None):
     evidence_sources: list[LegacyHostnameSource] = []
 
     async def store_evidence_sources() -> None:
-        run_result = await execute_run(word, tuple(evidence_sources))
-        executions = {execution.source: execution for execution in run_result.source_executions}
-        for evidence_source in evidence_sources:
-            execution = executions[evidence_source.name]
-            if execution.status in (SourceStatus.SUCCEEDED, SourceStatus.EMPTY) or execution.observation_count:
-                await store(evidence_source.search, evidence_source.legacy_name, run_result)
+        async with AsyncExitStack() as resolver_stack:
+            dns_validator = None
+            if len(final_dns_resolver_list) == 3:
+                vantages = []
+                for nameserver in final_dns_resolver_list:
+                    vantage = AioDnsResolverVantage(nameserver)
+                    vantages.append(vantage)
+                    resolver_stack.push_async_callback(vantage.close)
+                dns_validator = DnsValidator(tuple(vantages))
+            run_result = (
+                await execute_run(word, tuple(evidence_sources), dns_validator=dns_validator)
+                if dns_validator is not None
+                else await execute_run(word, tuple(evidence_sources))
+            )
+            executions = {execution.source: execution for execution in run_result.source_executions}
+            for evidence_source in evidence_sources:
+                execution = executions[evidence_source.name]
+                if execution.status in (SourceStatus.SUCCEEDED, SourceStatus.EMPTY) or execution.observation_count:
+                    await store(evidence_source.search, evidence_source.legacy_name, run_result)
 
     if args.source is not None:
         engines = Core.expand_source_selection(args.source)

--- a/theHarvester/lib/dns_validation.py
+++ b/theHarvester/lib/dns_validation.py
@@ -1,3 +1,12 @@
+"""DNS consensus evidence for current addressability.
+
+Discovery providers can report historical, stale, or wildcard-backed names. This
+module therefore preserves each DNS answer as evidence instead of treating one
+resolver lookup as truth. Every candidate and synthetic wildcard control is
+queried through exactly three distinct resolver vantages; two matching vantages
+form the quorum used for an addressability classification.
+"""
+
 from __future__ import annotations
 
 import asyncio
@@ -20,6 +29,8 @@ _DEFAULT_QUERY_TIMEOUT_SECONDS = 10.0
 
 
 class Addressability(StrEnum):
+    """Operator-facing classification derived from resolver consensus."""
+
     CURRENT = 'currently-addressable'
     NOT_CURRENT = 'not-currently-addressable'
     RESOLVER_DISPUTED = 'resolver-disputed'
@@ -28,6 +39,8 @@ class Addressability(StrEnum):
 
 @dataclass(frozen=True)
 class DnsResponse:
+    """Normalized A, AAAA, and CNAME evidence returned by one resolver."""
+
     ipv4: tuple[str, ...] = ()
     ipv6: tuple[str, ...] = ()
     cnames: tuple[str, ...] = ()
@@ -38,12 +51,16 @@ class DnsResponse:
 
 
 class ResolverVantage(Protocol):
+    """One independently configured DNS view used in the quorum."""
+
     name: str
 
     async def query(self, hostname: str) -> DnsResponse: ...
 
 
 class AioDnsResolverVantage:
+    """Adapt one explicit nameserver to the resolver-vantage contract."""
+
     def __init__(self, nameserver: str) -> None:
         self.name = nameserver
         self._resolver = aiodns.DNSResolver(nameservers=[nameserver])
@@ -117,6 +134,8 @@ class AioDnsResolverVantage:
 
 @dataclass(frozen=True)
 class DnsValidationObservation:
+    """One retained resolver answer, including failures and wildcard controls."""
+
     run_id: str
     candidate: str | None
     query_name: str
@@ -142,6 +161,8 @@ class CandidateClassification:
 
 @dataclass(frozen=True)
 class ValidationResult:
+    """Raw DNS observations plus one consensus classification per candidate."""
+
     observations: tuple[DnsValidationObservation, ...]
     classifications: tuple[CandidateClassification, ...]
 
@@ -231,6 +252,14 @@ def _classify(
 
 
 class DnsValidator:
+    """Classify candidates with three resolver views and wildcard controls.
+
+    A two-of-three quorum limits the effect of one resolver's cache, filtering,
+    outage, or inconsistent delegation view. Synthetic high-entropy names probe
+    the closest enclosing domain for wildcard behavior so a wildcard answer is
+    not promoted as evidence that the candidate exists as an exact DNS node.
+    """
+
     def __init__(
         self,
         vantages: tuple[ResolverVantage, ...],
@@ -288,7 +317,12 @@ class DnsValidator:
         *,
         deterministic_exact_names: tuple[str, ...] = (),
     ) -> ValidationResult:
-        """Trust deterministic_exact_names only as caller-supplied exact-node evidence."""
+        """Validate normalized in-scope candidates and retain every DNS query.
+
+        ``deterministic_exact_names`` is a narrow escape from wildcard comparison
+        for names already proven to be exact nodes by caller-supplied evidence.
+        It does not bypass the three-resolver addressability quorum.
+        """
         normalized_target = normalize_hostname(target)
         if normalized_target is None:
             raise ValueError('target must be a hostname')

--- a/theHarvester/lib/dns_validation.py
+++ b/theHarvester/lib/dns_validation.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Protocol
+from uuid import uuid4
+
+import aiodns
+
+from theHarvester.lib.hostnames import normalize_hostname, normalize_scoped_hostname
+
+_RESOLVER_COUNT = 3
+_RESOLVER_QUORUM = 2
+_PROBES_PER_DEPTH = 3
+_DEFAULT_QUERY_TIMEOUT_SECONDS = 10.0
+
+
+class Addressability(StrEnum):
+    CURRENT = 'currently-addressable'
+    NOT_CURRENT = 'not-currently-addressable'
+    RESOLVER_DISPUTED = 'resolver-disputed'
+    WILDCARD_INDISTINGUISHABLE = 'wildcard-indistinguishable'
+
+
+@dataclass(frozen=True)
+class DnsResponse:
+    ipv4: tuple[str, ...] = ()
+    ipv6: tuple[str, ...] = ()
+    cnames: tuple[str, ...] = ()
+    rcode: str = 'NOERROR'
+    ttl: int | None = None
+    cname_chain: tuple[str, ...] = ()
+    error: str | None = None
+
+
+class ResolverVantage(Protocol):
+    name: str
+
+    async def query(self, hostname: str) -> DnsResponse: ...
+
+
+class AioDnsResolverVantage:
+    def __init__(self, nameserver: str) -> None:
+        self.name = nameserver
+        self._resolver = aiodns.DNSResolver(nameservers=[nameserver])
+
+    async def query(self, hostname: str) -> DnsResponse:
+        record_types = ('A', 'AAAA', 'CNAME')
+        ipv4: set[str] = set()
+        ipv6: set[str] = set()
+        cnames: list[str] = []
+        ttls: list[int] = []
+        dns_error_codes: list[int] = []
+        errors: list[str] = []
+        successful_query = False
+        query_name = normalize_hostname(hostname)
+        if query_name is None:
+            return DnsResponse(rcode='ERROR', error='invalid hostname')
+
+        results = await asyncio.gather(
+            *(self._resolver.query_dns(query_name, record_type) for record_type in record_types),
+            return_exceptions=True,
+        )
+        for result in results:
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            if isinstance(result, aiodns.error.DNSError):
+                code = result.args[0]
+                dns_error_codes.append(code)
+                if code not in {aiodns.error.ARES_ENOTFOUND, aiodns.error.ARES_ENODATA}:
+                    errors.append(f'{type(result).__name__}: {result}')
+                continue
+            if isinstance(result, BaseException):
+                raise result
+            successful_query = True
+            for record in result.answer:
+                if (ttl := getattr(record, 'ttl', None)) is not None:
+                    ttls.append(ttl)
+                if (address := getattr(record.data, 'addr', None)) is not None:
+                    try:
+                        parsed = ipaddress.ip_address(address)
+                    except ValueError:
+                        errors.append(f'invalid address: {address}')
+                    else:
+                        (ipv4 if parsed.version == 4 else ipv6).add(str(parsed))
+                if (cname := getattr(record.data, 'cname', None)) is not None:
+                    if (normalized := normalize_hostname(cname)) is not None and normalized not in cnames:
+                        cnames.append(normalized)
+
+        if successful_query:
+            rcode = 'NOERROR'
+        elif dns_error_codes and all(code == aiodns.error.ARES_ENOTFOUND for code in dns_error_codes):
+            rcode = 'NXDOMAIN'
+        elif dns_error_codes and all(
+            code in {aiodns.error.ARES_ENOTFOUND, aiodns.error.ARES_ENODATA} for code in dns_error_codes
+        ):
+            rcode = 'NODATA'
+        else:
+            rcode = 'ERROR'
+        return DnsResponse(
+            ipv4=tuple(sorted(ipv4)),
+            ipv6=tuple(sorted(ipv6)),
+            cnames=tuple(cnames),
+            rcode=rcode,
+            ttl=min(ttls, default=None),
+            cname_chain=tuple(cnames),
+            error='; '.join(errors) or None,
+        )
+
+    async def close(self) -> None:
+        await self._resolver.close()
+
+
+@dataclass(frozen=True)
+class DnsValidationObservation:
+    run_id: str
+    candidate: str | None
+    query_name: str
+    resolver: str
+    queried_at: datetime
+    ipv4: tuple[str, ...]
+    ipv6: tuple[str, ...]
+    cnames: tuple[str, ...]
+    rcode: str
+    ttl: int | None
+    cname_chain: tuple[str, ...]
+    latency_ms: float
+    error: str | None
+    is_wildcard_control: bool = False
+    wildcard_depth: str | None = None
+
+
+@dataclass(frozen=True)
+class CandidateClassification:
+    candidate: str
+    addressability: Addressability
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    observations: tuple[DnsValidationObservation, ...]
+    classifications: tuple[CandidateClassification, ...]
+
+
+def _normalize_response(response: DnsResponse) -> DnsResponse:
+    return DnsResponse(
+        ipv4=tuple(sorted({str(ipaddress.IPv4Address(value)) for value in response.ipv4})),
+        ipv6=tuple(sorted({str(ipaddress.IPv6Address(value)) for value in response.ipv6})),
+        cnames=tuple(sorted(normalized for value in response.cnames if (normalized := normalize_hostname(value)) is not None)),
+        rcode=response.rcode.upper(),
+        ttl=response.ttl,
+        cname_chain=tuple(normalized for value in response.cname_chain if (normalized := normalize_hostname(value)) is not None),
+        error=response.error,
+    )
+
+
+def _wildcard_depths(target: str, candidate: str) -> tuple[str, ...]:
+    target_labels = target.split('.')
+    candidate_labels = candidate.split('.')
+    extra_labels = len(candidate_labels) - len(target_labels)
+    return (target, *('.'.join(candidate_labels[index:]) for index in range(extra_labels - 1, 0, -1)))
+
+
+def _has_dns_evidence(observation: DnsValidationObservation) -> bool:
+    return bool(observation.ipv4 or observation.ipv6 or observation.cnames or observation.cname_chain)
+
+
+def _signature(observation: DnsValidationObservation) -> tuple[object, ...]:
+    return (
+        observation.rcode,
+        observation.ipv4,
+        observation.ipv6,
+        observation.cnames,
+        observation.cname_chain,
+    )
+
+
+def _record_presence_signature(observation: DnsValidationObservation) -> tuple[object, ...]:
+    return (
+        observation.rcode,
+        bool(observation.ipv4),
+        bool(observation.ipv6),
+        bool(observation.cnames or observation.cname_chain),
+    )
+
+
+def _overlaps_wildcard(
+    candidate_observations: tuple[DnsValidationObservation, ...],
+    controls: tuple[DnsValidationObservation, ...],
+) -> bool:
+    candidate_evidence = tuple(observation for observation in candidate_observations if _has_dns_evidence(observation))
+    control_evidence = tuple(observation for observation in controls if _has_dns_evidence(observation))
+    if not candidate_evidence or not control_evidence:
+        return False
+    signatures = {_signature(observation) for observation in control_evidence}
+    if any(_signature(observation) in signatures for observation in candidate_evidence):
+        return True
+    return len(signatures) > 1 and any(
+        _record_presence_signature(observation) in {_record_presence_signature(control) for control in control_evidence}
+        for observation in candidate_evidence
+    )
+
+
+def _classify(
+    candidate_observations: tuple[DnsValidationObservation, ...],
+    controls: tuple[DnsValidationObservation, ...],
+    *,
+    deterministic_exact: bool,
+) -> Addressability:
+    if not deterministic_exact and _overlaps_wildcard(candidate_observations, controls):
+        return Addressability.WILDCARD_INDISTINGUISHABLE
+    addressable = sum(
+        observation.rcode == 'NOERROR' and bool(observation.ipv4 or observation.ipv6) for observation in candidate_observations
+    )
+    not_addressable = sum(
+        observation.error is None
+        and not observation.ipv4
+        and not observation.ipv6
+        and observation.rcode in {'NOERROR', 'NXDOMAIN', 'NODATA'}
+        for observation in candidate_observations
+    )
+    if addressable >= _RESOLVER_QUORUM:
+        return Addressability.CURRENT
+    if not_addressable >= _RESOLVER_QUORUM:
+        return Addressability.NOT_CURRENT
+    return Addressability.RESOLVER_DISPUTED
+
+
+class DnsValidator:
+    def __init__(
+        self,
+        vantages: tuple[ResolverVantage, ...],
+        *,
+        timeout_seconds: float = _DEFAULT_QUERY_TIMEOUT_SECONDS,
+    ) -> None:
+        if len(vantages) != _RESOLVER_COUNT or len({vantage.name for vantage in vantages}) != _RESOLVER_COUNT:
+            raise ValueError('DNS validation requires exactly three distinct resolver vantages')
+        if timeout_seconds <= 0:
+            raise ValueError('DNS validation timeout must be positive')
+        self.vantages = vantages
+        self.timeout_seconds = timeout_seconds
+
+    async def _query(
+        self,
+        run_id: str,
+        query_name: str,
+        *,
+        candidate: str | None = None,
+        wildcard_depth: str | None = None,
+    ) -> tuple[DnsValidationObservation, ...]:
+        async def query(vantage: ResolverVantage) -> DnsValidationObservation:
+            queried_at = datetime.now(UTC)
+            started = time.perf_counter()
+            try:
+                async with asyncio.timeout(self.timeout_seconds):
+                    response = _normalize_response(await vantage.query(query_name))
+            except Exception as error:
+                response = DnsResponse(rcode='ERROR', error=f'{type(error).__name__}: {error}')
+            return DnsValidationObservation(
+                run_id=run_id,
+                candidate=candidate,
+                query_name=query_name,
+                resolver=vantage.name,
+                queried_at=queried_at,
+                ipv4=response.ipv4,
+                ipv6=response.ipv6,
+                cnames=response.cnames,
+                rcode=response.rcode,
+                ttl=response.ttl,
+                cname_chain=response.cname_chain,
+                latency_ms=(time.perf_counter() - started) * 1000,
+                error=response.error,
+                is_wildcard_control=wildcard_depth is not None,
+                wildcard_depth=wildcard_depth,
+            )
+
+        return tuple(await asyncio.gather(*(query(vantage) for vantage in self.vantages)))
+
+    async def validate(
+        self,
+        run_id: str,
+        target: str,
+        candidates: tuple[str, ...],
+        *,
+        deterministic_exact_names: tuple[str, ...] = (),
+    ) -> ValidationResult:
+        """Trust deterministic_exact_names only as caller-supplied exact-node evidence."""
+        normalized_target = normalize_hostname(target)
+        if normalized_target is None:
+            raise ValueError('target must be a hostname')
+        normalized_candidates = tuple(
+            dict.fromkeys(
+                normalized
+                for candidate in candidates
+                if (normalized := normalize_scoped_hostname(candidate, normalized_target)) is not None
+                and normalized != normalized_target
+            )
+        )
+        normalized_deterministic_exact_names = {
+            normalized
+            for name in deterministic_exact_names
+            if (normalized := normalize_scoped_hostname(name, normalized_target)) is not None
+        }
+
+        candidate_observations: dict[str, tuple[DnsValidationObservation, ...]] = {}
+        observations: list[DnsValidationObservation] = []
+        for candidate in normalized_candidates:
+            candidate_observations[candidate] = await self._query(run_id, candidate, candidate=candidate)
+            observations.extend(candidate_observations[candidate])
+
+        depths = tuple(
+            dict.fromkeys(
+                depth for candidate in normalized_candidates for depth in _wildcard_depths(normalized_target, candidate)
+            )
+        )
+        controls_by_depth: dict[str, list[DnsValidationObservation]] = {depth: [] for depth in depths}
+        for depth in depths:
+            for _ in range(_PROBES_PER_DEPTH):
+                query_name = f'th-{uuid4().hex}.{depth}'
+                controls = await self._query(run_id, query_name, wildcard_depth=depth)
+                controls_by_depth[depth].extend(controls)
+                observations.extend(controls)
+
+        classifications = []
+        for candidate in normalized_candidates:
+            closest_depth = _wildcard_depths(normalized_target, candidate)[-1]
+            classifications.append(
+                CandidateClassification(
+                    candidate,
+                    _classify(
+                        candidate_observations[candidate],
+                        tuple(controls_by_depth[closest_depth]),
+                        deterministic_exact=candidate in normalized_deterministic_exact_names,
+                    ),
+                )
+            )
+        return ValidationResult(tuple(observations), tuple(classifications))

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -89,6 +89,8 @@ class LegacyHostnameSource:
 
 @dataclass(frozen=True)
 class DiscoveryObservation:
+    """One normalized source assertion retained before entity merging."""
+
     run_id: str
     target: str
     value: str
@@ -101,6 +103,8 @@ class DiscoveryObservation:
 
 @dataclass(frozen=True)
 class SourceExecution:
+    """Completion status and counts for one source attempt in a run."""
+
     run_id: str
     source: str
     source_family: str
@@ -124,6 +128,8 @@ class MergedEntity:
 
     @property
     def independent_corroboration_count(self) -> int:
+        """Count independent datasets, not adapters backed by the same data."""
+
         return len({observation.source_family for observation in self.observations})
 
 
@@ -161,6 +167,14 @@ async def execute_run(
     dns_validator: DnsValidator | None = None,
     deterministic_exact_dns_names: tuple[str, ...] = (),
 ) -> RunResult:
+    """Collect, normalize, scope, merge, and optionally DNS-validate one run.
+
+    DNS validation is intentionally downstream of provider collection: provider
+    observations remain intact even when current DNS disagrees or fails. The
+    merged entity receives the consensus classification, while the underlying
+    per-resolver answers stay available for audit and later reinterpretation.
+    """
+
     normalized_target = normalize_hostname(target)
     if normalized_target is None:
         raise ValueError('target must be a hostname')

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Protocol
 from uuid import uuid4
 
+from theHarvester.lib.dns_validation import (
+    Addressability,
+    DnsValidationObservation,
+    DnsValidator,
+)
 from theHarvester.lib.hostnames import normalize_hostname
 
 if TYPE_CHECKING:
@@ -111,6 +116,7 @@ class SourceExecution:
 class MergedEntity:
     value: str
     observations: tuple[DiscoveryObservation, ...]
+    addressability: Addressability | None = None
 
     @property
     def scope_classes(self) -> tuple[ScopeClass, ...]:
@@ -130,6 +136,7 @@ class RunResult:
     source_executions: tuple[SourceExecution, ...]
     observations: tuple[DiscoveryObservation, ...]
     entities: tuple[MergedEntity, ...]
+    dns_validations: tuple[DnsValidationObservation, ...] = ()
 
 
 def _classify_scope(target: str, value: str, derivation: Derivation) -> ScopeClass:
@@ -150,6 +157,9 @@ def _merge_observations(observations: Sequence[DiscoveryObservation]) -> tuple[M
 async def execute_run(
     target: str,
     sources: Sequence[PassiveSource],
+    *,
+    dns_validator: DnsValidator | None = None,
+    deterministic_exact_dns_names: tuple[str, ...] = (),
 ) -> RunResult:
     normalized_target = normalize_hostname(target)
     if normalized_target is None:
@@ -226,6 +236,21 @@ async def execute_run(
         logger.info(f'Source {source.name} completed with status {status}')
 
     merged_observations = tuple(observations)
+    entities = _merge_observations(merged_observations)
+    dns_validations: tuple[DnsValidationObservation, ...] = ()
+    if dns_validator is not None:
+        validation = await dns_validator.validate(
+            run_id,
+            normalized_target,
+            tuple(entity.value for entity in entities if ScopeClass.IN_SCOPE in entity.scope_classes),
+            deterministic_exact_names=deterministic_exact_dns_names,
+        )
+        classifications = {
+            classification.candidate: classification.addressability for classification in validation.classifications
+        }
+        entities = tuple(replace(entity, addressability=classifications.get(entity.value)) for entity in entities)
+        dns_validations = validation.observations
+
     result = RunResult(
         run_id=run_id,
         target=normalized_target,
@@ -233,13 +258,15 @@ async def execute_run(
         completed_at=datetime.now(UTC),
         source_executions=tuple(executions),
         observations=merged_observations,
-        entities=_merge_observations(merged_observations),
+        entities=entities,
+        dns_validations=dns_validations,
     )
     return result
 
 
 def legacy_hostnames(result: RunResult, source: str | None = None) -> list[str]:
     """Return the host list consumed by the existing CLI, REST, file, and stash paths."""
+    validated_hosts = {entity.value for entity in result.entities if entity.addressability is Addressability.CURRENT}
     return sorted(
         {
             observation.value
@@ -247,5 +274,18 @@ def legacy_hostnames(result: RunResult, source: str | None = None) -> list[str]:
             if observation.value != result.target
             and observation.scope_class is ScopeClass.IN_SCOPE
             and (source is None or observation.source == source)
+            and (not result.dns_validations or observation.value in validated_hosts)
         }
     )
+
+
+def legacy_dns_results(result: RunResult, source: str | None = None) -> tuple[list[str], list[str], list[str]]:
+    hosts = legacy_hostnames(result, source)
+    host_set = set(hosts)
+    addresses_by_host: dict[str, set[str]] = {host: set() for host in hosts}
+    for observation in result.dns_validations:
+        if not observation.is_wildcard_control and observation.candidate in host_set:
+            addresses_by_host[observation.candidate].update((*observation.ipv4, *observation.ipv6))
+    addresses = sorted({address for values in addresses_by_host.values() for address in values})
+    resolved = [f'{host}:{",".join(sorted(addresses_by_host[host]))}' if addresses_by_host[host] else host for host in hosts]
+    return resolved, hosts, addresses

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -25,6 +25,12 @@ _ROUTE_CAPABILITIES = {
 
 @dataclass(frozen=True)
 class SourceSpec:
+    """Discovery routes and the independent evidence family for one source.
+
+    Sources sharing an upstream dataset share a family. For example, ``shodan``
+    and ``shodanInternetDB`` are separate adapters but not independent evidence.
+    """
+
     name: str
     routes: frozenset[ResultRoute]
     family: str


### PR DESCRIPTION
## Summary

- validate in-scope candidates across three configured resolver vantages
- require two agreeing resolver observations for current addressability
- retain wildcard-control and resolver-disputed evidence without promoting it to results
- document quorum, load-balanced answers, CNAME handling, and corroboration

## Operator impact

With -r, operators can separate currently addressable names from historical, wildcard-indistinguishable, and disputed DNS evidence. DNS resolution remains off unless explicitly selected.

## Stack

Layer 4 of 10. Base: fix/dnsdb-evidence-status.

Fork tracking: https://github.com/NotoriousRebel/theHarvester/issues/63

## Verification

Consensus and wildcard behavior are covered with offline resolver doubles. The complete stack passed all required checks and both reviews.