### PR TITLE
fix: preserve completed run evidence across stages

### DIFF
--- a/tests/discovery/test_crtsh.py
+++ b/tests/discovery/test_crtsh.py
@@ -60,6 +60,15 @@ class TestCrtshSearch:
         assert set(await search.get_hostnames()) == {'a.example.com', 'b.example.com'}
 
     @pytest.mark.asyncio
+    async def test_multiline_wildcard_prefix_is_stripped(self, monkeypatch):
+        _patch_fetch(monkeypatch, [{'name_value': 'a.example.com\n*.b.example.com'}])
+        search = crtsh.SearchCrtsh('example.com')
+
+        await search.process()
+
+        assert set(await search.get_hostnames()) == {'a.example.com', 'b.example.com'}
+
+    @pytest.mark.asyncio
     async def test_numeric_prefixed_entries_are_filtered(self, monkeypatch):
         _patch_fetch(monkeypatch, [{'name_value': '1234.example.com'}, {'name_value': 'good.example.com'}])
         search = crtsh.SearchCrtsh('example.com')

--- a/tests/discovery/test_crtsh.py
+++ b/tests/discovery/test_crtsh.py
@@ -3,6 +3,7 @@ import asyncio
 import pytest
 
 from theHarvester.discovery import crtsh
+from theHarvester.lib.run import SourceIncompleteError
 
 
 def _patch_fetch(monkeypatch, payload):
@@ -100,15 +101,28 @@ class TestCrtshSearch:
         assert await search.get_hostnames() == ['api.example.com']
 
     @pytest.mark.asyncio
-    async def test_missing_name_value_key_is_handled(self, monkeypatch):
+    async def test_invalid_responses_report_failure(self, monkeypatch):
+        fetches = _patch_fetch(monkeypatch, '')
+        delays = _patch_sleep(monkeypatch)
+        search = crtsh.SearchCrtsh('example.com')
+
+        with pytest.raises(SourceIncompleteError):
+            await search.process()
+
+        assert len(fetches) == 3
+        assert delays == [2, 2]
+
+    @pytest.mark.asyncio
+    async def test_missing_name_value_key_reports_failure(self, monkeypatch):
         fetches = _patch_fetch(monkeypatch, [{'issuer_ca_id': 1}])
         delays = _patch_sleep(monkeypatch)
         search = crtsh.SearchCrtsh('example.com')
-        await search.process()
+
+        with pytest.raises(SourceIncompleteError):
+            await search.process()
 
         assert len(fetches) == 1
         assert delays == []
-        assert await search.get_hostnames() == []
 
 
 class TestCrtshIntegration:

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
@@ -73,6 +74,8 @@ async def test_completed_run_serializes_status_and_meaningful_timestamps() -> No
 @pytest.mark.asyncio
 async def test_complete_run_merges_late_and_direct_stage_results() -> None:
     result = await execute_run('example.com', (CompletedRunSource(),))
+    dns_completed_at = datetime(2026, 7, 15, 13, tzinfo=UTC)
+    direct_completed_at = datetime(2026, 7, 15, 14, tzinfo=UTC)
 
     completed = complete_run(
         result,
@@ -83,6 +86,8 @@ async def test_complete_run_merges_late_and_direct_stage_results() -> None:
                 1,
                 1,
                 (StageFinding(StageFindingKind.HOSTNAME, 'late.example.com:192.0.2.11'),),
+                is_action=True,
+                completed_at=dns_completed_at,
             ),
             StageResult(
                 'action:take-over',
@@ -90,6 +95,8 @@ async def test_complete_run_merges_late_and_direct_stage_results() -> None:
                 1,
                 1,
                 (StageFinding(StageFindingKind.TAKEOVER, 'api.example.com', 'not vulnerable'),),
+                is_action=True,
+                completed_at=direct_completed_at,
             ),
         ),
     )
@@ -102,11 +109,13 @@ async def test_complete_run_merges_late_and_direct_stage_results() -> None:
     assert {(item.kind, item.value, item.detail) for item in completed.selected_observations} == {
         (StageFindingKind.TAKEOVER, 'api.example.com', 'not vulnerable')
     }
-    assert {execution.source for execution in completed.source_executions} == {
-        'fixture',
+    assert {execution.source for execution in completed.source_executions} == {'fixture'}
+    assert {execution.stage for execution in completed.stage_executions} == {
         'action:dns-brute',
         'action:take-over',
     }
+    assert next(item for item in completed.observations if item.value == 'late.example.com').collected_at == dns_completed_at
+    assert completed.selected_observations[0].collected_at == direct_completed_at
 
 
 class TerminalRunSource:
@@ -145,6 +154,7 @@ async def test_terminal_reports_each_hostname_once_with_status_and_sources() -> 
                 1,
                 1,
                 (StageFinding(StageFindingKind.TAKEOVER, 'api.example.com', 'not vulnerable'),),
+                is_action=True,
             ),
         ),
     )
@@ -157,7 +167,42 @@ async def test_terminal_reports_each_hostname_once_with_status_and_sources() -> 
     assert 'Secondary evidence / needs review (2)' in terminal
     assert 'Scope-extension candidates (1)' in terminal
     assert 'status=currently-addressable; sources=fixture; takeover=not vulnerable' in terminal
+    assert 'related.example.net [status=scope-extension-candidate; sources=fixture]' in terminal
+    assert 'cdn.vendor.test [status=external-relationship; sources=fixture]' in terminal
+    assert 'status=None' not in terminal
     assert 'Run status: complete' in terminal
+
+
+@pytest.mark.asyncio
+async def test_terminal_keeps_recognizable_non_host_sections() -> None:
+    result = await execute_run('example.com', (CompletedRunSource(),))
+    result = complete_run(
+        result,
+        (
+            StageResult(
+                'fixture',
+                SourceStatus.SUCCEEDED,
+                1,
+                5,
+                (
+                    StageFinding(StageFindingKind.EMAIL, 'ops@example.com'),
+                    StageFinding(StageFindingKind.IP_ADDRESS, '192.0.2.10'),
+                    StageFinding(StageFindingKind.ASN, 'AS64500'),
+                    StageFinding(StageFindingKind.PERSON, 'Alice'),
+                    StageFinding(StageFindingKind.INTERESTING_URL, 'https://example.com/status'),
+                ),
+            ),
+        ),
+    )
+
+    terminal = format_run_terminal(result)
+
+    assert '[*] Emails found: 1' in terminal
+    assert '[*] IPs found: 1' in terminal
+    assert '[*] ASNS found: 1' in terminal
+    assert '[*] People found: 1' in terminal
+    assert '[*] Interesting Urls found: 1' in terminal
+    assert 'ops@example.com [status=observed; sources=fixture]' in terminal
 
 
 @pytest.mark.asyncio
@@ -190,7 +235,7 @@ async def test_jsonl_preserves_typed_records_provenance_and_timestamps() -> None
 @pytest.mark.asyncio
 async def test_legacy_json_and_xml_keep_existing_fields_and_add_evidence() -> None:
     validator = DnsValidator(tuple(TerminalResolver(f'resolver-{index}') for index in range(3)))
-    result = await execute_run('example.com', (CompletedRunSource(),), dns_validator=validator)
+    result = await execute_run('example.com', (TerminalRunSource(),), dns_validator=validator)
 
     legacy = legacy_json_result(
         result,
@@ -206,9 +251,21 @@ async def test_legacy_json_and_xml_keep_existing_fields_and_add_evidence() -> No
     assert legacy['emails'] == ['ops@example.com']
     assert legacy['hosts'] == ['legacy.example.com', 'api.example.com']
     assert legacy['evidence_run']['status'] == 'complete'
+    assert {item['value'] for item in legacy['evidence_run']['merged_results']} == {
+        'api.example.com',
+        'old.example.com',
+        'related.example.net',
+        'cdn.vendor.test',
+    }
     assert evidence_xml.tag == 'evidence_run'
     assert evidence_xml.attrib['status'] == 'complete'
     assert evidence_xml.find("source[@name='fixture']").attrib['status'] == 'succeeded'
+    assert {item.attrib['value'] for item in evidence_xml.findall('merged_result')} == {
+        'api.example.com',
+        'old.example.com',
+        'related.example.net',
+        'cdn.vendor.test',
+    }
 
 
 @pytest.mark.asyncio
@@ -229,6 +286,7 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
     import theHarvester.__main__ as main_module
 
     events: list[str] = []
+    terminal_messages: list[str] = []
     wordlist = tmp_path / 'api-endpoints.txt'
     wordlist.write_text('/v1/status\n')
     report = tmp_path / 'completed-run'
@@ -266,9 +324,19 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
             return None
 
         async def check(self):
-            return ['api.example.com:192.0.2.10'], ['api.example.com'], ['192.0.2.10']
+            return (
+                [
+                    'api.example.com:192.0.2.10',
+                    'api.example.com:198.51.100.10',
+                ],
+                ['api.example.com'],
+                ['192.0.2.10', '198.51.100.10'],
+            )
 
-    async def fake_reverse_all_ips_in_range(**_kwargs) -> None:
+    async def fake_reverse_all_ips_in_range(*, iprange: str, **_kwargs) -> None:
+        if iprange.startswith('192.0.2.10'):
+            raise RuntimeError('one reverse range failed')
+        await asyncio.sleep(0.05)
         events.append('dns-lookup')
 
     class FakeTakeOver:
@@ -285,6 +353,41 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
         async def get_takeover_results(self) -> dict[str, str]:
             return {'api.example.com': 'not vulnerable'}
 
+    class FakePool:
+        def __init__(self, _workers: int) -> None:
+            return None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args) -> None:
+            return None
+
+        async def map(self, function, items):
+            return [await function(item) for item in items]
+
+    class FailedScreenShotter:
+        output = 'screenshots'
+        slash = '/'
+
+        def __init__(self, _output: str) -> None:
+            return None
+
+        def verify_path(self) -> bool:
+            return True
+
+        async def verify_installation(self) -> None:
+            return None
+
+        async def visit(self, host: str):
+            return host, ('https',)
+
+        def chunk_list(self, hosts: list[str], _chunk_size: int):
+            return (hosts,)
+
+        async def take_screenshot(self, _host: str) -> None:
+            raise RuntimeError('screenshot capture failed')
+
     class FakeApiScanner:
         def __init__(self, *_args, **_kwargs) -> None:
             return None
@@ -296,22 +399,31 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
             return {'https://example.com/v1/status': SimpleNamespace(status_code=200)}
 
         def get_interesting_endpoints(self):
-            return {}
+            return {'https://example.com/v1/interesting': SimpleNamespace(status_code=200)}
 
         def get_auth_required(self):
-            return {}
+            return {'https://example.com/v1/private': SimpleNamespace(status_code=401)}
 
         def get_api_versions(self):
-            return set()
+            return {'v1'}
 
         def get_rate_limits(self):
-            return {}
+            return {'https://example.com/v1/limited': SimpleNamespace(method='GET')}
 
         def get_methods(self):
             return {'GET'}
 
         def get_status_codes(self):
-            return {200}
+            return {200, 401, 429}
+
+    class FakeShodanSearch:
+        async def search_ip(self, ip: str):
+            if ip == '198.51.100.10':
+                return {ip: 'provider failed'}
+            return {ip: {'product': 'raw-provider-secret'}}
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
 
     class FakeRunStore:
         saved: ClassVar[list] = []
@@ -324,16 +436,28 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
         events.append('terminal')
         return format_run_terminal(result)
 
+    def capture_output(message: object, *_args, **_kwargs) -> None:
+        terminal_messages.append(str(message))
+
     monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
     monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
     monkeypatch.setattr(main_module.hostchecker, 'Checker', FakeHostChecker)
     monkeypatch.setattr(main_module.dnssearch, 'DnsForce', FakeDnsForce)
-    monkeypatch.setattr(main_module.dnssearch, 'serialize_ip_range', lambda **_kwargs: '192.0.2.0/24')
+    monkeypatch.setattr(
+        main_module.dnssearch,
+        'serialize_ip_range',
+        lambda *, ip, **_kwargs: f'{ip}/24',
+    )
     monkeypatch.setattr(main_module.dnssearch, 'reverse_all_ips_in_range', fake_reverse_all_ips_in_range)
     monkeypatch.setattr(main_module.takeover, 'TakeOver', FakeTakeOver)
+    monkeypatch.setattr(main_module, 'ScreenShotter', FailedScreenShotter)
+    monkeypatch.setattr(main_module, 'Pool', FakePool)
     monkeypatch.setattr(main_module.api_endpoints, 'SearchApiEndpoints', FakeApiScanner)
+    monkeypatch.setattr(main_module.shodansearch, 'SearchShodan', FakeShodanSearch)
+    monkeypatch.setattr(main_module.asyncio, 'sleep', no_sleep)
     monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore, raising=False)
     monkeypatch.setattr(main_module, 'format_run_terminal', capture_terminal, raising=False)
+    monkeypatch.setattr(main_module.output_logger, 'info', capture_output)
 
     response = await main_module.start(
         SimpleNamespace(
@@ -347,8 +471,8 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
             limit=500,
             proxies=False,
             quiet=False,
-            screenshot='',
-            shodan=False,
+            screenshot='screenshots',
+            shodan=True,
             source='crtsh',
             start=0,
             take_over=True,
@@ -358,19 +482,72 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
     )
 
     result = response[-1]
+    terminal = '\n'.join(terminal_messages)
     assert events == ['collect', 'dns-brute', 'dns-lookup', 'takeover', 'api-scan', 'persist', 'terminal']
     assert result is FakeRunStore.saved[0]
+    assert next(item for item in result.stage_executions if item.stage == 'action:screenshot').status is SourceStatus.FAILED
     assert {entity.value for entity in result.entities} == {'api.example.com', 'late.example.com'}
     assert {(item.kind, item.value) for item in result.selected_observations} == {
         (StageFindingKind.TAKEOVER, 'api.example.com'),
         (StageFindingKind.API_ENDPOINT, 'https://example.com/v1/status'),
+        (StageFindingKind.INTERESTING_URL, 'https://example.com/v1/interesting'),
+        (StageFindingKind.API_AUTH_REQUIRED, 'https://example.com/v1/private'),
+        (StageFindingKind.API_VERSION, 'v1'),
+        (StageFindingKind.API_RATE_LIMIT, 'https://example.com/v1/limited'),
+        (StageFindingKind.HTTP_METHOD, 'GET'),
+        (StageFindingKind.HTTP_STATUS_CODE, '200'),
+        (StageFindingKind.HTTP_STATUS_CODE, '401'),
+        (StageFindingKind.HTTP_STATUS_CODE, '429'),
+        (StageFindingKind.SHODAN_RESULT, '192.0.2.10'),
     }
+    assert next(item for item in result.stage_executions if item.stage == 'action:shodan').status is SourceStatus.FAILED
     legacy_json = json.loads(report.with_suffix('.json').read_text())
     evidence_xml = ElementTree.parse(report.with_suffix('.xml')).getroot().find('evidence_run')
     jsonl = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
     assert legacy_json['evidence_run']['run_id'] == result.run_id
     assert evidence_xml.attrib['run_id'] == result.run_id
-    assert {record['record_type'] for record in jsonl} >= {'run', 'selected_observation'}
+    assert {record['record_type'] for record in jsonl} >= {'run', 'stage_execution', 'selected_observation'}
+    assert terminal.count('https://example.com/v1/status') == 1
+    assert 'raw-provider-secret' not in terminal
+    assert '[*] Interesting Urls found: 1' in terminal
+    assert '[*] Endpoints requiring authentication: 1' in terminal
+    assert '[*] Detected API versions: 1' in terminal
+    assert '[*] Rate limited endpoints: 1' in terminal
+    assert '[*] HTTP methods used: 1' in terminal
+    assert '[*] HTTP status codes encountered: 3' in terminal
+
+    from theHarvester.lib.api import api
+
+    async def completed_start(_args, *, return_evidence_run: bool = False):
+        assert return_evidence_run is True
+        return (
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            ['api.example.com', 'late.example.com'],
+            result,
+        )
+
+    monkeypatch.setattr(api.__main__, 'start', completed_start)
+    monkeypatch.setattr(api.__main__.Core, 'get_supportedengines', lambda: ['fixture'])
+
+    rest_response = TestClient(api.app).get('/query?domain=example.com&source=fixture')
+
+    assert rest_response.status_code == 200
+    assert rest_response.json()['evidence_run']['run_id'] == result.run_id
+    assert {item['value'] for item in rest_response.json()['evidence_run']['merged_results']} == {
+        'api.example.com',
+        'late.example.com',
+    }
+    assert {(item['kind'], item['value']) for item in rest_response.json()['evidence_run']['selected_observations']} >= {
+        ('takeover', 'api.example.com'),
+        ('api-endpoint', 'https://example.com/v1/status'),
+    }
 
 
 @pytest.mark.asyncio
@@ -491,12 +668,65 @@ async def test_cli_preserves_the_actual_provider_failure(monkeypatch: pytest.Mon
     assert execution.error_type == 'RuntimeError'
 
 
+@pytest.mark.asyncio
+async def test_cli_preserves_shodan_provider_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    import socket
+
+    import theHarvester.__main__ as main_module
+
+    class FailedShodanSearch:
+        async def search_ip(self, _ip: str):
+            raise RuntimeError('provider failed')
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args) -> None:
+            return None
+
+    class FakeRunStore:
+        async def save(self, _result) -> None:
+            return None
+
+    monkeypatch.setattr(socket, 'gethostbyname', lambda _domain: '192.0.2.10')
+    monkeypatch.setattr(main_module.shodansearch, 'SearchShodan', FailedShodanSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore)
+
+    response = await main_module.start(
+        SimpleNamespace(
+            api_scan=False,
+            dns_brute=False,
+            dns_lookup=False,
+            dns_resolve='',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=500,
+            proxies=False,
+            quiet=False,
+            screenshot='',
+            shodan=False,
+            source='shodan',
+            start=0,
+            take_over=False,
+            wordlist='',
+        ),
+        return_evidence_run=True,
+    )
+
+    execution = response[-1].source_executions[0]
+    assert execution.status is SourceStatus.FAILED
+    assert execution.error_type == 'RuntimeError'
+
+
 def test_rest_query_keeps_legacy_fields_and_adds_the_completed_run(monkeypatch: pytest.MonkeyPatch) -> None:
     import asyncio
 
     from theHarvester.lib.api import api
 
-    result = asyncio.run(execute_run('example.com', (CompletedRunSource(),)))
+    result = asyncio.run(execute_run('example.com', (TerminalRunSource(),)))
 
     async def fake_start(_args, *, return_evidence_run: bool = False):
         assert return_evidence_run is True
@@ -522,6 +752,46 @@ def test_rest_query_keeps_legacy_fields_and_adds_the_completed_run(monkeypatch: 
     assert response.json()['emails'] == ['ops@example.com']
     assert response.json()['hosts'] == ['api.example.com', 'old.example.com']
     assert response.json()['evidence_run']['run_id'] == result.run_id
+    assert {item['value'] for item in response.json()['evidence_run']['merged_results']} == {
+        'api.example.com',
+        'old.example.com',
+        'related.example.net',
+        'cdn.vendor.test',
+    }
+
+
+def test_rest_dnsbrute_keeps_legacy_results_and_failed_stage_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    import asyncio
+
+    from theHarvester.lib.api import api
+
+    result = asyncio.run(execute_run('example.com', ()))
+    result = complete_run(
+        result,
+        (
+            StageResult(
+                'action:dns-brute',
+                SourceStatus.FAILED,
+                1,
+                0,
+                error_type='RuntimeError',
+                is_action=True,
+            ),
+        ),
+    )
+
+    async def fake_start(_args, *, return_evidence_run: bool = False):
+        assert return_evidence_run is True
+        return [], result
+
+    monkeypatch.setattr(api.__main__, 'start', fake_start)
+
+    response = TestClient(api.app).get('/dnsbrute?domain=example.com')
+
+    assert response.status_code == 200
+    assert response.json()['dns_bruteforce'] == []
+    assert response.json()['evidence_run']['status'] == 'failed'
+    assert response.json()['evidence_run']['stage_executions'][0]['status'] == 'failed'
 
 
 @pytest.mark.parametrize(

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -551,6 +551,97 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
 
 
 @pytest.mark.asyncio
+async def test_cli_dns_validates_legacy_source_before_reporting(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    import theHarvester.__main__ as main_module
+
+    candidate = 'www.example.com'
+    report = tmp_path / 'legacy-source'
+
+    class FakeCertSpotter:
+        def __init__(self, target: str) -> None:
+            assert target == 'example.com'
+
+        async def process(self, _proxy: bool = False) -> None:
+            return None
+
+        async def get_hostnames(self) -> list[str]:
+            return [candidate]
+
+    class FakeVantage:
+        def __init__(self, nameserver: str) -> None:
+            self.name = nameserver
+
+        async def query(self, hostname: str) -> DnsResponse:
+            return DnsResponse(ipv4=('192.0.2.10',)) if hostname == candidate else DnsResponse(rcode='NXDOMAIN')
+
+        async def close(self) -> None:
+            return None
+
+    class FakeHostChecker:
+        def __init__(self, *_args: object) -> None:
+            raise AssertionError('consensus validation must replace the legacy resolver path')
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args: object) -> None:
+            return None
+
+        async def store(self, *_args: object) -> None:
+            return None
+
+    class FakeRunStore:
+        saved: ClassVar[list] = []
+
+        async def save(self, result) -> None:
+            self.saved.append(result)
+
+    terminal_messages: list[str] = []
+    monkeypatch.setattr(main_module.certspottersearch, 'SearchCertspoter', FakeCertSpotter)
+    monkeypatch.setattr(main_module, 'AioDnsResolverVantage', FakeVantage, raising=False)
+    monkeypatch.setattr(main_module.hostchecker, 'Checker', FakeHostChecker)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore, raising=False)
+    monkeypatch.setattr(main_module.output_logger, 'info', lambda message, *_args: terminal_messages.append(str(message)))
+
+    monkeypatch.setattr(
+        main_module.sys,
+        'argv',
+        [
+            'theHarvester',
+            '-d',
+            'example.com',
+            '-b',
+            'certspotter',
+            '-r',
+            '192.0.2.53,192.0.2.54,192.0.2.55',
+            '-f',
+            str(report),
+            '-q',
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await main_module.start()
+
+    assert exit_info.value.code == 0
+    result = FakeRunStore.saved[0]
+    legacy_json = json.loads(report.with_suffix('.json').read_text())
+    evidence_xml = ElementTree.parse(report.with_suffix('.xml')).getroot().find('evidence_run')
+
+    assert len(result.dns_validations) == 12
+    assert result.entities[0].addressability == 'currently-addressable'
+    assert legacy_json['hosts'] == [f'{candidate}:192.0.2.10']
+    assert [item.attrib['value'] for item in evidence_xml.findall('merged_result')] == [candidate]
+    assert '\n'.join(terminal_messages).count(f'{candidate} [status=currently-addressable') == 1
+    assert FakeRunStore.saved == [result]
+
+
+@pytest.mark.asyncio
 async def test_cli_records_provider_people_in_the_completed_run(monkeypatch: pytest.MonkeyPatch) -> None:
     import theHarvester.__main__ as main_module
 

--- a/tests/lib/test_hostchecker.py
+++ b/tests/lib/test_hostchecker.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+
+import pytest
+
+from theHarvester.lib import hostchecker
+
+
+@pytest.mark.asyncio
+async def test_checker_normalizes_byte_addresses(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResolver:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        async def getaddrinfo(self, _host: str, _family: int) -> SimpleNamespace:
+            return SimpleNamespace(nodes=[SimpleNamespace(addr=(b'192.0.2.10', 0))])
+
+    monkeypatch.setattr(hostchecker.aiodns, 'DNSResolver', FakeResolver)
+
+    resolved, hosts, addresses = await hostchecker.Checker(
+        ['www.example.com'],
+        ['192.0.2.53'],
+    ).check()
+
+    assert resolved == ['www.example.com:192.0.2.10']
+    assert hosts == ['www.example.com']
+    assert addresses == ['192.0.2.10']

--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -376,17 +376,15 @@ async def test_crtsh_bridge_uses_three_resolvers_without_legacy_requery(
     captured: list[run_module.RunResult] = []
     output: list[object] = []
 
-    async def capture_run(target, sources, **kwargs):
-        result = await run_module.execute_run(target, sources, **kwargs)
-        captured.append(result)
-        return result
+    class CaptureRunStore:
+        async def save(self, result: run_module.RunResult) -> None:
+            captured.append(result)
 
     monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
     monkeypatch.setattr(main_module, 'AioDnsResolverVantage', FakeVantage, raising=False)
     monkeypatch.setattr(main_module.hostchecker, 'Checker', FailOnLegacyChecker)
     monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
-    monkeypatch.setattr(main_module, 'SQLiteRunStore', NoopRunStore)
-    monkeypatch.setattr(main_module, 'execute_run', capture_run, raising=True)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', CaptureRunStore)
     monkeypatch.setattr(main_module.output_logger, 'info', output.append)
 
     monkeypatch.setattr(

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -573,11 +573,11 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 resolver_stack.push_async_callback(vantage.close)
             return await validate_run(result, DnsValidator(tuple(vantages)))
 
-    async def finish_run(
+    async def merge_validate_and_adapt_run(
         result: RunResult,
-        results: list[StageResult],
+        new_stage_results: list[StageResult],
     ) -> tuple[RunResult, tuple[list[str], list[str], list[str]] | None]:
-        result = await validate_completed_run(complete_run(result, results))
+        result = await validate_completed_run(complete_run(result, new_stage_results))
         return result, legacy_dns_results(result) if result.dns_validations else None
 
     if args.source is not None:
@@ -1501,7 +1501,7 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 )
             )
     provider_stage_count = len(stage_results)
-    completed_run_result, legacy_results = await finish_run(completed_run_result, stage_results)
+    completed_run_result, legacy_results = await merge_validate_and_adapt_run(completed_run_result, stage_results)
     if legacy_results is not None:
         full, all_hosts, validated_ips = legacy_results
         all_ip.extend(validated_ips)
@@ -1884,7 +1884,7 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
             output_logger.info('    Continuing with the rest of the scan...')
             traceback.print_exc()  # More detailed error information for developers
 
-    completed_run_result, legacy_results = await finish_run(
+    completed_run_result, legacy_results = await merge_validate_and_adapt_run(
         completed_run_result,
         stage_results[provider_stage_count:],
     )

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -573,6 +573,13 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 resolver_stack.push_async_callback(vantage.close)
             return await validate_run(result, DnsValidator(tuple(vantages)))
 
+    async def finish_run(
+        result: RunResult,
+        results: list[StageResult],
+    ) -> tuple[RunResult, tuple[list[str], list[str], list[str]] | None]:
+        result = await validate_completed_run(complete_run(result, results))
+        return result, legacy_dns_results(result) if result.dns_validations else None
+
     if args.source is not None:
         engines = Core.expand_source_selection(args.source)
         # Iterate through search engines in order
@@ -1494,10 +1501,9 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 )
             )
     provider_stage_count = len(stage_results)
-    completed_run_result = complete_run(completed_run_result, stage_results)
-    completed_run_result = await validate_completed_run(completed_run_result)
-    if completed_run_result.dns_validations:
-        full, all_hosts, validated_ips = legacy_dns_results(completed_run_result)
+    completed_run_result, legacy_results = await finish_run(completed_run_result, stage_results)
+    if legacy_results is not None:
+        full, all_hosts, validated_ips = legacy_results
         all_ip.extend(validated_ips)
     total_asns = sorted_unique(total_asns)
     interesting_urls = sorted_unique(interesting_urls)
@@ -1878,10 +1884,12 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
             output_logger.info('    Continuing with the rest of the scan...')
             traceback.print_exc()  # More detailed error information for developers
 
-    completed_run_result = complete_run(completed_run_result, stage_results[provider_stage_count:])
-    completed_run_result = await validate_completed_run(completed_run_result)
-    if completed_run_result.dns_validations:
-        full, all_hosts, validated_ips = legacy_dns_results(completed_run_result)
+    completed_run_result, legacy_results = await finish_run(
+        completed_run_result,
+        stage_results[provider_stage_count:],
+    )
+    if legacy_results is not None:
+        full, all_hosts, validated_ips = legacy_results
         all_ip.extend(validated_ips)
         ip_list = sorted(set([*ip_list, *validated_ips]))
     await SQLiteRunStore().save(completed_run_result)

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -370,22 +370,32 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
         started: float,
         findings: list[StageFinding] | tuple[StageFinding, ...] = (),
         error: Exception | None = None,
+        *,
+        source_family: str | None = None,
+        execution: Any | None = None,
+        is_action: bool = True,
     ) -> None:
         unique_findings = tuple(dict.fromkeys(findings))
         stage_results.append(
             StageResult(
                 source=source,
                 status=(
-                    SourceStatus.FAILED
+                    execution.status
+                    if execution is not None
+                    else SourceStatus.FAILED
                     if error is not None
                     else SourceStatus.SUCCEEDED
                     if unique_findings
                     else SourceStatus.EMPTY
                 ),
                 duration_ms=(time.perf_counter() - started) * 1000,
-                result_count=len(findings),
+                result_count=execution.result_count if execution is not None else len(findings),
                 findings=unique_findings,
-                error_type=type(error).__name__ if error is not None else None,
+                source_family=source_family,
+                error_type=(
+                    execution.error_type if execution is not None else type(error).__name__ if error is not None else None
+                ),
+                is_action=is_action,
             )
         )
 
@@ -524,24 +534,14 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 raise
             finally:
                 source_spec = get_source_spec(source)
-                stage_results.append(
-                    StageResult(
-                        source=source_spec.name,
-                        source_family=source_spec.family,
-                        status=(
-                            execution.status
-                            if execution is not None
-                            else SourceStatus.FAILED
-                            if error is not None
-                            else SourceStatus.SUCCEEDED
-                            if findings
-                            else SourceStatus.EMPTY
-                        ),
-                        duration_ms=(time.perf_counter() - started) * 1000,
-                        result_count=execution.result_count if execution is not None else len(findings),
-                        findings=tuple(dict.fromkeys(findings)),
-                        error_type=execution.error_type if execution is not None else type(error).__name__ if error else None,
-                    )
+                record_stage_result(
+                    source_spec.name,
+                    started,
+                    findings,
+                    error,
+                    source_family=source_spec.family,
+                    execution=execution,
+                    is_action=False,
                 )
 
         return run_stage()
@@ -1199,8 +1199,10 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                                         output_logger.info(f'Found Shodan data for {ip}')
                                     elif ip in result and isinstance(result[ip], str):
                                         output_logger.info(f'{ip}: {result[ip]}')
+                                        raise RuntimeError(result[ip])
                                 except Exception as e:
                                     output_logger.info(f'Error in Shodan search: {e}')
+                                    raise
 
                             async def get_hostnames(self):
                                 return list(self.hosts)
@@ -1604,16 +1606,19 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 # nameservers=list(map(str, dnsserver.split(','))) if dnsserver else None))
 
         # run all the reversing tasks concurrently
-        try:
-            await asyncio.gather(*__reverse_dns_tasks.values())
-            record_stage_result(
-                'action:dns-lookup',
-                stage_started,
-                [StageFinding(StageFindingKind.HOSTNAME, host) for host in dnsrev],
-            )
-        except Exception as error:
-            record_stage_result('action:dns-lookup', stage_started, error=error)
-            output_logger.info(f'[!] Reverse DNS lookup failed: {error}')
+        results = await asyncio.gather(*__reverse_dns_tasks.values(), return_exceptions=True)
+        for result in results:
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+        reverse_error = next((result for result in results if isinstance(result, Exception)), None)
+        record_stage_result(
+            'action:dns-lookup',
+            stage_started,
+            [StageFinding(StageFindingKind.HOSTNAME, host) for host in dnsrev],
+            reverse_error,
+        )
+        if reverse_error is not None:
+            output_logger.info(f'[!] Reverse DNS lookup failed: {reverse_error}')
 
     takeover_results = dict()
     # TakeOver Checking
@@ -1648,50 +1653,61 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
     screenshot_path = getattr(args, 'screenshot', '')
     if len(screenshot_path) > 0:
         stage_started = time.perf_counter()
-        screen_shotter = ScreenShotter(screenshot_path)
-        path_exists = screen_shotter.verify_path()
-        # Verify the path exists, if not create it or if user does not create it skips screenshot
-        if path_exists:
-            await screen_shotter.verify_installation()
-            output_logger.info(f'\nScreenshots can be found in: {screen_shotter.output}{screen_shotter.slash}')
-            start_time = time.perf_counter()
-            output_logger.info('Filtering domains for ones we can reach')
-            if dnsresolve is None or len(final_dns_resolver_list) > 0:
-                unique_resolved_domains = {url.split(':')[0] for url in full if ':' in url and 'www.' not in url}
-            else:
-                # Technically not resolved in this case, which is not ideal
-                # You should always use dns resolve when doing screenshotting
-                output_logger.info('NOTE for future use cases you should only use screenshotting in tandem with DNS resolving')
-                unique_resolved_domains = set(all_hosts)
-            if len(unique_resolved_domains) > 0:
-                # First filter out ones that didn't resolve
-                output_logger.info('Attempting to visit unique resolved domains, this is ACTIVE RECON')
-                async with Pool(10) as pool:
-                    results = await pool.map(screen_shotter.visit, list(unique_resolved_domains))
-                    # Filter out domains that we couldn't connect to
-                    unique_resolved_domains_list = list(sorted({tup[0] for tup in results if len(tup[1]) > 0}))
-                    screenshot_hosts.extend(unique_resolved_domains_list)
-                async with Pool(3) as pool:
-                    output_logger.info(f'Length of unique resolved domains: {len(unique_resolved_domains_list)} chunking now!\n')
-                    # If you have the resources, you could make the function faster by increasing the chunk number
-                    chunk_number = 14
-                    for chunk in screen_shotter.chunk_list(unique_resolved_domains_list, chunk_number):
-                        try:
-                            screenshot_tups.extend(await pool.map(screen_shotter.take_screenshot, chunk))
-                        except Exception as ee:
-                            output_logger.info(f'An exception has occurred while mapping: {ee}')
-            end = time.perf_counter()
-            # There is probably an easier way to do this
-            total = int(end - start_time)
-            mon, sec = divmod(total, 60)
-            hr, mon = divmod(mon, 60)
-            total_time = f'{mon:02d}:{sec:02d}'
-            output_logger.info(f'Finished taking screenshots in {total_time} seconds')
-            output_logger.info('[+] Note there may be leftover chrome processes you may have to kill manually\n')
+        screenshot_error: Exception | None = None
+        try:
+            screen_shotter = ScreenShotter(screenshot_path)
+            path_exists = screen_shotter.verify_path()
+            # Verify the path exists, if not create it or if user does not create it skips screenshot
+            if path_exists:
+                await screen_shotter.verify_installation()
+                output_logger.info(f'\nScreenshots can be found in: {screen_shotter.output}{screen_shotter.slash}')
+                start_time = time.perf_counter()
+                output_logger.info('Filtering domains for ones we can reach')
+                if dnsresolve is None or len(final_dns_resolver_list) > 0:
+                    unique_resolved_domains = {url.split(':')[0] for url in full if ':' in url and 'www.' not in url}
+                else:
+                    # Technically not resolved in this case, which is not ideal
+                    # You should always use dns resolve when doing screenshotting
+                    output_logger.info(
+                        'NOTE for future use cases you should only use screenshotting in tandem with DNS resolving'
+                    )
+                    unique_resolved_domains = set(all_hosts)
+                if len(unique_resolved_domains) > 0:
+                    # First filter out ones that didn't resolve
+                    output_logger.info('Attempting to visit unique resolved domains, this is ACTIVE RECON')
+                    async with Pool(10) as pool:
+                        results = await pool.map(screen_shotter.visit, list(unique_resolved_domains))
+                        # Filter out domains that we couldn't connect to
+                        unique_resolved_domains_list = list(sorted({tup[0] for tup in results if len(tup[1]) > 0}))
+                    async with Pool(3) as pool:
+                        output_logger.info(
+                            f'Length of unique resolved domains: {len(unique_resolved_domains_list)} chunking now!\n'
+                        )
+                        # If you have the resources, you could make the function faster by increasing the chunk number
+                        chunk_number = 14
+                        for chunk in screen_shotter.chunk_list(unique_resolved_domains_list, chunk_number):
+                            try:
+                                screenshot_tups.extend(await pool.map(screen_shotter.take_screenshot, chunk))
+                                screenshot_hosts.extend(chunk)
+                            except Exception as ee:
+                                screenshot_error = ee
+                                output_logger.info(f'An exception has occurred while mapping: {ee}')
+                end = time.perf_counter()
+                # There is probably an easier way to do this
+                total = int(end - start_time)
+                mon, sec = divmod(total, 60)
+                hr, mon = divmod(mon, 60)
+                total_time = f'{mon:02d}:{sec:02d}'
+                output_logger.info(f'Finished taking screenshots in {total_time} seconds')
+                output_logger.info('[+] Note there may be leftover chrome processes you may have to kill manually\n')
+        except Exception as error:
+            screenshot_error = error
+            output_logger.info(f'[!] Screenshot stage failed: {error}')
         record_stage_result(
             'action:screenshot',
             stage_started,
             [StageFinding(StageFindingKind.SCREENSHOT, host) for host in screenshot_hosts],
+            screenshot_error,
         )
 
     # Shodan
@@ -1712,6 +1728,7 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                     # Check if the result is a string (error message)
                     if isinstance(shodandict[ip], str):
                         output_logger.info(f'{ip}: {shodandict[ip]}')
+                        shodan_errors.append(RuntimeError(shodandict[ip]))
                         continue
 
                     # Process the results if it's a dictionary
@@ -1730,8 +1747,6 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                                 ip,
                             )
                         )
-                        output_logger.info(ujson.dumps(shodandict[ip], indent=4, sort_keys=True))
-                        output_logger.info('\n')
                 except Exception as ip_error:
                     shodan_errors.append(ip_error)
                     output_logger.info(f'[SHODAN-error] Error searching {ip}: {ip_error}')
@@ -1790,37 +1805,13 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
             api_scanner = api_endpoints.SearchApiEndpoints(word=args.domain, wordlist=wordlist)
             await api_scanner.do_search()
 
-            # Print results
             endpoints_found = api_scanner.get_found_endpoints()
-            output_logger.info(f'\n[*] API Endpoints found: {len(endpoints_found)}')
-            for endpoint in endpoints_found:
-                output_logger.info(f'    - {endpoint}')
-
             interesting_endpoints = api_scanner.get_interesting_endpoints()
-            output_logger.info(f'\n[*] Interesting endpoints (200, 201, 202): {len(interesting_endpoints)}')
-            for endpoint in interesting_endpoints:
-                output_logger.info(f'    - {endpoint}')
-
             auth_required = api_scanner.get_auth_required()
-            output_logger.info(f'\n[*] Endpoints requiring authentication: {len(auth_required)}')
-            for endpoint in auth_required:
-                output_logger.info(f'    - {endpoint}')
-
             api_versions = api_scanner.get_api_versions()
-            output_logger.info(f'\n[*] Detected API versions: {len(api_versions)}')
-            for version in api_versions:
-                output_logger.info(f'    - {version}')
-
             rate_limits = api_scanner.get_rate_limits()
-            output_logger.info(f'\n[*] Rate limited endpoints: {len(rate_limits)}')
-            for endpoint, info in rate_limits.items():
-                output_logger.info(f'    - {endpoint} ({info.method})')
-
             methods = api_scanner.get_methods()
-            output_logger.info(f'\n[*] HTTP methods used: {", ".join(methods)}')
-
             status_codes = api_scanner.get_status_codes()
-            output_logger.info(f'\n[*] HTTP status codes encountered: {", ".join(map(str, status_codes))}')
 
             # Add results to storage
             db = stash.StashManager()
@@ -1846,8 +1837,25 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 'action:api-scan',
                 stage_started,
                 [
-                    StageFinding(StageFindingKind.API_ENDPOINT, endpoint, str(result.status_code))
-                    for endpoint, result in endpoints_found.items()
+                    *(
+                        StageFinding(StageFindingKind.API_ENDPOINT, endpoint, str(result.status_code))
+                        for endpoint, result in endpoints_found.items()
+                    ),
+                    *(
+                        StageFinding(StageFindingKind.INTERESTING_URL, endpoint, str(result.status_code))
+                        for endpoint, result in interesting_endpoints.items()
+                    ),
+                    *(
+                        StageFinding(StageFindingKind.API_AUTH_REQUIRED, endpoint, str(result.status_code))
+                        for endpoint, result in auth_required.items()
+                    ),
+                    *(StageFinding(StageFindingKind.API_VERSION, version) for version in sorted(api_versions)),
+                    *(
+                        StageFinding(StageFindingKind.API_RATE_LIMIT, endpoint, result.method)
+                        for endpoint, result in rate_limits.items()
+                    ),
+                    *(StageFinding(StageFindingKind.HTTP_METHOD, method) for method in sorted(methods)),
+                    *(StageFinding(StageFindingKind.HTTP_STATUS_CODE, str(status_code)) for status_code in sorted(status_codes)),
                 ],
             )
             output_logger.info('\n[+] API scanning completed successfully.')
@@ -1936,6 +1944,8 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
         output_logger.info('\n\n')
 
     if rest_args is not None:
+        if not rest_args.source and rest_args.dns_brute:
+            return (resolved_pair, completed_run_result) if return_evidence_run else resolved_pair
         all_hosts = sorted({host.replace('www.', '') for host in all_hosts})
         response = (
             total_asns,
@@ -1948,8 +1958,6 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
             all_emails,
             all_hosts,
         )
-        if not rest_args.source and rest_args.dns_brute and not return_evidence_run:
-            return resolved_pair
         return (*response, completed_run_result) if return_evidence_run else response
     sys.exit(0)
 

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -104,6 +104,7 @@ from theHarvester.lib.run import (
     execute_run,
     legacy_dns_results,
     legacy_hostnames,
+    validate_run,
 )
 from theHarvester.lib.source_catalog import ResultRoute, get_source_spec
 from theHarvester.screenshot.screenshot import ScreenShotter
@@ -440,7 +441,9 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 else:
                     host_names = list(_normalize_hosts_for_storage(discovered_hosts, word))
             if not has_dns_validation:
-                if source != 'hackertarget' and source != 'pentesttools' and source != 'rapiddns':
+                if len(final_dns_resolver_list) == 3:
+                    full.extend(host_names)
+                elif source != 'hackertarget' and source != 'pentesttools' and source != 'rapiddns':
                     # If a source is inside this conditional, it means the hosts returned must be resolved to obtain ip
                     # This should only be checked if --dns-resolve has a wordlist
                     if dnsresolve is None or len(final_dns_resolver_list) > 0:
@@ -551,26 +554,24 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
 
     async def store_evidence_sources() -> None:
         nonlocal completed_run_result
+        run_result = await execute_run(word, tuple(evidence_sources))
+        completed_run_result = run_result
+        executions = {execution.source: execution for execution in run_result.source_executions}
+        for evidence_source in evidence_sources:
+            execution = executions[evidence_source.name]
+            if execution.status in (SourceStatus.SUCCEEDED, SourceStatus.EMPTY) or execution.observation_count:
+                await store(evidence_source.search, evidence_source.legacy_name, run_result)
+
+    async def validate_completed_run(result: RunResult) -> RunResult:
+        if len(final_dns_resolver_list) != 3 or not any(entity.addressability is None for entity in result.entities):
+            return result
         async with AsyncExitStack() as resolver_stack:
-            dns_validator = None
-            if len(final_dns_resolver_list) == 3:
-                vantages = []
-                for nameserver in final_dns_resolver_list:
-                    vantage = AioDnsResolverVantage(nameserver)
-                    vantages.append(vantage)
-                    resolver_stack.push_async_callback(vantage.close)
-                dns_validator = DnsValidator(tuple(vantages))
-            run_result = (
-                await execute_run(word, tuple(evidence_sources), dns_validator=dns_validator)
-                if dns_validator is not None
-                else await execute_run(word, tuple(evidence_sources))
-            )
-            completed_run_result = run_result
-            executions = {execution.source: execution for execution in run_result.source_executions}
-            for evidence_source in evidence_sources:
-                execution = executions[evidence_source.name]
-                if execution.status in (SourceStatus.SUCCEEDED, SourceStatus.EMPTY) or execution.observation_count:
-                    await store(evidence_source.search, evidence_source.legacy_name, run_result)
+            vantages = []
+            for nameserver in final_dns_resolver_list:
+                vantage = AioDnsResolverVantage(nameserver)
+                vantages.append(vantage)
+                resolver_stack.push_async_callback(vantage.close)
+            return await validate_run(result, DnsValidator(tuple(vantages)))
 
     if args.source is not None:
         engines = Core.expand_source_selection(args.source)
@@ -1492,6 +1493,12 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                     error_type='SourceDidNotStart',
                 )
             )
+    provider_stage_count = len(stage_results)
+    completed_run_result = complete_run(completed_run_result, stage_results)
+    completed_run_result = await validate_completed_run(completed_run_result)
+    if completed_run_result.dns_validations:
+        full, all_hosts, validated_ips = legacy_dns_results(completed_run_result)
+        all_ip.extend(validated_ips)
     total_asns = sorted_unique(total_asns)
     interesting_urls = sorted_unique(interesting_urls)
     twitter_people_list_tracker = sorted_unique(twitter_people_list_tracker)
@@ -1871,7 +1878,12 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
             output_logger.info('    Continuing with the rest of the scan...')
             traceback.print_exc()  # More detailed error information for developers
 
-    completed_run_result = complete_run(completed_run_result, stage_results)
+    completed_run_result = complete_run(completed_run_result, stage_results[provider_stage_count:])
+    completed_run_result = await validate_completed_run(completed_run_result)
+    if completed_run_result.dns_validations:
+        full, all_hosts, validated_ips = legacy_dns_results(completed_run_result)
+        all_ip.extend(validated_ips)
+        ip_list = sorted(set([*ip_list, *validated_ips]))
     await SQLiteRunStore().save(completed_run_result)
     output_logger.info(format_run_terminal(completed_run_result))
 

--- a/theHarvester/discovery/crtsh.py
+++ b/theHarvester/discovery/crtsh.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 from theHarvester.lib.core import AsyncFetcher
+from theHarvester.lib.run import SourceIncompleteError
 
 logger = logging.getLogger(__name__)
 
@@ -27,15 +28,16 @@ class SearchCrtsh:
                     await asyncio.sleep(2)
 
             if response is None:
-                logger.info(f'No valid response from crt.sh after {max_attempts} attempts.')
-                return []
+                raise SourceIncompleteError(f'No valid response from crt.sh after {max_attempts} attempts.')
 
             data = set([(dct['name_value'][2:] if dct['name_value'][:2] == '*.' else dct['name_value']) for dct in response])
             data = {domain for domain in data if (domain[0] != '*' and str(domain[0:4]).isnumeric() is False)}
-        except KeyError as ke:
-            logger.info(f'Missing expected key in response: {ke}')
-        except Exception as e:
-            logger.info(f'Unexpected error: {e}')
+        except SourceIncompleteError:
+            raise
+        except KeyError as error:
+            raise SourceIncompleteError(f'Missing expected key in crt.sh response: {error}') from error
+        except Exception as error:
+            raise SourceIncompleteError(f'Unexpected crt.sh error: {error}') from error
         clean: list = []
         for x in data:
             pre = x.split()

--- a/theHarvester/discovery/crtsh.py
+++ b/theHarvester/discovery/crtsh.py
@@ -14,7 +14,6 @@ class SearchCrtsh:
         self.proxy = False
 
     async def do_search(self) -> list:
-        data: set = set()
         url = f'https://crt.sh/?q=%25.{self.word}&exclude=expired&deduplicate=Y&output=json'
         response = None
         try:
@@ -30,20 +29,19 @@ class SearchCrtsh:
             if response is None:
                 raise SourceIncompleteError(f'No valid response from crt.sh after {max_attempts} attempts.')
 
-            data = set([(dct['name_value'][2:] if dct['name_value'][:2] == '*.' else dct['name_value']) for dct in response])
-            data = {domain for domain in data if (domain[0] != '*' and str(domain[0:4]).isnumeric() is False)}
+            clean: set[str] = set()
+            for item in response:
+                for name in item['name_value'].split():
+                    name = name.removeprefix('*.')
+                    if name and not name.startswith('*') and not name[:4].isnumeric():
+                        clean.add(name)
         except SourceIncompleteError:
             raise
         except KeyError as error:
             raise SourceIncompleteError(f'Missing expected key in crt.sh response: {error}') from error
         except Exception as error:
             raise SourceIncompleteError(f'Unexpected crt.sh error: {error}') from error
-        clean: list = []
-        for x in data:
-            pre = x.split()
-            for y in pre:
-                clean.append(y)
-        return clean
+        return list(clean)
 
     async def process(self, proxy: bool = False) -> None:
         self.proxy = proxy

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -201,6 +201,7 @@ async def getsources(request: Request) -> Response:
 # Define Pydantic model for DNS brute force response
 class DnsBruteResponse(BaseModel):
     dns_bruteforce: list[str] = Field(default_factory=list, description='List of DNS brute force results')
+    evidence_run: dict[str, Any] | None = None
 
 
 @app.get(
@@ -237,7 +238,7 @@ async def dnsbrute(
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Domain must be at least 3 characters long')
 
         # Call the main function with the provided parameters
-        dns_bruteforce = await __main__.start(
+        dns_bruteforce, evidence_run = await __main__.start(
             argparse.Namespace(
                 dns_brute=True,
                 dns_lookup=False,
@@ -255,10 +256,17 @@ async def dnsbrute(
                 wordlist='',
                 api_scan=False,
                 dns_resolve=dns_resolve,
-            )
+            ),
+            return_evidence_run=True,
         )
 
-        return JSONResponse({'dns_bruteforce': dns_bruteforce})
+        adapted = legacy_json_result(evidence_run, {'dns_bruteforce': dns_bruteforce})
+        return JSONResponse(
+            {
+                'dns_bruteforce': dns_bruteforce,
+                'evidence_run': adapted['evidence_run'],
+            }
+        )
 
     except HTTPException as e:
         # Re-raise HTTP exceptions

--- a/theHarvester/lib/hostchecker.py
+++ b/theHarvester/lib/hostchecker.py
@@ -40,7 +40,9 @@ class Checker:
         try:
             # TODO add check for ipv6 addrs as well
             result = await resolver.getaddrinfo(host, socket.AF_INET)
-            addresses_list: list[str] = [r.addr[0] for r in result.nodes]
+            addresses_list = [
+                address.decode('ascii') if isinstance(address, bytes) else address for r in result.nodes if (address := r.addr[0])
+            ]
             if addresses_list == [] or addresses_list is None or result is None:
                 return f'{host}:'
             else:

--- a/theHarvester/lib/output.py
+++ b/theHarvester/lib/output.py
@@ -230,7 +230,9 @@ def legacy_json_result(result: RunResult, existing: Mapping[str, object] | None 
     adapted = dict(existing or {})
     existing_hosts = adapted.get('hosts', [])
     hosts = list(existing_hosts) if isinstance(existing_hosts, list) else []
-    adapted['hosts'] = list(dict.fromkeys([*hosts, *legacy_hostnames(result)]))
+    represented_hosts = {host.split(':', 1)[0] for host in hosts if isinstance(host, str)}
+    hosts.extend(host for host in legacy_hostnames(result) if host not in represented_hosts)
+    adapted['hosts'] = list(dict.fromkeys(hosts))
     adapted['evidence_run'] = {
         **_run_record(result),
         'source_executions': [execution.to_dict() for execution in result.source_executions],

--- a/theHarvester/lib/output.py
+++ b/theHarvester/lib/output.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 from xml.etree.ElementTree import Element, SubElement, tostring
 
 from theHarvester.lib.dns_validation import Addressability
-from theHarvester.lib.run import ScopeClass, legacy_hostnames
+from theHarvester.lib.run import ScopeClass, StageFindingKind, legacy_hostnames
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -90,7 +90,13 @@ def print_linkedin_sections(
 def _entity_line(entity: MergedEntity, selected: Sequence[SelectedObservation] = ()) -> str:
     sources = ','.join(sorted({observation.source for observation in entity.observations}))
     selected_status = ''.join(f'; {observation.kind}={observation.detail or "observed"}' for observation in selected)
-    return f'{entity.value} [status={entity.addressability}; sources={sources}{selected_status}]'
+    status = (
+        entity.addressability
+        or ('scope-extension-candidate' if ScopeClass.SCOPE_EXTENSION in entity.scope_classes else None)
+        or ('external-relationship' if ScopeClass.EXTERNAL_RELATIONSHIP in entity.scope_classes else None)
+        or 'needs-review'
+    )
+    return f'{entity.value} [status={status}; sources={sources}{selected_status}]'
 
 
 def format_run_terminal(result: RunResult) -> str:
@@ -122,6 +128,31 @@ def format_run_terminal(result: RunResult) -> str:
         for value in entity_values
     }
     standalone_selected = [observation for observation in result.selected_observations if observation.value not in entity_values]
+    selected_sections: list[str] = []
+    for kind, title in (
+        (StageFindingKind.EMAIL, 'Emails found'),
+        (StageFindingKind.IP_ADDRESS, 'IPs found'),
+        (StageFindingKind.ASN, 'ASNS found'),
+        (StageFindingKind.PERSON, 'People found'),
+        (StageFindingKind.URL, 'URLs found'),
+        (StageFindingKind.INTERESTING_URL, 'Interesting Urls found'),
+        (StageFindingKind.TAKEOVER, 'Takeover results'),
+        (StageFindingKind.SCREENSHOT, 'Screenshots captured'),
+        (StageFindingKind.SHODAN_RESULT, 'Shodan results'),
+        (StageFindingKind.API_ENDPOINT, 'API Endpoints found'),
+        (StageFindingKind.API_AUTH_REQUIRED, 'Endpoints requiring authentication'),
+        (StageFindingKind.API_VERSION, 'Detected API versions'),
+        (StageFindingKind.API_RATE_LIMIT, 'Rate limited endpoints'),
+        (StageFindingKind.HTTP_METHOD, 'HTTP methods used'),
+        (StageFindingKind.HTTP_STATUS_CODE, 'HTTP status codes encountered'),
+    ):
+        observations = [observation for observation in standalone_selected if observation.kind is kind]
+        if not observations:
+            continue
+        selected_sections.append(f'[*] {title}: {len(observations)}')
+        for observation in observations:
+            detail = f'; detail={observation.detail}' if observation.detail is not None else ''
+            selected_sections.append(f'{observation.value} [status=observed; sources={observation.source}{detail}]')
     sections = [
         f'[*] Run status: {result.status}',
         f'[*] Currently addressable subdomains ({len(primary)})',
@@ -130,16 +161,18 @@ def format_run_terminal(result: RunResult) -> str:
         *(_entity_line(entity, selected_by_entity[entity.value]) for entity in secondary),
         f'[*] Scope-extension candidates ({len(scope_extensions)})',
         *(_entity_line(entity, selected_by_entity[entity.value]) for entity in scope_extensions),
-        f'[*] Selected stage observations ({len(standalone_selected)})',
-        *(
-            f'{observation.value} [{observation.kind}={observation.detail or "observed"}; source={observation.source}]'
-            for observation in standalone_selected
-        ),
+        *selected_sections,
         '[*] Source executions',
         *(
             f'{execution.source} [status={execution.status}; results={execution.result_count}; '
             f'observations={execution.observation_count}]'
             for execution in result.source_executions
+        ),
+        '[*] Selected stage executions',
+        *(
+            f'{execution.stage} [status={execution.status}; results={execution.result_count}; '
+            f'observations={execution.observation_count}]'
+            for execution in result.stage_executions
         ),
     ]
     return '\n'.join(sections)
@@ -150,6 +183,7 @@ def run_result_jsonl(result: RunResult) -> str:
     serialized = result.to_dict()
     records: list[tuple[str, dict[str, Any]]] = [('run', _run_record(result))]
     records.extend(('source_execution', item) for item in cast('list[dict[str, Any]]', serialized['source_executions']))
+    records.extend(('stage_execution', item) for item in cast('list[dict[str, Any]]', serialized['stage_executions']))
     records.extend(('discovery_observation', item) for item in cast('list[dict[str, Any]]', serialized['observations']))
     for item in cast('list[dict[str, Any]]', serialized['dns_validations']):
         validation = dict(item)
@@ -183,6 +217,7 @@ def _run_record(result: RunResult) -> dict[str, object]:
         'completed_at': result.completed_at.isoformat(),
         'record_counts': {
             'source_executions': len(result.source_executions),
+            'stage_executions': len(result.stage_executions),
             'discovery_observations': len(result.observations),
             'dns_validation_observations': len(result.dns_validations),
             'merged_results': len(result.entities),
@@ -199,6 +234,8 @@ def legacy_json_result(result: RunResult, existing: Mapping[str, object] | None 
     adapted['evidence_run'] = {
         **_run_record(result),
         'source_executions': [execution.to_dict() for execution in result.source_executions],
+        'stage_executions': [execution.to_dict() for execution in result.stage_executions],
+        'merged_results': [entity.to_dict() for entity in result.entities],
         'selected_observations': [observation.to_dict() for observation in result.selected_observations],
     }
     return adapted
@@ -208,6 +245,17 @@ def evidence_xml_fragment(result: RunResult) -> str:
     evidence_run = Element('evidence_run', run_id=result.run_id, status=result.status)
     for execution in result.source_executions:
         SubElement(evidence_run, 'source', name=execution.source, status=execution.status)
+    for stage_execution in result.stage_executions:
+        SubElement(evidence_run, 'stage', name=stage_execution.stage, status=stage_execution.status)
+    for entity in result.entities:
+        attributes = {
+            'value': entity.value,
+            'scope_classes': ','.join(sorted(entity.scope_classes)),
+            'sources': ','.join(sorted({observation.source for observation in entity.observations})),
+        }
+        if entity.addressability is not None:
+            attributes['addressability'] = entity.addressability
+        SubElement(evidence_run, 'merged_result', attributes)
     for observation in result.selected_observations:
         attributes = {
             'source': observation.source,

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -384,6 +384,36 @@ def _merge_observations(observations: Sequence[DiscoveryObservation]) -> tuple[M
     return tuple(MergedEntity(value, tuple(supporting)) for value, supporting in grouped.items())
 
 
+async def validate_run(
+    result: RunResult,
+    dns_validator: DnsValidator,
+    *,
+    deterministic_exact_dns_names: tuple[str, ...] = (),
+) -> RunResult:
+    candidates = tuple(
+        entity.value
+        for entity in result.entities
+        if ScopeClass.IN_SCOPE in entity.scope_classes and entity.addressability is None
+    )
+    if not candidates:
+        return result
+    validation = await dns_validator.validate(
+        result.run_id,
+        result.target,
+        candidates,
+        deterministic_exact_names=deterministic_exact_dns_names,
+    )
+    classifications = {classification.candidate: classification.addressability for classification in validation.classifications}
+    return replace(
+        result,
+        completed_at=datetime.now(UTC),
+        entities=tuple(
+            replace(entity, addressability=classifications.get(entity.value, entity.addressability)) for entity in result.entities
+        ),
+        dns_validations=(*result.dns_validations, *validation.observations),
+    )
+
+
 async def execute_run(
     target: str,
     sources: Sequence[PassiveSource],
@@ -476,20 +506,6 @@ async def execute_run(
 
     merged_observations = tuple(observations)
     entities = _merge_observations(merged_observations)
-    dns_validations: tuple[DnsValidationObservation, ...] = ()
-    if dns_validator is not None:
-        validation = await dns_validator.validate(
-            run_id,
-            normalized_target,
-            tuple(entity.value for entity in entities if ScopeClass.IN_SCOPE in entity.scope_classes),
-            deterministic_exact_names=deterministic_exact_dns_names,
-        )
-        classifications = {
-            classification.candidate: classification.addressability for classification in validation.classifications
-        }
-        entities = tuple(replace(entity, addressability=classifications.get(entity.value)) for entity in entities)
-        dns_validations = validation.observations
-
     result = RunResult(
         run_id=run_id,
         target=normalized_target,
@@ -498,9 +514,16 @@ async def execute_run(
         source_executions=tuple(executions),
         observations=merged_observations,
         entities=entities,
-        dns_validations=dns_validations,
     )
-    return result
+    return (
+        await validate_run(
+            result,
+            dns_validator,
+            deterministic_exact_dns_names=deterministic_exact_dns_names,
+        )
+        if dns_validator is not None
+        else result
+    )
 
 
 def legacy_hostnames(result: RunResult, source: str | None = None) -> list[str]:

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
@@ -69,6 +69,11 @@ class StageFindingKind(StrEnum):
     API_ENDPOINT = 'api-endpoint'
     SCREENSHOT = 'screenshot'
     SHODAN_RESULT = 'shodan-result'
+    API_AUTH_REQUIRED = 'api-auth-required'
+    API_VERSION = 'api-version'
+    API_RATE_LIMIT = 'api-rate-limit'
+    HTTP_METHOD = 'http-method'
+    HTTP_STATUS_CODE = 'http-status-code'
 
 
 @dataclass(frozen=True)
@@ -88,6 +93,8 @@ class StageResult:
     findings: tuple[StageFinding, ...] = ()
     source_family: str | None = None
     error_type: str | None = None
+    is_action: bool = False
+    completed_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
 
 class SourceIncompleteError(Exception):
@@ -190,6 +197,32 @@ class SourceExecution:
 
 
 @dataclass(frozen=True)
+class StageExecution:
+    run_id: str
+    stage: str
+    status: SourceStatus
+    duration_ms: float
+    result_count: int
+    observation_count: int
+    entity_count: int
+    completed_at: datetime
+    error_type: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            'run_id': self.run_id,
+            'stage': self.stage,
+            'status': self.status,
+            'duration_ms': self.duration_ms,
+            'result_count': self.result_count,
+            'observation_count': self.observation_count,
+            'entity_count': self.entity_count,
+            'completed_at': self.completed_at.isoformat(),
+            'error_type': self.error_type,
+        }
+
+
+@dataclass(frozen=True)
 class SelectedObservation:
     run_id: str
     source: str
@@ -248,13 +281,18 @@ class RunResult:
     entities: tuple[MergedEntity, ...]
     dns_validations: tuple[DnsValidationObservation, ...] = ()
     selected_observations: tuple[SelectedObservation, ...] = ()
+    stage_executions: tuple[StageExecution, ...] = ()
 
     @property
     def status(self) -> RunStatus:
+        statuses = [
+            *(execution.status for execution in self.source_executions),
+            *(execution.status for execution in self.stage_executions),
+        ]
         incomplete = {SourceStatus.FAILED, SourceStatus.RATE_LIMITED}
-        if self.source_executions and all(execution.status is SourceStatus.FAILED for execution in self.source_executions):
+        if statuses and all(status is SourceStatus.FAILED for status in statuses):
             return RunStatus.FAILED
-        if any(execution.status in incomplete for execution in self.source_executions):
+        if any(status in incomplete for status in statuses):
             return RunStatus.PARTIAL
         return RunStatus.COMPLETE
 
@@ -266,6 +304,7 @@ class RunResult:
             'completed_at': self.completed_at.isoformat(),
             'status': self.status,
             'source_executions': [execution.to_dict() for execution in self.source_executions],
+            'stage_executions': [execution.to_dict() for execution in self.stage_executions],
             'observations': [observation.to_dict() for observation in self.observations],
             'dns_validations': [
                 {
@@ -493,7 +532,6 @@ def legacy_dns_results(result: RunResult, source: str | None = None) -> tuple[li
 
 def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -> RunResult:
     """Merge selected stage results once and close the run."""
-    collected_at = datetime.now(UTC)
     stage_findings = tuple((stage, finding) for stage in stage_results for finding in dict.fromkeys(stage.findings))
     existing = {(item.source, item.value, item.derivation) for item in result.observations}
     added: list[DiscoveryObservation] = []
@@ -511,7 +549,7 @@ def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -
                 source=stage.source,
                 source_family=stage.source_family or stage.source,
                 derivation=finding.derivation,
-                collected_at=collected_at,
+                collected_at=stage.completed_at,
                 scope_class=_classify_scope(result.target, value, finding.derivation),
             )
         )
@@ -532,15 +570,44 @@ def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -
             value=finding.value,
             detail=finding.detail,
             derivation=finding.derivation,
-            collected_at=collected_at,
+            collected_at=stage.completed_at,
         )
         for stage, finding in stage_findings
         if finding.kind is not StageFindingKind.HOSTNAME
     )
     executions = list(result.source_executions)
+    stage_executions = list(result.stage_executions)
     recorded_sources = {execution.source.casefold(): index for index, execution in enumerate(executions)}
+    recorded_stages = {execution.stage.casefold(): index for index, execution in enumerate(stage_executions)}
     for stage in stage_results:
         source_key = stage.source.casefold()
+        findings = tuple(dict.fromkeys(stage.findings))
+        entity_count = len(
+            {
+                value
+                for finding in findings
+                if finding.kind is StageFindingKind.HOSTNAME
+                and (value := normalize_hostname(finding.value.split(':', 1)[0])) is not None
+            }
+        )
+        if stage.is_action:
+            stage_execution = StageExecution(
+                run_id=result.run_id,
+                stage=stage.source,
+                status=stage.status,
+                duration_ms=stage.duration_ms,
+                result_count=stage.result_count,
+                observation_count=len(findings),
+                entity_count=entity_count,
+                completed_at=stage.completed_at,
+                error_type=stage.error_type,
+            )
+            if source_key in recorded_stages:
+                stage_executions[recorded_stages[source_key]] = stage_execution
+            else:
+                recorded_stages[source_key] = len(stage_executions)
+                stage_executions.append(stage_execution)
+            continue
         if source_key in recorded_sources:
             index = recorded_sources[source_key]
             execution = executions[index]
@@ -551,7 +618,6 @@ def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -
                 error_type=stage.error_type or execution.error_type,
             )
             continue
-        findings = tuple(dict.fromkeys(stage.findings))
         executions.append(
             SourceExecution(
                 run_id=result.run_id,
@@ -561,14 +627,7 @@ def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -
                 duration_ms=stage.duration_ms,
                 result_count=stage.result_count,
                 observation_count=len(findings),
-                entity_count=len(
-                    {
-                        value
-                        for finding in findings
-                        if finding.kind is StageFindingKind.HOSTNAME
-                        and (value := normalize_hostname(finding.value.split(':', 1)[0])) is not None
-                    }
-                ),
+                entity_count=entity_count,
                 error_type=stage.error_type,
             )
         )
@@ -577,6 +636,7 @@ def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -
         result,
         completed_at=datetime.now(UTC),
         source_executions=tuple(executions),
+        stage_executions=tuple(stage_executions),
         observations=(*result.observations, *added),
         entities=entities,
         selected_observations=(*result.selected_observations, *selected),


### PR DESCRIPTION
## Summary

- preserve collected evidence while later stages update the completed run
- validate provider evidence before final reporting
- normalize multiline crt.sh wildcard entries
- share one finalization path across CLI branches

## Operator impact

Later stages cannot erase earlier evidence, and crt.sh wildcard artifacts do not appear as malformed results.

## Stack

Layer 8 of 10. Base: feature/completed-run-integration.

Fork tracking: https://github.com/NotoriousRebel/theHarvester/issues/63

## Verification

Focused regressions cover stage preservation, provider validation, host checking, and crt.sh parsing. The complete stack passed all required checks and both reviews.