### PR TITLE
feat: integrate completed run reporting

### DIFF
--- a/tests/discovery/test_intelxsearch.py
+++ b/tests/discovery/test_intelxsearch.py
@@ -142,7 +142,12 @@ async def test_orchestrator_stores_intelx_hostnames(monkeypatch: pytest.MonkeyPa
         async def get_interestingurls(self) -> list[str]:
             return []
 
+    class _RunStore:
+        async def save(self, _result) -> None:
+            return None
+
     monkeypatch.setattr(theharvester_main.stash, 'StashManager', _Stash)
+    monkeypatch.setattr(theharvester_main, 'SQLiteRunStore', _RunStore)
     monkeypatch.setattr(intelxsearch, 'SearchIntelx', _Intelx)
 
     results = await theharvester_main.start(

--- a/tests/discovery/test_shodan_engine.py
+++ b/tests/discovery/test_shodan_engine.py
@@ -22,7 +22,12 @@ class TestShodanEngine:
             async def store_all(self, domain, all, res_type, source) -> None:  # noqa: A002
                 return None
 
+        class DummyRunStore:
+            async def save(self, _result) -> None:
+                return None
+
         monkeypatch.setattr(main_module.stash, "StashManager", DummyStashManager, raising=True)
+        monkeypatch.setattr(main_module, "SQLiteRunStore", DummyRunStore, raising=True)
 
         # Stub Shodan search to avoid network and API key requirements.
         class DummySearchShodan:

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -1,0 +1,573 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import ClassVar
+from xml.etree import ElementTree
+
+import pytest
+from fastapi.testclient import TestClient
+
+from theHarvester.lib.dns_validation import DnsResponse, DnsValidator
+from theHarvester.lib.output import (
+    evidence_xml_fragment,
+    format_run_terminal,
+    legacy_json_result,
+    run_result_jsonl,
+)
+from theHarvester.lib.run import (
+    Derivation,
+    RunStatus,
+    SourceFinding,
+    SourceRateLimitedError,
+    SourceStatus,
+    SQLiteRunStore,
+    StageFinding,
+    StageFindingKind,
+    StageResult,
+    complete_run,
+    execute_run,
+)
+
+
+class CompletedRunSource:
+    name = 'fixture'
+    family = 'fixture-family'
+
+    async def collect(self, _target: str) -> list[SourceFinding]:
+        return [
+            SourceFinding(
+                'api.example.com',
+                observed_at=datetime(2026, 7, 15, 12, tzinfo=UTC),
+            ),
+            SourceFinding('old.example.com'),
+        ]
+
+
+class IncompleteRunSource:
+    name = 'fixture'
+    family = 'fixture-family'
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    async def collect(self, _target: str) -> list[SourceFinding]:
+        raise self.error
+
+
+@pytest.mark.asyncio
+async def test_completed_run_serializes_status_and_meaningful_timestamps() -> None:
+    result = await execute_run('example.com', (CompletedRunSource(),))
+
+    serialized = result.to_dict()
+
+    assert result.status is RunStatus.COMPLETE
+    assert serialized['started_at']
+    assert serialized['completed_at']
+    assert serialized['observations'][0]['collected_at']
+    assert serialized['observations'][0]['provider_observed_at'] == '2026-07-15T12:00:00+00:00'
+    assert 'provider_observed_at' not in serialized['observations'][1]
+
+
+@pytest.mark.asyncio
+async def test_complete_run_merges_late_and_direct_stage_results() -> None:
+    result = await execute_run('example.com', (CompletedRunSource(),))
+
+    completed = complete_run(
+        result,
+        (
+            StageResult(
+                'action:dns-brute',
+                SourceStatus.SUCCEEDED,
+                1,
+                1,
+                (StageFinding(StageFindingKind.HOSTNAME, 'late.example.com:192.0.2.11'),),
+            ),
+            StageResult(
+                'action:take-over',
+                SourceStatus.SUCCEEDED,
+                1,
+                1,
+                (StageFinding(StageFindingKind.TAKEOVER, 'api.example.com', 'not vulnerable'),),
+            ),
+        ),
+    )
+
+    assert {entity.value for entity in completed.entities} == {
+        'api.example.com',
+        'old.example.com',
+        'late.example.com',
+    }
+    assert {(item.kind, item.value, item.detail) for item in completed.selected_observations} == {
+        (StageFindingKind.TAKEOVER, 'api.example.com', 'not vulnerable')
+    }
+    assert {execution.source for execution in completed.source_executions} == {
+        'fixture',
+        'action:dns-brute',
+        'action:take-over',
+    }
+
+
+class TerminalRunSource:
+    name = 'fixture'
+    family = 'fixture-family'
+
+    async def collect(self, _target: str) -> list[SourceFinding]:
+        return [
+            SourceFinding('api.example.com'),
+            SourceFinding('old.example.com'),
+            SourceFinding('related.example.net', Derivation.SCOPE_EXTENSION),
+            SourceFinding('cdn.vendor.test', Derivation.EXTERNAL_RELATIONSHIP),
+        ]
+
+
+class TerminalResolver:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    async def query(self, hostname: str) -> DnsResponse:
+        if hostname == 'api.example.com':
+            return DnsResponse(ipv4=('192.0.2.10',))
+        return DnsResponse(rcode='NXDOMAIN')
+
+
+@pytest.mark.asyncio
+async def test_terminal_reports_each_hostname_once_with_status_and_sources() -> None:
+    validator = DnsValidator(tuple(TerminalResolver(f'resolver-{index}') for index in range(3)))
+    result = await execute_run('example.com', (TerminalRunSource(),), dns_validator=validator)
+    result = complete_run(
+        result,
+        (
+            StageResult(
+                'action:take-over',
+                SourceStatus.SUCCEEDED,
+                1,
+                1,
+                (StageFinding(StageFindingKind.TAKEOVER, 'api.example.com', 'not vulnerable'),),
+            ),
+        ),
+    )
+
+    terminal = format_run_terminal(result)
+
+    for hostname in ('api.example.com', 'old.example.com', 'related.example.net', 'cdn.vendor.test'):
+        assert terminal.count(hostname) == 1
+    assert 'Currently addressable subdomains (1)' in terminal
+    assert 'Secondary evidence / needs review (2)' in terminal
+    assert 'Scope-extension candidates (1)' in terminal
+    assert 'status=currently-addressable; sources=fixture; takeover=not vulnerable' in terminal
+    assert 'Run status: complete' in terminal
+
+
+@pytest.mark.asyncio
+async def test_jsonl_preserves_typed_records_provenance_and_timestamps() -> None:
+    validator = DnsValidator(tuple(TerminalResolver(f'resolver-{index}') for index in range(3)))
+    result = await execute_run('example.com', (CompletedRunSource(),), dns_validator=validator)
+
+    records = [json.loads(line) for line in run_result_jsonl(result).splitlines()]
+
+    assert {record['record_type'] for record in records} == {
+        'run',
+        'source_execution',
+        'discovery_observation',
+        'dns_validation_observation',
+        'merged_result',
+    }
+    assert all(record['schema_version'] == 'theharvester-evidence-v1' for record in records)
+    assert all(record['run_id'] == result.run_id for record in records)
+    discovery = [record['data'] for record in records if record['record_type'] == 'discovery_observation']
+    assert all(record['collected_at'] for record in discovery)
+    assert discovery[0]['provider_observed_at'] == '2026-07-15T12:00:00+00:00'
+    assert 'provider_observed_at' not in discovery[1]
+    validations = [record['data'] for record in records if record['record_type'] == 'dns_validation_observation']
+    assert all(record['validated_at'] for record in validations)
+    assert all('queried_at' not in record for record in validations)
+    merged = [record['data'] for record in records if record['record_type'] == 'merged_result']
+    assert all(record['provenance'] for record in merged)
+
+
+@pytest.mark.asyncio
+async def test_legacy_json_and_xml_keep_existing_fields_and_add_evidence() -> None:
+    validator = DnsValidator(tuple(TerminalResolver(f'resolver-{index}') for index in range(3)))
+    result = await execute_run('example.com', (CompletedRunSource(),), dns_validator=validator)
+
+    legacy = legacy_json_result(
+        result,
+        {
+            'cmd': 'theHarvester -d example.com',
+            'emails': ['ops@example.com'],
+            'hosts': ['legacy.example.com'],
+        },
+    )
+    evidence_xml = ElementTree.fromstring(evidence_xml_fragment(result))
+
+    assert legacy['cmd'] == 'theHarvester -d example.com'
+    assert legacy['emails'] == ['ops@example.com']
+    assert legacy['hosts'] == ['legacy.example.com', 'api.example.com']
+    assert legacy['evidence_run']['status'] == 'complete'
+    assert evidence_xml.tag == 'evidence_run'
+    assert evidence_xml.attrib['status'] == 'complete'
+    assert evidence_xml.find("source[@name='fixture']").attrib['status'] == 'succeeded'
+
+
+@pytest.mark.asyncio
+async def test_structured_run_persistence_round_trips_in_its_own_table(tmp_path) -> None:
+    result = await execute_run('example.com', (CompletedRunSource(),))
+    store = SQLiteRunStore(tmp_path / 'stash.sqlite')
+
+    await store.save(result)
+
+    assert await store.load(result.run_id) == result.to_dict()
+
+
+@pytest.mark.asyncio
+async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import theHarvester.__main__ as main_module
+
+    events: list[str] = []
+    wordlist = tmp_path / 'api-endpoints.txt'
+    wordlist.write_text('/v1/status\n')
+    report = tmp_path / 'completed-run'
+
+    class FakeCrtshSearch:
+        def __init__(self, _target: str) -> None:
+            return None
+
+        async def process(self, _proxy: bool = False) -> None:
+            events.append('collect')
+
+        async def get_hostnames(self) -> list[str]:
+            return ['api.example.com']
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args) -> None:
+            return None
+
+        async def store(self, *_args) -> None:
+            return None
+
+    class FakeDnsForce:
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def run(self):
+            events.append('dns-brute')
+            return ['late.example.com:192.0.2.11'], ['late.example.com'], ['192.0.2.11']
+
+    class FakeHostChecker:
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def check(self):
+            return ['api.example.com:192.0.2.10'], ['api.example.com'], ['192.0.2.10']
+
+    async def fake_reverse_all_ips_in_range(**_kwargs) -> None:
+        events.append('dns-lookup')
+
+    class FakeTakeOver:
+        def __init__(self, _hosts: list[str]) -> None:
+            return None
+
+        async def populate_fingerprints(self) -> None:
+            return None
+
+        async def process(self, *, proxy: bool) -> None:
+            assert proxy is False
+            events.append('takeover')
+
+        async def get_takeover_results(self) -> dict[str, str]:
+            return {'api.example.com': 'not vulnerable'}
+
+    class FakeApiScanner:
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def do_search(self) -> None:
+            events.append('api-scan')
+
+        def get_found_endpoints(self):
+            return {'https://example.com/v1/status': SimpleNamespace(status_code=200)}
+
+        def get_interesting_endpoints(self):
+            return {}
+
+        def get_auth_required(self):
+            return {}
+
+        def get_api_versions(self):
+            return set()
+
+        def get_rate_limits(self):
+            return {}
+
+        def get_methods(self):
+            return {'GET'}
+
+        def get_status_codes(self):
+            return {200}
+
+    class FakeRunStore:
+        saved: ClassVar[list] = []
+
+        async def save(self, result) -> None:
+            events.append('persist')
+            self.saved.append(result)
+
+    def capture_terminal(result) -> str:
+        events.append('terminal')
+        return format_run_terminal(result)
+
+    monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module.hostchecker, 'Checker', FakeHostChecker)
+    monkeypatch.setattr(main_module.dnssearch, 'DnsForce', FakeDnsForce)
+    monkeypatch.setattr(main_module.dnssearch, 'serialize_ip_range', lambda **_kwargs: '192.0.2.0/24')
+    monkeypatch.setattr(main_module.dnssearch, 'reverse_all_ips_in_range', fake_reverse_all_ips_in_range)
+    monkeypatch.setattr(main_module.takeover, 'TakeOver', FakeTakeOver)
+    monkeypatch.setattr(main_module.api_endpoints, 'SearchApiEndpoints', FakeApiScanner)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore, raising=False)
+    monkeypatch.setattr(main_module, 'format_run_terminal', capture_terminal, raising=False)
+
+    response = await main_module.start(
+        SimpleNamespace(
+            api_scan=True,
+            dns_brute=True,
+            dns_lookup=True,
+            dns_resolve=None,
+            dns_server=None,
+            domain='example.com',
+            filename=str(report),
+            limit=500,
+            proxies=False,
+            quiet=False,
+            screenshot='',
+            shodan=False,
+            source='crtsh',
+            start=0,
+            take_over=True,
+            wordlist=str(wordlist),
+        ),
+        return_evidence_run=True,
+    )
+
+    result = response[-1]
+    assert events == ['collect', 'dns-brute', 'dns-lookup', 'takeover', 'api-scan', 'persist', 'terminal']
+    assert result is FakeRunStore.saved[0]
+    assert {entity.value for entity in result.entities} == {'api.example.com', 'late.example.com'}
+    assert {(item.kind, item.value) for item in result.selected_observations} == {
+        (StageFindingKind.TAKEOVER, 'api.example.com'),
+        (StageFindingKind.API_ENDPOINT, 'https://example.com/v1/status'),
+    }
+    legacy_json = json.loads(report.with_suffix('.json').read_text())
+    evidence_xml = ElementTree.parse(report.with_suffix('.xml')).getroot().find('evidence_run')
+    jsonl = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
+    assert legacy_json['evidence_run']['run_id'] == result.run_id
+    assert evidence_xml.attrib['run_id'] == result.run_id
+    assert {record['record_type'] for record in jsonl} >= {'run', 'selected_observation'}
+
+
+@pytest.mark.asyncio
+async def test_cli_records_provider_people_in_the_completed_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    import theHarvester.__main__ as main_module
+
+    class FakeVenacusSearch:
+        def __init__(self, **_kwargs) -> None:
+            return None
+
+        async def process(self, _proxy: bool = False) -> None:
+            return None
+
+        async def get_emails(self) -> list[str]:
+            return []
+
+        async def get_ips(self) -> list[str]:
+            return []
+
+        async def get_people(self) -> list[dict[str, str]]:
+            return [{'name': 'Alice'}]
+
+        async def get_interestingurls(self) -> list[str]:
+            return []
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args) -> None:
+            return None
+
+    class FakeRunStore:
+        async def save(self, _result) -> None:
+            return None
+
+    monkeypatch.setattr(main_module.venacussearch, 'SearchVenacus', FakeVenacusSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore)
+
+    response = await main_module.start(
+        SimpleNamespace(
+            api_scan=False,
+            dns_brute=False,
+            dns_lookup=False,
+            dns_resolve='',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=500,
+            proxies=False,
+            quiet=False,
+            screenshot='',
+            shodan=False,
+            source='venacus',
+            start=0,
+            take_over=False,
+            wordlist='',
+        ),
+        return_evidence_run=True,
+    )
+
+    assert {(item.kind, item.value) for item in response[-1].selected_observations} == {
+        (StageFindingKind.PERSON, '{"name":"Alice"}')
+    }
+
+
+@pytest.mark.asyncio
+async def test_cli_preserves_the_actual_provider_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    import theHarvester.__main__ as main_module
+
+    class FailedCrtshSearch:
+        def __init__(self, _target: str) -> None:
+            return None
+
+        async def process(self, _proxy: bool = False) -> None:
+            raise RuntimeError('provider failed')
+
+        async def get_hostnames(self) -> list[str]:
+            raise AssertionError('failed source must not expose results')
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+    class FakeRunStore:
+        async def save(self, _result) -> None:
+            return None
+
+    monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FailedCrtshSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore)
+
+    response = await main_module.start(
+        SimpleNamespace(
+            api_scan=False,
+            dns_brute=False,
+            dns_lookup=False,
+            dns_resolve='',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=500,
+            proxies=False,
+            quiet=False,
+            screenshot='',
+            shodan=False,
+            source='crtsh',
+            start=0,
+            take_over=False,
+            wordlist='',
+        ),
+        return_evidence_run=True,
+    )
+
+    execution = response[-1].source_executions[0]
+    assert execution.status is SourceStatus.FAILED
+    assert execution.error_type == 'RuntimeError'
+
+
+def test_rest_query_keeps_legacy_fields_and_adds_the_completed_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    import asyncio
+
+    from theHarvester.lib.api import api
+
+    result = asyncio.run(execute_run('example.com', (CompletedRunSource(),)))
+
+    async def fake_start(_args, *, return_evidence_run: bool = False):
+        assert return_evidence_run is True
+        return (
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            ['ops@example.com'],
+            ['api.example.com'],
+            result,
+        )
+
+    monkeypatch.setattr(api.__main__.Core, 'get_supportedengines', lambda: ['fixture'])
+    monkeypatch.setattr(api.__main__, 'start', fake_start)
+
+    response = TestClient(api.app).get('/query?domain=example.com&source=fixture')
+
+    assert response.status_code == 200
+    assert response.json()['emails'] == ['ops@example.com']
+    assert response.json()['hosts'] == ['api.example.com', 'old.example.com']
+    assert response.json()['evidence_run']['run_id'] == result.run_id
+
+
+@pytest.mark.parametrize(
+    ('error', 'expected_run_status', 'expected_source_status'),
+    [
+        (RuntimeError('provider failed'), 'failed', 'failed'),
+        (SourceRateLimitedError(), 'partial', 'rate-limited'),
+    ],
+)
+@pytest.mark.asyncio
+async def test_incomplete_source_states_remain_visible_on_every_output(
+    error: Exception,
+    expected_run_status: str,
+    expected_source_status: str,
+) -> None:
+    result = await execute_run('example.com', (IncompleteRunSource(error),))
+
+    terminal = format_run_terminal(result)
+    records = [json.loads(line) for line in run_result_jsonl(result).splitlines()]
+    legacy = legacy_json_result(result)
+    evidence_xml = ElementTree.fromstring(evidence_xml_fragment(result))
+
+    assert f'Run status: {expected_run_status}' in terminal
+    assert f'fixture [status={expected_source_status}' in terminal
+    assert records[0]['data']['status'] == expected_run_status
+    assert legacy['evidence_run']['status'] == expected_run_status
+    assert evidence_xml.attrib['status'] == expected_run_status
+
+
+@pytest.mark.asyncio
+async def test_late_source_failure_cannot_remain_a_complete_run() -> None:
+    result = await execute_run('example.com', (CompletedRunSource(),))
+
+    completed = complete_run(
+        result,
+        (
+            StageResult(
+                'fixture',
+                SourceStatus.FAILED,
+                1,
+                0,
+                error_type='RuntimeError',
+            ),
+        ),
+    )
+
+    assert completed.status is RunStatus.FAILED
+    assert completed.source_executions[0].status is SourceStatus.FAILED
+    assert completed.source_executions[0].error_type == 'RuntimeError'

--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -39,6 +39,11 @@ class FakePassiveSource:
         ]
 
 
+class NoopRunStore:
+    async def save(self, _result) -> None:
+        return None
+
+
 @pytest.mark.asyncio
 async def test_complete_run_retains_late_evidence_status_and_persistence(tmp_path) -> None:
     result = await execute_run('example.com', (FakePassiveSource(),))
@@ -283,6 +288,7 @@ async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch
 
     monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
     monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', NoopRunStore)
     monkeypatch.setattr(main_module, 'execute_run', execute_with_temporary_store, raising=True)
     crtsh_spec = main_module.get_source_spec('crtsh')
     monkeypatch.setattr(
@@ -379,6 +385,7 @@ async def test_crtsh_bridge_uses_three_resolvers_without_legacy_requery(
     monkeypatch.setattr(main_module, 'AioDnsResolverVantage', FakeVantage, raising=False)
     monkeypatch.setattr(main_module.hostchecker, 'Checker', FailOnLegacyChecker)
     monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', NoopRunStore)
     monkeypatch.setattr(main_module, 'execute_run', capture_run, raising=True)
     monkeypatch.setattr(main_module.output_logger, 'info', output.append)
 
@@ -403,8 +410,9 @@ async def test_crtsh_bridge_uses_three_resolvers_without_legacy_requery(
     assert set(created) == {'192.0.2.53', '192.0.2.54', '192.0.2.55'}
     assert set(closed) == set(created)
     assert captured[0].entities[0].addressability is Addressability.CURRENT
-    assert output.count(f'{candidate}:192.0.2.10') == 1
-    assert candidate not in output
+    terminal = '\n'.join(map(str, output))
+    assert terminal.count(candidate) == 1
+    assert 'status=currently-addressable; sources=crtsh' in terminal
 
 
 @pytest.mark.asyncio
@@ -445,6 +453,7 @@ async def test_dnsdb_bridge_preserves_partial_results_and_status(monkeypatch: py
 
     monkeypatch.setattr(main_module.dnsdb, 'SearchDNSDB', FakeDNSDBSearch)
     monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', NoopRunStore)
     monkeypatch.setattr(main_module, 'execute_run', capture_run, raising=True)
 
     await main_module.start(

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -8,9 +8,9 @@ import string
 import sys
 import time
 import traceback
-from collections.abc import Iterable
+from collections.abc import Awaitable, Iterable
 from contextlib import AsyncExitStack
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import anyio
 import netaddr
@@ -83,20 +83,30 @@ from theHarvester.lib import hostchecker, stash
 from theHarvester.lib.core import DATA_DIR, Core, show_default_error_message
 from theHarvester.lib.dns_validation import AioDnsResolverVantage, DnsValidator
 from theHarvester.lib.hostnames import normalize_scoped_hostname
-from theHarvester.lib.output import configure_logging, output_logger, print_linkedin_sections, print_section, sorted_unique
+from theHarvester.lib.output import (
+    configure_logging,
+    evidence_xml_fragment,
+    format_run_terminal,
+    legacy_json_result,
+    output_logger,
+    run_result_jsonl,
+    sorted_unique,
+)
 from theHarvester.lib.run import (
     LegacyHostnameSource,
     RunResult,
     SourceStatus,
+    SQLiteRunStore,
+    StageFinding,
+    StageFindingKind,
+    StageResult,
+    complete_run,
     execute_run,
     legacy_dns_results,
     legacy_hostnames,
 )
 from theHarvester.lib.source_catalog import ResultRoute, get_source_spec
 from theHarvester.screenshot.screenshot import ScreenShotter
-
-if TYPE_CHECKING:
-    from collections.abc import Awaitable
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +144,7 @@ def sanitize_filename(filename: str) -> str:
     return filename
 
 
-async def start(rest_args: argparse.Namespace | None = None):
+async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_run: bool = False):
     """Main program function"""
     parser = argparse.ArgumentParser(
         description='theHarvester is used to gather open source intelligence (OSINT) on a company or domain.'
@@ -211,7 +221,7 @@ async def start(rest_args: argparse.Namespace | None = None):
     parser.add_argument(
         '-f',
         '--filename',
-        help='Save the results to an XML and JSON file.',
+        help='Save XML, legacy JSON, and normalized JSONL reports.',
         default='',
         type=str,
     )
@@ -245,11 +255,12 @@ async def start(rest_args: argparse.Namespace | None = None):
         elif rest_args.dns_brute:
             args = rest_args
             dnsbrute = (rest_args.dns_brute, True)
+            filename = args.filename
         else:
             args = rest_args
             dnsbrute = (args.dns_brute, False)
             # We need to make sure the filename is random as to not overwrite other files
-            filename: str = args.filename
+            filename = args.filename
             alphabet = string.ascii_letters + string.digits
             rest_filename += f'{"".join(secrets.choice(alphabet) for _ in range(32))}_{filename}' if len(filename) != 0 else ''
     else:
@@ -351,12 +362,39 @@ async def start(rest_args: argparse.Namespace | None = None):
 
     interesting_urls = []
     total_asns = []
+    completed_run_result: RunResult | None = None
+    stage_results: list[StageResult] = []
 
-    async def store(
+    def record_stage_result(
+        source: str,
+        started: float,
+        findings: list[StageFinding] | tuple[StageFinding, ...] = (),
+        error: Exception | None = None,
+    ) -> None:
+        unique_findings = tuple(dict.fromkeys(findings))
+        stage_results.append(
+            StageResult(
+                source=source,
+                status=(
+                    SourceStatus.FAILED
+                    if error is not None
+                    else SourceStatus.SUCCEEDED
+                    if unique_findings
+                    else SourceStatus.EMPTY
+                ),
+                duration_ms=(time.perf_counter() - started) * 1000,
+                result_count=len(findings),
+                findings=unique_findings,
+                error_type=type(error).__name__ if error is not None else None,
+            )
+        )
+
+    async def _store(
         search_engine: Any,
         source: str,
         run_result: RunResult | None = None,
-    ) -> None:
+        stage_findings: list[StageFinding] | None = None,
+    ):
         """Process a source and persist its declared consolidated result routes.
 
         :param search_engine: search engine to fetch details from
@@ -413,46 +451,106 @@ async def start(rest_args: argparse.Namespace | None = None):
                     full.extend(host_names)
             all_hosts.extend(host_names)
             await db_stash.store_all(word, all_hosts, 'host', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.HOSTNAME, host) for host in host_names)
 
         if ResultRoute.EMAILS in routes:
             email_list = await search_engine.get_emails()
             all_emails.extend(email_list)
             await db_stash.store_all(word, email_list, 'email', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.EMAIL, email) for email in email_list)
 
         if ResultRoute.IPS in routes:
             ips_list = await search_engine.get_ips()
             all_ip.extend(ips_list)
             await db_stash.store_all(word, all_ip, 'ip', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.IP_ADDRESS, str(ip)) for ip in ips_list)
 
         if ResultRoute.PEOPLE in routes:
             people_list = await search_engine.get_people()
             all_people.extend(people_list)
             await db_stash.store_all(word, people_list, 'people', source)
+            if stage_findings is not None:
+                stage_findings.extend(
+                    StageFinding(StageFindingKind.PERSON, ujson.dumps(person, sort_keys=True)) for person in people_list
+                )
 
         if ResultRoute.LINKS in routes:
             links = await search_engine.get_links()
             linkedin_links_tracker.extend(links)
             if len(links) > 0:
                 await db.store_all(word, links, 'linkedinlinks', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.URL, link) for link in links)
 
         if ResultRoute.INTERESTING_URLS in routes:
             iurls = await search_engine.get_interestingurls()
             interesting_urls.extend(iurls)
             if len(iurls) > 0:
                 await db.store_all(word, iurls, 'interestingurls', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.INTERESTING_URL, url) for url in iurls)
 
         if ResultRoute.ASNS in routes:
             fasns = await search_engine.get_asns()
             total_asns.extend(fasns)
             if len(fasns) > 0:
                 await db.store_all(word, fasns, 'asns', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.ASN, str(asn)) for asn in fasns)
         if run_result is None:
             logger.info(f'Source {source} completed')
+            return None
+        return next(
+            execution for execution in run_result.source_executions if execution.source.casefold() == source_spec.name.casefold()
+        )
+
+    def store(
+        search_engine: Any,
+        source: str,
+        run_result: RunResult | None = None,
+    ) -> Awaitable[None]:
+        async def run_stage() -> None:
+            findings: list[StageFinding] = []
+            started = time.perf_counter()
+            execution = None
+            error: Exception | None = None
+            try:
+                execution = await _store(search_engine, source, run_result, findings)
+            except Exception as stage_error:
+                error = stage_error
+                raise
+            finally:
+                source_spec = get_source_spec(source)
+                stage_results.append(
+                    StageResult(
+                        source=source_spec.name,
+                        source_family=source_spec.family,
+                        status=(
+                            execution.status
+                            if execution is not None
+                            else SourceStatus.FAILED
+                            if error is not None
+                            else SourceStatus.SUCCEEDED
+                            if findings
+                            else SourceStatus.EMPTY
+                        ),
+                        duration_ms=(time.perf_counter() - started) * 1000,
+                        result_count=execution.result_count if execution is not None else len(findings),
+                        findings=tuple(dict.fromkeys(findings)),
+                        error_type=execution.error_type if execution is not None else type(error).__name__ if error else None,
+                    )
+                )
+
+        return run_stage()
 
     stor_lst = []
     evidence_sources: list[LegacyHostnameSource] = []
 
     async def store_evidence_sources() -> None:
+        nonlocal completed_run_result
         async with AsyncExitStack() as resolver_stack:
             dns_validator = None
             if len(final_dns_resolver_list) == 3:
@@ -467,6 +565,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 if dns_validator is not None
                 else await execute_run(word, tuple(evidence_sources))
             )
+            completed_run_result = run_result
             executions = {execution.source: execution for execution in run_result.source_executions}
             for evidence_source in evidence_sources:
                 execution = executions[evidence_source.name]
@@ -1374,111 +1473,42 @@ async def start(rest_args: argparse.Namespace | None = None):
         await asyncio.gather(*tasks, return_exceptions=True)
 
     await handler(lst=stor_lst)
-    return_ips: list = []
-    if rest_args is not None and len(rest_filename) == 0 and rest_args.dns_brute is False:
-        # Indicates user is using REST api but not wanting output to be saved to a file
-        # cast to string so Rest API can understand the type
-        return_ips.extend([str(ip) for ip in sorted([netaddr.IPAddress(ip.strip()) for ip in set(all_ip)])])
-        # return list(set(all_emails)), return_ips, full, '', ''
-        all_hosts = [host.replace('www.', '') for host in all_hosts if host.replace('www.', '') in all_hosts]
-        all_hosts = list(sorted(set(all_hosts)))
-        return (
-            total_asns,
-            interesting_urls,
-            twitter_people_list_tracker,
-            linkedin_people_list_tracker,
-            linkedin_links_tracker,
-            all_urls,
-            all_ip,
-            all_emails,
-            all_hosts,
-        )
-    # Check to see if all_emails and all_hosts are defined.
-    try:
-        all_emails
-    except NameError:
-        output_logger.info('\n\n[!] No emails found because all_emails is not defined.\n\n ')
-        sys.exit(1)
-    try:
-        all_hosts
-    except NameError:
-        output_logger.info('\n\n[!] No hosts found because all_hosts is not defined.\n\n ')
-        sys.exit(1)
-
-    # Results
-    if len(total_asns) > 0:
-        print_section(f'\n[*] ASNS found: {len(total_asns)}', total_asns, '--------------------')
-        total_asns = sorted_unique(total_asns)
-
-    if len(interesting_urls) > 0:
-        print_section(f'\n[*] Interesting Urls found: {len(interesting_urls)}', interesting_urls, '--------------------')
-        interesting_urls = sorted_unique(interesting_urls)
-
-    if len(twitter_people_list_tracker) == 0 and 'twitter' in engines:
-        output_logger.info('\n[*] No Twitter users found.\n\n')
-    elif len(twitter_people_list_tracker) >= 1:
-        print_section(
-            '\n[*] Twitter Users found: ' + str(len(twitter_people_list_tracker)),
-            twitter_people_list_tracker,
-            '---------------------',
-        )
-        twitter_people_list_tracker = sorted_unique(twitter_people_list_tracker)
-
-    print_linkedin_sections(engines, linkedin_people_list_tracker, linkedin_links_tracker)
+    if completed_run_result is None:
+        completed_run_result = await execute_run(word, ())
+    recorded_sources = {result.source.casefold() for result in stage_results}
+    recorded_sources.update(execution.source.casefold() for execution in completed_run_result.source_executions)
+    for engine in engines:
+        if engine.casefold() not in recorded_sources:
+            source_spec = get_source_spec(engine)
+            stage_results.append(
+                StageResult(
+                    source=source_spec.name,
+                    source_family=source_spec.family,
+                    status=SourceStatus.FAILED,
+                    duration_ms=0,
+                    result_count=0,
+                    error_type='SourceDidNotStart',
+                )
+            )
+    total_asns = sorted_unique(total_asns)
+    interesting_urls = sorted_unique(interesting_urls)
+    twitter_people_list_tracker = sorted_unique(twitter_people_list_tracker)
     linkedin_people_list_tracker = sorted_unique(linkedin_people_list_tracker)
     linkedin_links_tracker = sorted_unique(linkedin_links_tracker)
+    all_urls = sorted_unique(all_urls)
+    ip_list = []
+    for ip in set(all_ip):
+        try:
+            value = ip.strip()
+            if value:
+                ip_list.append(str(netaddr.IPNetwork(value) if '/' in value else netaddr.IPAddress(value)))
+        except (netaddr.core.AddrFormatError, ValueError, TypeError) as error:
+            output_logger.info(f'An exception has occurred while adding: {ip} to ip_list: {error}')
+    ip_list.sort()
+    host_ip = ip_list
+    all_emails = sorted_unique(all_emails)
 
-    length_urls = len(all_urls)
-    if length_urls == 0:
-        if len(engines) >= 1 and 'trello' in engines:
-            output_logger.info('\n[*] No Trello URLs found.')
-    else:
-        total = length_urls
-        print_section('\n[*] Trello URLs found: ' + str(total), all_urls, '--------------------')
-        all_urls = sorted_unique(all_urls)
-
-    if len(all_ip) == 0:
-        output_logger.info('\n[*] No IPs found.')
-    else:
-        output_logger.info('\n[*] IPs found: ' + str(len(all_ip)))
-        output_logger.info('-------------------')
-        # use netaddr as the list may contain ipv4 and ipv6 addresses
-        ip_list = []
-        for ip in set(all_ip):
-            try:
-                ip = ip.strip()
-                if len(ip) > 0:
-                    if '/' in ip:
-                        ip_list.append(str(netaddr.IPNetwork(ip)))
-                    else:
-                        ip_list.append(str(netaddr.IPAddress(ip)))
-            except (netaddr.core.AddrFormatError, ValueError, TypeError) as e:
-                output_logger.info(f'An exception has occurred while adding: {ip} to ip_list: {e}')
-                continue
-        ip_list = list(sorted(ip_list))
-        output_logger.info('\n'.join(map(str, ip_list)))
-        # Populate host_ip from ip_list for DNS lookup, virtual hosts search, and Shodan search
-        host_ip = ip_list
-
-    if len(all_emails) == 0:
-        output_logger.info('\n[*] No emails found.')
-    else:
-        output_logger.info('\n[*] Emails found: ' + str(len(all_emails)))
-        output_logger.info('----------------------')
-        all_emails = sorted(list(set(all_emails)))
-        output_logger.info('\n'.join(all_emails))
-
-    if len(all_people) == 0:
-        output_logger.info('\n[*] No people found.')
-    else:
-        output_logger.info('\n[*] People found: ' + str(len(all_people)))
-        output_logger.info('----------------------')
-        for person in all_people:
-            output_logger.info(person)
-
-    if len(all_hosts) == 0:
-        output_logger.info('\n[*] No hosts found.\n\n')
-    else:
+    if len(all_hosts) > 0:
         db = stash.StashManager()
         if dnsresolve is None or len(final_dns_resolver_list) > 0:
             temp = set()
@@ -1497,10 +1527,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                     temp.add(host)
             full = list(sorted(temp))
             full.sort(key=lambda el: el.split(':')[0])
-            output_logger.info('\n[*] Hosts found: ' + str(len(full)))
-            output_logger.info('---------------------')
             for host in full:
-                output_logger.info(host)
                 try:
                     if ':' in host:
                         _, addr = host.split(':', 1)
@@ -1511,19 +1538,23 @@ async def start(rest_args: argparse.Namespace | None = None):
         else:
             all_hosts = [host.replace('www.', '') for host in all_hosts if host.replace('www.', '') in all_hosts]
             all_hosts = list(sorted(set(all_hosts)))
-            output_logger.info('\n[*] Hosts found: ' + str(len(all_hosts)))
-            output_logger.info('---------------------')
-            for host in all_hosts:
-                output_logger.info(host)
 
     # DNS brute force
+    resolved_pair: list[str] = []
     if dnsbrute and dnsbrute[0] is True:
         output_logger.info('\n[*] Starting DNS brute force.')
-        dns_force = dnssearch.DnsForce(word, final_dns_resolver_list, verbose=True)
-        resolved_pair, hosts, ips = await dns_force.run()
-        # Check if Rest API is being used if so return found hosts
-        if dnsbrute[1]:
-            return resolved_pair
+        stage_started = time.perf_counter()
+        try:
+            dns_force = dnssearch.DnsForce(word, final_dns_resolver_list, verbose=True)
+            resolved_pair, hosts, ips = await dns_force.run()
+            record_stage_result(
+                'action:dns-brute',
+                stage_started,
+                [StageFinding(StageFindingKind.HOSTNAME, host) for host in resolved_pair],
+            )
+        except Exception as error:
+            record_stage_result('action:dns-brute', stage_started, error=error)
+            output_logger.info(f'[!] DNS brute force failed: {error}')
         db = stash.StashManager()
         temp = set()
         for host in resolved_pair:
@@ -1547,24 +1578,13 @@ async def start(rest_args: argparse.Namespace | None = None):
                     temp.add(host)
                 if host not in all_hosts:
                     all_hosts.append(host)
-        output_logger.info('\n[*] Hosts found after DNS brute force:')
-        for sub in temp:
-            output_logger.info(sub)
         await db.store_all(word, list(sorted(temp)), 'host', 'dns_bruteforce')
 
-    takeover_results = dict()
-    # TakeOver Checking
-    if takeover_status:
-        output_logger.info('\n[*] Performing subdomain takeover check')
-        output_logger.info('\n[*] Subdomain Takeover checking IS ACTIVE RECON')
-        search_take = takeover.TakeOver(all_hosts)
-        await search_take.populate_fingerprints()
-        await search_take.process(proxy=use_proxy)
-        takeover_results = await search_take.get_takeover_results()
     # DNS reverse lookup
     dnsrev: list = []
     if dnslookup is True:
         output_logger.info('\n[*] Starting active queries for DNSLookup.')
+        stage_started = time.perf_counter()
 
         # reverse each iprange in a separate task
         __reverse_dns_tasks: dict = {}
@@ -1584,16 +1604,51 @@ async def start(rest_args: argparse.Namespace | None = None):
                 # nameservers=list(map(str, dnsserver.split(','))) if dnsserver else None))
 
         # run all the reversing tasks concurrently
-        await asyncio.gather(*__reverse_dns_tasks.values())
-        output_logger.info('\n[*] Hosts found after reverse lookup (in target domain):')
-        output_logger.info('--------------------------------------------------------')
-        for xh in dnsrev:
-            output_logger.info(xh)
+        try:
+            await asyncio.gather(*__reverse_dns_tasks.values())
+            record_stage_result(
+                'action:dns-lookup',
+                stage_started,
+                [StageFinding(StageFindingKind.HOSTNAME, host) for host in dnsrev],
+            )
+        except Exception as error:
+            record_stage_result('action:dns-lookup', stage_started, error=error)
+            output_logger.info(f'[!] Reverse DNS lookup failed: {error}')
+
+    takeover_results = dict()
+    # TakeOver Checking
+    if takeover_status:
+        output_logger.info('\n[*] Performing subdomain takeover check')
+        output_logger.info('\n[*] Subdomain Takeover checking IS ACTIVE RECON')
+        stage_started = time.perf_counter()
+        try:
+            search_take = takeover.TakeOver(all_hosts)
+            await search_take.populate_fingerprints()
+            await search_take.process(proxy=use_proxy)
+            takeover_results = await search_take.get_takeover_results()
+            record_stage_result(
+                'action:take-over',
+                stage_started,
+                [
+                    StageFinding(
+                        StageFindingKind.TAKEOVER,
+                        str(host),
+                        result if isinstance(result, str) else ujson.dumps(result, sort_keys=True),
+                    )
+                    for host, result in takeover_results.items()
+                ],
+            )
+        except Exception as error:
+            record_stage_result('action:take-over', stage_started, error=error)
+            output_logger.info(f'[!] Takeover check failed: {error}')
 
     # Screenshots
     screenshot_tups = []
-    if len(args.screenshot) > 0:
-        screen_shotter = ScreenShotter(args.screenshot)
+    screenshot_hosts: list[str] = []
+    screenshot_path = getattr(args, 'screenshot', '')
+    if len(screenshot_path) > 0:
+        stage_started = time.perf_counter()
+        screen_shotter = ScreenShotter(screenshot_path)
         path_exists = screen_shotter.verify_path()
         # Verify the path exists, if not create it or if user does not create it skips screenshot
         if path_exists:
@@ -1615,6 +1670,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                     results = await pool.map(screen_shotter.visit, list(unique_resolved_domains))
                     # Filter out domains that we couldn't connect to
                     unique_resolved_domains_list = list(sorted({tup[0] for tup in results if len(tup[1]) > 0}))
+                    screenshot_hosts.extend(unique_resolved_domains_list)
                 async with Pool(3) as pool:
                     output_logger.info(f'Length of unique resolved domains: {len(unique_resolved_domains_list)} chunking now!\n')
                     # If you have the resources, you could make the function faster by increasing the chunk number
@@ -1632,10 +1688,18 @@ async def start(rest_args: argparse.Namespace | None = None):
             total_time = f'{mon:02d}:{sec:02d}'
             output_logger.info(f'Finished taking screenshots in {total_time} seconds')
             output_logger.info('[+] Note there may be leftover chrome processes you may have to kill manually\n')
+        record_stage_result(
+            'action:screenshot',
+            stage_started,
+            [StageFinding(StageFindingKind.SCREENSHOT, host) for host in screenshot_hosts],
+        )
 
     # Shodan
     shodanres = []
+    shodan_findings: list[StageFinding] = []
+    shodan_errors: list[Exception] = []
     if shodan is True:
+        stage_started = time.perf_counter()
         output_logger.info('[*] Searching Shodan. ')
         try:
             for ip in host_ip:
@@ -1660,113 +1724,33 @@ async def start(rest_args: argparse.Namespace | None = None):
                                 value = ', '.join(map(str, value))
                             rowdata.append(value)
                         shodanres.append(rowdata)
+                        shodan_findings.append(
+                            StageFinding(
+                                StageFindingKind.SHODAN_RESULT,
+                                ip,
+                            )
+                        )
                         output_logger.info(ujson.dumps(shodandict[ip], indent=4, sort_keys=True))
                         output_logger.info('\n')
                 except Exception as ip_error:
+                    shodan_errors.append(ip_error)
                     output_logger.info(f'[SHODAN-error] Error searching {ip}: {ip_error}')
                     continue
         except Exception as e:
+            shodan_errors.append(e)
             output_logger.info(f'[!] An error occurred with Shodan: {e} ')
+        record_stage_result(
+            'action:shodan',
+            stage_started,
+            shodan_findings,
+            shodan_errors[0] if shodan_errors else None,
+        )
     else:
         pass
 
-    if filename != '':
-        output_logger.info('\n[*] Reporting started.')
-        try:
-            if len(rest_filename) == 0:
-                filename = filename.rsplit('.', 1)[0] + '.xml'
-            else:
-                filename = 'theHarvester/app/static/' + rest_filename.rsplit('.', 1)[0] + '.xml'
-            # XML REPORT SECTION
-            async with await anyio.open_file(filename, 'w+') as file:
-                await file.write('<?xml version="1.0" encoding="UTF-8"?><theHarvester>')
-                sanitized_args = [sanitize_for_xml(f'"{arg}"' if ' ' in arg else arg) for arg in sys.argv[1:]]
-                await file.write('<cmd>' + ' '.join(sanitized_args) + '</cmd>')
-                for email in all_emails:
-                    await file.write('<email>' + sanitize_for_xml(email) + '</email>')
-                for x in full:
-                    host, ip = x.split(':', 1) if ':' in x else (x, '')
-                    if ip and len(ip) > 3:
-                        await file.write(
-                            f'<host><ip>{sanitize_for_xml(ip)}</ip><hostname>{sanitize_for_xml(host)}</hostname></host>'
-                        )
-                    else:
-                        await file.write(f'<host>{sanitize_for_xml(host)}</host>')
-                for x in vhost:
-                    host, ip = x.split(':', 1) if ':' in x else (x, '')
-                    if ip and len(ip) > 3:
-                        await file.write(
-                            f'<vhost><ip>{sanitize_for_xml(ip)} </ip><hostname>{sanitize_for_xml(host)}</hostname></vhost>'
-                        )
-                    else:
-                        await file.write(f'<vhost>{sanitize_for_xml(host)}</vhost>')
-                # TODO add Shodan output into XML report
-                await file.write('</theHarvester>')
-                output_logger.info('[*] XML File saved.')
-        except (OSError, ValueError, TypeError, UnicodeEncodeError) as error:
-            output_logger.info(f'[!] An error occurred while saving the XML file: {error}')
-
-        try:
-            # JSON REPORT SECTION
-            filename = filename.rsplit('.', 1)[0] + '.json'
-            # create dict with values for JSON output
-            json_dict: dict = dict()
-            # start by adding the command line arguments
-            json_dict['cmd'] = ' '.join([f'"{arg}"' if ' ' in arg else arg for arg in sys.argv[1:]])
-            # to determine if a variable exists
-            # it should but just a validation check
-            if 'ip_list' in locals():
-                if all_ip and len(all_ip) >= 1 and ip_list and len(ip_list) > 0:
-                    json_dict['ips'] = ip_list
-
-            if len(all_emails) > 0:
-                json_dict['emails'] = all_emails
-
-            if dnsresolve is None or (len(final_dns_resolver_list) > 0 and len(full) > 0):
-                json_dict['hosts'] = full
-            elif len(all_hosts) > 0:
-                json_dict['hosts'] = all_hosts
-            else:
-                json_dict['hosts'] = []
-
-            if vhost and len(vhost) > 0:
-                json_dict['vhosts'] = vhost
-
-            if len(interesting_urls) > 0:
-                json_dict['interesting_urls'] = interesting_urls
-
-            if len(all_urls) > 0:
-                json_dict['trello_urls'] = all_urls
-
-            if len(total_asns) > 0:
-                json_dict['asns'] = total_asns
-
-            if len(twitter_people_list_tracker) > 0:
-                json_dict['twitter_people'] = twitter_people_list_tracker
-
-            if len(linkedin_people_list_tracker) > 0:
-                json_dict['linkedin_people'] = linkedin_people_list_tracker
-
-            if len(linkedin_links_tracker) > 0:
-                json_dict['linkedin_links'] = linkedin_links_tracker
-
-            if len(all_people) > 0:
-                json_dict['people'] = all_people
-
-            if takeover_status and len(takeover_results) > 0:
-                json_dict['takeover_results'] = takeover_results
-
-            json_dict['shodan'] = shodanres
-            async with await anyio.open_file(filename, 'w+') as fp:
-                dumped_json = ujson.dumps(json_dict, sort_keys=True)
-                await fp.write(dumped_json)
-            output_logger.info('[*] JSON File saved.')
-        except (OSError, ValueError, TypeError, UnicodeEncodeError) as er:
-            output_logger.info(f'[!] An error occurred while saving the JSON file: {er} ')
-        output_logger.info('\n\n')
-
     # Enhanced code block for API Endpoint scanning feature
-    if args.api_scan or 'api_endpoints' in engines:
+    if getattr(args, 'api_scan', False) or 'api_endpoints' in engines:
+        stage_started = time.perf_counter()
         try:
             # Define a default wordlist if none is specified
             wordlist = args.wordlist or str(DATA_DIR / 'wordlists' / 'api_endpoints.txt')
@@ -1858,74 +1842,102 @@ async def start(rest_args: argparse.Namespace | None = None):
                 # Also add complete domain paths to the interesting_urls list
                 all_urls.extend(new_urls)
 
+            record_stage_result(
+                'action:api-scan',
+                stage_started,
+                [
+                    StageFinding(StageFindingKind.API_ENDPOINT, endpoint, str(result.status_code))
+                    for endpoint, result in endpoints_found.items()
+                ],
+            )
             output_logger.info('\n[+] API scanning completed successfully.')
 
-        except MissingKey:
+        except MissingKey as error:
+            record_stage_result('action:api-scan', stage_started, error=error)
             output_logger.info('\n[!] API endpoint scanning requires a wordlist. Use -w to specify a wordlist file.')
             output_logger.info('    Creating a basic wordlist and trying again...')
             # The wordlist creation code above could be used here
         except Exception as e:
+            record_stage_result('action:api-scan', stage_started, error=e)
             output_logger.info(f'\n[!] An exception has occurred in API Endpoints scanning: {e}')
             output_logger.info('    Continuing with the rest of the scan...')
             traceback.print_exc()  # More detailed error information for developers
 
-    if 'securityscorecard' in engines:
+    completed_run_result = complete_run(completed_run_result, stage_results)
+    await SQLiteRunStore().save(completed_run_result)
+    output_logger.info(format_run_terminal(completed_run_result))
+
+    if filename != '':
+        output_logger.info('\n[*] Reporting started.')
+        report_base = (
+            os.path.join('theHarvester/app/static', os.path.splitext(rest_filename)[0])
+            if rest_filename
+            else os.path.splitext(filename)[0]
+        )
         try:
-            output_logger.info('\n[*] Performing SecurityScorecard scan...')
-            securityscorecard_scanner = securityscorecard.SearchSecurityScorecard(word)
-            await securityscorecard_scanner.process(use_proxy)
+            xml_filename = report_base + '.xml'
+            async with await anyio.open_file(xml_filename, 'w+') as file:
+                await file.write('<?xml version="1.0" encoding="UTF-8"?><theHarvester>')
+                sanitized_args = [sanitize_for_xml(f'"{arg}"' if ' ' in arg else arg) for arg in sys.argv[1:]]
+                await file.write('<cmd>' + ' '.join(sanitized_args) + '</cmd>')
+                for email in all_emails:
+                    await file.write('<email>' + sanitize_for_xml(email) + '</email>')
+                for value in full:
+                    host, ip = value.split(':', 1) if ':' in value else (value, '')
+                    if ip and len(ip) > 3:
+                        await file.write(
+                            f'<host><ip>{sanitize_for_xml(ip)}</ip><hostname>{sanitize_for_xml(host)}</hostname></host>'
+                        )
+                    else:
+                        await file.write(f'<host>{sanitize_for_xml(host)}</host>')
+                for value in vhost:
+                    host, ip = value.split(':', 1) if ':' in value else (value, '')
+                    if ip and len(ip) > 3:
+                        await file.write(
+                            f'<vhost><ip>{sanitize_for_xml(ip)} </ip><hostname>{sanitize_for_xml(host)}</hostname></vhost>'
+                        )
+                    else:
+                        await file.write(f'<vhost>{sanitize_for_xml(host)}</vhost>')
+                await file.write(evidence_xml_fragment(completed_run_result))
+                await file.write('</theHarvester>')
+            output_logger.info('[*] XML File saved.')
+        except (OSError, ValueError, TypeError, UnicodeEncodeError) as error:
+            output_logger.info(f'[!] An error occurred while saving the XML file: {error}')
 
-            # Use the existing API to get results
-            hosts = await securityscorecard_scanner.get_hostnames()
-            if hosts:
-                output_logger.info(f'\n[*] SecurityScorecard results: {len(hosts)} hosts found')
-                for host in hosts:
-                    output_logger.info(f'    - {host}')
-
-                all_hosts.extend(hosts)
-
-            ips = await securityscorecard_scanner.get_ips()
-            if ips:
-                output_logger.info(f'\n[*] SecurityScorecard IPs found: {len(ips)}')
-                for ip in ips:
-                    output_logger.info(f'    - {ip}')
-                all_ip.extend(ips)
-
-        except Exception as e:
-            output_logger.info(f'An exception has occurred in SecurityScorecard scanning: {e}')
-
-    if 'builtwith' in engines:
         try:
-            output_logger.info('\n[*] Performing BuiltWith scan...')
-            builtwith_scanner = builtwith.SearchBuiltWith(word)
-            await builtwith_scanner.process(use_proxy)
-
-            hosts = await builtwith_scanner.get_hostnames()
-            if hosts:
-                output_logger.info(f'\n[*] BuiltWith results: {len(hosts)} hosts found')
-                for host in hosts:
-                    output_logger.info(f'    - {host}')
-
-                # Add results to the main host list
-                all_hosts.extend(hosts)
-
-            urls = list(await builtwith_scanner.get_interesting_urls())
-            if urls:
-                output_logger.info(f'\n[*] BuiltWith interesting URLs found: {len(urls)}')
-                for url in urls:
-                    output_logger.info(f'    - {url}')
-                interesting_urls.extend(urls)
-
-        except Exception as e:
-            if isinstance(e, MissingKey):
-                if not args.quiet:
-                    output_logger.info(MissingKey('BuiltWith'))
-                else:
-                    output_logger.info(f'An exception has occurred in BuiltWith scanning: {e}')
+            json_dict: dict[str, object] = {
+                'cmd': ' '.join(f'"{arg}"' if ' ' in arg else arg for arg in sys.argv[1:]),
+                'hosts': (full if dnsresolve is None or (final_dns_resolver_list and full) else all_hosts),
+                'shodan': shodanres,
+            }
+            optional_results = {
+                'ips': ip_list if 'ip_list' in locals() else all_ip,
+                'emails': all_emails,
+                'vhosts': vhost,
+                'interesting_urls': interesting_urls,
+                'trello_urls': all_urls,
+                'asns': total_asns,
+                'twitter_people': twitter_people_list_tracker,
+                'linkedin_people': linkedin_people_list_tracker,
+                'linkedin_links': linkedin_links_tracker,
+                'people': all_people,
+                'takeover_results': takeover_results if takeover_status else {},
+            }
+            json_dict.update({key: value for key, value in optional_results.items() if value})
+            json_dict = legacy_json_result(completed_run_result, json_dict)
+            async with await anyio.open_file(report_base + '.json', 'w+') as file:
+                await file.write(ujson.dumps(json_dict, sort_keys=True))
+            output_logger.info('[*] JSON File saved.')
+            async with await anyio.open_file(report_base + '.jsonl', 'w+') as file:
+                await file.write(run_result_jsonl(completed_run_result) + '\n')
+            output_logger.info('[*] JSONL File saved.')
+        except (OSError, ValueError, TypeError, UnicodeEncodeError) as error:
+            output_logger.info(f'[!] An error occurred while saving the JSON files: {error}')
+        output_logger.info('\n\n')
 
     if rest_args is not None:
         all_hosts = sorted({host.replace('www.', '') for host in all_hosts})
-        return (
+        response = (
             total_asns,
             interesting_urls,
             twitter_people_list_tracker,
@@ -1936,6 +1948,9 @@ async def start(rest_args: argparse.Namespace | None = None):
             all_emails,
             all_hosts,
         )
+        if not rest_args.source and rest_args.dns_brute and not return_evidence_run:
+            return resolved_pair
+        return (*response, completed_run_result) if return_evidence_run else response
     sys.exit(0)
 
 

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -17,6 +17,7 @@ from starlette.staticfiles import StaticFiles
 
 from theHarvester import __main__
 from theHarvester.lib.api.additional_endpoints import router as additional_router
+from theHarvester.lib.output import legacy_json_result
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +48,7 @@ class QueryResponse(BaseModel):
     ips: list[str] = Field(default_factory=list, description='List of IPs')
     emails: list[str] = Field(default_factory=list, description='List of emails')
     hosts: list[str] = Field(default_factory=list, description='List of hosts')
+    evidence_run: dict[str, Any] | None = Field(None, description='Completed evidence run summary')
 
 
 class ErrorResponse(BaseModel):
@@ -340,6 +342,7 @@ async def query(
             aips,
             aemails,
             ahosts,
+            evidence_run,
         ) = await __main__.start(
             argparse.Namespace(
                 dns_brute=dns_brute,
@@ -358,23 +361,23 @@ async def query(
                 dns_resolve=dns_resolve,
                 quiet=False,
                 screenshot='',
-            )
+            ),
+            return_evidence_run=True,
         )
 
         # Return the results using the Pydantic model
-        return JSONResponse(
-            {
-                'asns': asns,
-                'interesting_urls': iurls,
-                'twitter_people': twitter_people_list,
-                'linkedin_people': linkedin_people_list,
-                'linkedin_links': linkedin_links,
-                'trello_urls': aurls,
-                'ips': aips,
-                'emails': aemails,
-                'hosts': ahosts,
-            }
-        )
+        response_data = {
+            'asns': asns,
+            'interesting_urls': iurls,
+            'twitter_people': twitter_people_list,
+            'linkedin_people': linkedin_people_list,
+            'linkedin_links': linkedin_links,
+            'trello_urls': aurls,
+            'ips': aips,
+            'emails': aemails,
+            'hosts': ahosts,
+        }
+        return JSONResponse(legacy_json_result(evidence_run, response_data))
     except HTTPException as e:
         # Re-raise HTTP exceptions
         raise e


### PR DESCRIPTION
## Summary

- connect CLI collection and every selected post-source stage to RunResult completion
- adapt REST responses and structured persistence from the completed result
- report only after DNS, takeover, Shodan, screenshot, and API stages finish when selected

## Operator impact

Terminal and file output describe the run that actually finished, including its effective options, instead of reporting before later stages have contributed results.

## Stack

Layer 7 of 10. Base: feature/completed-output-adapters.

Fork tracking: https://github.com/NotoriousRebel/theHarvester/issues/63

## Verification

Integration tests cover stage ordering, REST adaptation, compatibility output, and persistence. The complete stack passed all required checks and both reviews.