### PR TITLE
fix: preserve incomplete provider evidence

### DIFF
--- a/tests/discovery/test_certspotter.py
+++ b/tests/discovery/test_certspotter.py
@@ -9,6 +9,7 @@ import pytest
 
 from theHarvester.discovery import certspottersearch
 from theHarvester.lib.core import Core
+from theHarvester.lib.run import SourceIncompleteError, SourcePartialError, SourceRateLimitedError
 
 
 class TestCertspotter(object):
@@ -30,8 +31,10 @@ class TestCertspotterSearch(object):
 
     @pytest.mark.asyncio
     async def test_search(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[list[dict[str, list[str]]]]:
-            return [[{'dns_names': ['api.example.com', 'www.example.com']}]]
+        pages = [[{'id': '1', 'dns_names': ['api.example.com', 'www.example.com']}], []]
+
+        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[list[dict[str, Any]]]:
+            return [pages.pop(0)]
 
         monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
         search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
@@ -91,11 +94,18 @@ class TestCertspotterSearch(object):
         monkeypatch.setattr(certspottersearch.SearchCertspoter, 'MAX_PAGES', 2, raising=False)
 
         search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
-        with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+        with (
+            caplog.at_level(logging.WARNING, logger=certspottersearch.__name__),
+            pytest.raises(SourcePartialError) as error,
+        ):
             await search.process()
 
         assert requests == 2
         assert await search.get_hostnames() == {'host-1.example.com', 'host-2.example.com'}
+        assert {finding.value for finding in error.value.findings} == {
+            'host-1.example.com',
+            'host-2.example.com',
+        }
         assert 'page limit reached; results may be incomplete' in caplog.text
 
     @pytest.mark.asyncio
@@ -113,7 +123,6 @@ class TestCertspotterSearch(object):
                         '.example.com',
                         'bad..example.com',
                         '-bad.example.com',
-                        None,
                     ],
                 }
             ],
@@ -143,10 +152,14 @@ class TestCertspotterSearch(object):
 
         monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
         search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
-        with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+        with (
+            caplog.at_level(logging.WARNING, logger=certspottersearch.__name__),
+            pytest.raises(SourceRateLimitedError) as error,
+        ):
             await search.process()
 
         assert await search.get_hostnames() == {'first.example.com'}
+        assert {finding.value for finding in error.value.findings} == {'first.example.com'}
         assert 'rate_limited' in caplog.text
         assert 'results may be incomplete' in caplog.text
         assert 'provider details must not be logged' not in caplog.text
@@ -165,10 +178,14 @@ class TestCertspotterSearch(object):
 
         monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
         search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
-        with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+        with (
+            caplog.at_level(logging.WARNING, logger=certspottersearch.__name__),
+            pytest.raises(SourcePartialError) as error,
+        ):
             await search.process()
 
         assert await search.get_hostnames() == {'first.example.com'}
+        assert {finding.value for finding in error.value.findings} == {'first.example.com'}
         assert 'results may be incomplete' in caplog.text
 
     @pytest.mark.asyncio
@@ -181,7 +198,10 @@ class TestCertspotterSearch(object):
 
         monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
         search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
-        with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+        with (
+            caplog.at_level(logging.WARNING, logger=certspottersearch.__name__),
+            pytest.raises(SourceIncompleteError),
+        ):
             await search.process()
 
         assert await search.get_hostnames() == set()
@@ -201,10 +221,14 @@ class TestCertspotterSearch(object):
 
         monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
         search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
-        with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+        with (
+            caplog.at_level(logging.WARNING, logger=certspottersearch.__name__),
+            pytest.raises(SourcePartialError) as error,
+        ):
             await search.process()
 
         assert await search.get_hostnames() == {'first.example.com'}
+        assert {finding.value for finding in error.value.findings} == {'first.example.com'}
         assert 'results may be incomplete' in caplog.text
 
     @pytest.mark.asyncio
@@ -231,10 +255,14 @@ class TestCertspotterSearch(object):
 
         monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
         search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
-        with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+        with (
+            caplog.at_level(logging.WARNING, logger=certspottersearch.__name__),
+            pytest.raises(SourcePartialError) as incomplete,
+        ):
             await search.process()
 
         assert await search.get_hostnames() == {'first.example.com'}
+        assert {finding.value for finding in incomplete.value.findings} == {'first.example.com'}
         assert 'results may be incomplete' in caplog.text
         assert str(error) not in caplog.text
 
@@ -255,10 +283,17 @@ class TestCertspotterSearch(object):
 
         monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
         search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
-        with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+        with (
+            caplog.at_level(logging.WARNING, logger=certspottersearch.__name__),
+            pytest.raises(SourcePartialError) as error,
+        ):
             await search.process()
 
         assert await search.get_hostnames() == {'first.example.com', 'second.example.com'}
+        assert {finding.value for finding in error.value.findings} == {
+            'first.example.com',
+            'second.example.com',
+        }
         assert calls == 2
         assert 'results may be incomplete' in caplog.text
 
@@ -306,10 +341,14 @@ class TestCertspotterSearch(object):
 
         monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
         search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
-        with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+        with (
+            caplog.at_level(logging.WARNING, logger=certspottersearch.__name__),
+            pytest.raises(SourcePartialError) as error,
+        ):
             await search.process()
 
         assert await search.get_hostnames() == {'first.example.com'}
+        assert {finding.value for finding in error.value.findings} == {'first.example.com'}
         assert calls == 1
         assert 'results may be incomplete' in caplog.text
 

--- a/tests/discovery/test_commoncrawl.py
+++ b/tests/discovery/test_commoncrawl.py
@@ -4,6 +4,7 @@ from urllib.parse import parse_qs, urlsplit
 import pytest
 
 from theHarvester.discovery import commoncrawl
+from theHarvester.lib.run import SourcePartialError
 
 
 @pytest.mark.asyncio
@@ -185,7 +186,10 @@ async def test_process_caps_provider_page_counts_and_reports_truncation(
     monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
     monkeypatch.setattr(commoncrawl.SearchCommoncrawl, 'MAX_PAGES_PER_QUERY', 2)
 
-    with caplog.at_level(logging.WARNING, logger=commoncrawl.__name__):
+    with (
+        caplog.at_level(logging.WARNING, logger=commoncrawl.__name__),
+        pytest.raises(SourcePartialError),
+    ):
         await commoncrawl.SearchCommoncrawl('example.com', limit=50).process()
 
     assert requested_pages == [0, 1, 0, 1]
@@ -260,10 +264,14 @@ async def test_process_reports_failed_or_malformed_index_without_discarding_othe
     monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
 
     search = commoncrawl.SearchCommoncrawl('example.com')
-    with caplog.at_level(logging.WARNING, logger=commoncrawl.__name__):
+    with (
+        caplog.at_level(logging.WARNING, logger=commoncrawl.__name__),
+        pytest.raises(SourcePartialError) as error,
+    ):
         await search.process()
 
     assert await search.get_hostnames() == {'survivor.example.com'}
+    assert {finding.value for finding in error.value.findings} == {'survivor.example.com'}
     assert 'CC-MAIN-BROKEN' in caplog.text
     assert 'CC-MAIN-2026-30' in caplog.text
 
@@ -328,10 +336,14 @@ async def test_process_keeps_later_valid_page_after_malformed_page(
     monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
     search = commoncrawl.SearchCommoncrawl('example.com')
 
-    with caplog.at_level(logging.WARNING, logger=commoncrawl.__name__):
+    with (
+        caplog.at_level(logging.WARNING, logger=commoncrawl.__name__),
+        pytest.raises(SourcePartialError) as error,
+    ):
         await search.process()
 
     assert await search.get_hostnames() == {'api.example.com'}
+    assert {finding.value for finding in error.value.findings} == {'api.example.com'}
     assert 'malformed JSON line' in caplog.text
 
 
@@ -386,6 +398,8 @@ async def test_process_keeps_results_when_another_query_fails(monkeypatch: pytes
     monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
     search = commoncrawl.SearchCommoncrawl('example.com')
 
-    await search.process()
+    with pytest.raises(SourcePartialError) as error:
+        await search.process()
 
     assert await search.get_hostnames() == {'api.example.com'}
+    assert {finding.value for finding in error.value.findings} == {'api.example.com'}

--- a/tests/discovery/test_commoncrawl.py
+++ b/tests/discovery/test_commoncrawl.py
@@ -8,6 +8,28 @@ from theHarvester.lib.run import SourcePartialError
 
 
 @pytest.mark.asyncio
+async def test_process_reports_an_invalid_catalog_as_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch_all(_urls: list[str], **_kwargs: object) -> list[object]:
+        return []
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    with pytest.raises(RuntimeError, match='invalid index catalog'):
+        await commoncrawl.SearchCommoncrawl('example.com').process()
+
+
+@pytest.mark.asyncio
+async def test_process_reports_a_catalog_request_error_as_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch_all(_urls: list[str], **_kwargs: object) -> list[object]:
+        raise OSError('provider unavailable')
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    with pytest.raises(RuntimeError, match='Common Crawl request failed'):
+        await commoncrawl.SearchCommoncrawl('example.com').process()
+
+
+@pytest.mark.asyncio
 async def test_process_exhausts_current_catalog_index_pages(monkeypatch: pytest.MonkeyPatch) -> None:
     catalog = [
         {
@@ -230,6 +252,40 @@ async def test_process_respects_the_result_limit_across_page_requests(monkeypatc
 
     assert requested_limits == [1, 1, 1]
     assert len(await search.get_hostnames()) == 3
+
+
+@pytest.mark.asyncio
+async def test_process_preserves_partial_status_when_the_result_limit_is_reached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = [
+        {
+            'id': 'CC-MAIN-2026-30',
+            'cdx-api': 'https://index.commoncrawl.org/CC-MAIN-2026-30-index',
+            'to': '2026-07-12T00:00:00',
+        }
+    ]
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        if urls == ['https://index.commoncrawl.org/collinfo.json']:
+            return [catalog]
+        query = parse_qs(urlsplit(urls[0]).query)
+        if query.get('showNumPages') == ['true']:
+            return ['{"pages": 1, "pageSize": 5, "blocks": 1}']
+        if query['url'] == ['*.example.com']:
+            return ['not-json']
+        return [
+            '{"url":"https://api.example.com/v1"}\n'
+            '{"url":"https://mail.example.com/inbox"}'
+        ]
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = commoncrawl.SearchCommoncrawl('example.com', limit=1)
+
+    with pytest.raises(SourcePartialError) as error:
+        await search.process()
+
+    assert {finding.value for finding in error.value.findings} == {'api.example.com'}
 
 
 @pytest.mark.asyncio

--- a/tests/discovery/test_commoncrawl.py
+++ b/tests/discovery/test_commoncrawl.py
@@ -263,12 +263,19 @@ async def test_process_preserves_partial_status_when_the_result_limit_is_reached
             'id': 'CC-MAIN-2026-30',
             'cdx-api': 'https://index.commoncrawl.org/CC-MAIN-2026-30-index',
             'to': '2026-07-12T00:00:00',
-        }
+        },
+        {
+            'id': 'CC-MAIN-2026-25',
+            'cdx-api': 'https://index.commoncrawl.org/CC-MAIN-2026-25-index',
+            'to': '2026-06-12T00:00:00',
+        },
     ]
+    requested_urls: list[str] = []
 
     async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
         if urls == ['https://index.commoncrawl.org/collinfo.json']:
             return [catalog]
+        requested_urls.extend(urls)
         query = parse_qs(urlsplit(urls[0]).query)
         if query.get('showNumPages') == ['true']:
             return ['{"pages": 1, "pageSize": 5, "blocks": 1}']
@@ -286,6 +293,7 @@ async def test_process_preserves_partial_status_when_the_result_limit_is_reached
         await search.process()
 
     assert {finding.value for finding in error.value.findings} == {'api.example.com'}
+    assert all('CC-MAIN-2026-25-index' not in url for url in requested_urls)
 
 
 @pytest.mark.asyncio

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -701,9 +701,11 @@ async def test_cli_records_provider_people_in_the_completed_run(monkeypatch: pyt
         return_evidence_run=True,
     )
 
-    assert {(item.kind, item.value) for item in response[-1].selected_observations} == {
+    result = response[-1]
+    assert {(item.kind, item.value) for item in result.selected_observations} == {
         (StageFindingKind.PERSON, '{"name":"Alice"}')
     }
+    assert all(item.collected_at >= result.started_at for item in result.selected_observations)
 
 
 @pytest.mark.asyncio

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -18,6 +18,7 @@ from theHarvester.lib.output import (
     run_result_jsonl,
 )
 from theHarvester.lib.run import (
+    ActivityClass,
     Derivation,
     RunStatus,
     SourceFinding,
@@ -88,6 +89,7 @@ async def test_complete_run_merges_late_and_direct_stage_results() -> None:
                 1,
                 (StageFinding(StageFindingKind.HOSTNAME, 'late.example.com:192.0.2.11'),),
                 is_action=True,
+                activity_class=ActivityClass.DNS,
                 completed_at=dns_completed_at,
             ),
             StageResult(
@@ -97,6 +99,7 @@ async def test_complete_run_merges_late_and_direct_stage_results() -> None:
                 1,
                 (StageFinding(StageFindingKind.TAKEOVER, 'api.example.com', 'not vulnerable'),),
                 is_action=True,
+                activity_class=ActivityClass.DIRECT,
                 completed_at=direct_completed_at,
             ),
         ),
@@ -156,6 +159,7 @@ async def test_terminal_reports_each_hostname_once_with_status_and_sources() -> 
                 1,
                 (StageFinding(StageFindingKind.TAKEOVER, 'api.example.com', 'not vulnerable'),),
                 is_action=True,
+                activity_class=ActivityClass.DIRECT,
             ),
         ),
     )
@@ -181,8 +185,22 @@ async def test_activity_classes_are_serialized_and_summarized() -> None:
     result = complete_run(
         result,
         (
-            StageResult('action:dns-brute', SourceStatus.EMPTY, 1, 0, is_action=True),
-            StageResult('action:take-over', SourceStatus.EMPTY, 1, 0, is_action=True),
+            StageResult(
+                'action:dns-brute',
+                SourceStatus.EMPTY,
+                1,
+                0,
+                is_action=True,
+                activity_class=ActivityClass.DNS,
+            ),
+            StageResult(
+                'action:take-over',
+                SourceStatus.EMPTY,
+                1,
+                0,
+                is_action=True,
+                activity_class=ActivityClass.DIRECT,
+            ),
         ),
     )
 
@@ -965,6 +983,7 @@ def test_rest_dnsbrute_keeps_legacy_results_and_failed_stage_status(monkeypatch:
                 0,
                 error_type='RuntimeError',
                 is_action=True,
+                activity_class=ActivityClass.DNS,
             ),
         ),
     )

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -21,6 +21,7 @@ from theHarvester.lib.run import (
     Derivation,
     RunStatus,
     SourceFinding,
+    SourcePartialError,
     SourceRateLimitedError,
     SourceStatus,
     SQLiteRunStore,
@@ -759,6 +760,67 @@ async def test_cli_preserves_the_actual_provider_failure(monkeypatch: pytest.Mon
     execution = response[-1].source_executions[0]
     assert execution.status is SourceStatus.FAILED
     assert execution.error_type == 'RuntimeError'
+
+
+@pytest.mark.asyncio
+async def test_cli_serializes_partial_commoncrawl_findings(monkeypatch: pytest.MonkeyPatch) -> None:
+    import theHarvester.__main__ as main_module
+
+    class PartialCommonCrawlSearch:
+        def __init__(self, _target: str, _limit: int) -> None:
+            return None
+
+        async def process(self, _proxy: bool = False) -> None:
+            raise SourcePartialError(
+                'one page failed',
+                findings=(SourceFinding('survivor.example.com'),),
+            )
+
+        async def get_hostnames(self) -> list[str]:
+            raise AssertionError('partial findings must come from the incomplete source result')
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args) -> None:
+            return None
+
+    class FakeRunStore:
+        async def save(self, _result) -> None:
+            return None
+
+    monkeypatch.setattr(main_module.commoncrawl, 'SearchCommoncrawl', PartialCommonCrawlSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore)
+
+    response = await main_module.start(
+        SimpleNamespace(
+            api_scan=False,
+            dns_brute=False,
+            dns_lookup=False,
+            dns_resolve='',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=500,
+            proxies=False,
+            quiet=False,
+            screenshot='',
+            shodan=False,
+            source='commoncrawl',
+            start=0,
+            take_over=False,
+            wordlist='',
+        ),
+        return_evidence_run=True,
+    )
+
+    result = response[-1]
+    assert result.status is RunStatus.PARTIAL
+    assert result.source_executions[0].status is SourceStatus.PARTIAL
+    records = [json.loads(line) for line in run_result_jsonl(result).splitlines()]
+    assert any(record['data'].get('value') == 'survivor.example.com' for record in records)
 
 
 @pytest.mark.asyncio

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -814,19 +814,42 @@ async def test_cli_preserves_the_actual_provider_failure(monkeypatch: pytest.Mon
     assert execution.error_type == 'RuntimeError'
 
 
+@pytest.mark.parametrize(
+    ('source', 'module_name', 'class_name', 'error', 'expected_status'),
+    [
+        (
+            'commoncrawl',
+            'commoncrawl',
+            'SearchCommoncrawl',
+            SourcePartialError('one page failed', findings=(SourceFinding('survivor.example.com'),)),
+            SourceStatus.PARTIAL,
+        ),
+        (
+            'certspotter',
+            'certspottersearch',
+            'SearchCertspoter',
+            SourceRateLimitedError('rate limit reached', findings=(SourceFinding('survivor.example.com'),)),
+            SourceStatus.RATE_LIMITED,
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_cli_serializes_partial_commoncrawl_findings(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_cli_serializes_incomplete_provider_findings(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+    module_name: str,
+    class_name: str,
+    error: Exception,
+    expected_status: SourceStatus,
+) -> None:
     import theHarvester.__main__ as main_module
 
-    class PartialCommonCrawlSearch:
-        def __init__(self, _target: str, _limit: int) -> None:
+    class IncompleteProviderSearch:
+        def __init__(self, *_args) -> None:
             return None
 
         async def process(self, _proxy: bool = False) -> None:
-            raise SourcePartialError(
-                'one page failed',
-                findings=(SourceFinding('survivor.example.com'),),
-            )
+            raise error
 
         async def get_hostnames(self) -> list[str]:
             raise AssertionError('partial findings must come from the incomplete source result')
@@ -842,7 +865,7 @@ async def test_cli_serializes_partial_commoncrawl_findings(monkeypatch: pytest.M
         async def save(self, _result) -> None:
             return None
 
-    monkeypatch.setattr(main_module.commoncrawl, 'SearchCommoncrawl', PartialCommonCrawlSearch)
+    monkeypatch.setattr(getattr(main_module, module_name), class_name, IncompleteProviderSearch)
     monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
     monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore)
 
@@ -860,7 +883,7 @@ async def test_cli_serializes_partial_commoncrawl_findings(monkeypatch: pytest.M
             quiet=False,
             screenshot='',
             shodan=False,
-            source='commoncrawl',
+            source=source,
             start=0,
             take_over=False,
             wordlist='',
@@ -870,7 +893,7 @@ async def test_cli_serializes_partial_commoncrawl_findings(monkeypatch: pytest.M
 
     result = response[-1]
     assert result.status is RunStatus.PARTIAL
-    assert result.source_executions[0].status is SourceStatus.PARTIAL
+    assert result.source_executions[0].status is expected_status
     records = [json.loads(line) for line in run_result_jsonl(result).splitlines()]
     assert any(record['data'].get('value') == 'survivor.example.com' for record in records)
 

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -175,6 +175,40 @@ async def test_terminal_reports_each_hostname_once_with_status_and_sources() -> 
 
 
 @pytest.mark.asyncio
+async def test_activity_classes_are_serialized_and_summarized() -> None:
+    validator = DnsValidator(tuple(TerminalResolver(f'resolver-{index}') for index in range(3)))
+    result = await execute_run('example.com', (CompletedRunSource(),), dns_validator=validator)
+    result = complete_run(
+        result,
+        (
+            StageResult('action:dns-brute', SourceStatus.EMPTY, 1, 0, is_action=True),
+            StageResult('action:take-over', SourceStatus.EMPTY, 1, 0, is_action=True),
+        ),
+    )
+
+    records = [json.loads(line) for line in run_result_jsonl(result).splitlines()]
+    source = next(record['data'] for record in records if record['record_type'] == 'source_execution')
+    stages = {
+        record['data']['stage']: record['data']['activity_class']
+        for record in records
+        if record['record_type'] == 'stage_execution'
+    }
+    validations = [record['data'] for record in records if record['record_type'] == 'dns_validation_observation']
+
+    assert source['activity_class'] == 'P0 passive collection'
+    assert stages == {
+        'action:dns-brute': 'P1 DNS interaction',
+        'action:take-over': 'P2 direct interaction',
+    }
+    assert {record['activity_class'] for record in validations} == {'P1 DNS interaction'}
+    terminal = format_run_terminal(result)
+    assert terminal.count('[*] Activity summary:') == 1
+    assert 'P0 passive collection=1 source' in terminal
+    assert 'P1 DNS interaction=dns-consensus, action:dns-brute' in terminal
+    assert 'P2 direct interaction=action:take-over' in terminal
+
+
+@pytest.mark.asyncio
 async def test_terminal_keeps_recognizable_non_host_sections() -> None:
     result = await execute_run('example.com', (CompletedRunSource(),))
     result = complete_run(

--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -44,6 +44,11 @@ class NoopRunStore:
         return None
 
 
+def test_action_stage_requires_an_explicit_activity_class() -> None:
+    with pytest.raises(ValueError, match='activity class'):
+        StageResult('action:future', SourceStatus.EMPTY, 0, 0, is_action=True)
+
+
 @pytest.mark.asyncio
 async def test_complete_run_retains_late_evidence_status_and_persistence(tmp_path) -> None:
     result = await execute_run('example.com', (FakePassiveSource(),))

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -95,6 +95,7 @@ from theHarvester.lib.output import (
     sorted_unique,
 )
 from theHarvester.lib.run import (
+    ActivityClass,
     LegacyHostnameSource,
     RunResult,
     SourceStatus,
@@ -378,6 +379,7 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
         source_family: str | None = None,
         execution: Any | None = None,
         is_action: bool = True,
+        activity_class: ActivityClass | None = None,
     ) -> None:
         unique_findings = tuple(dict.fromkeys(findings))
         stage_results.append(
@@ -400,6 +402,7 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                     execution.error_type if execution is not None else type(error).__name__ if error is not None else None
                 ),
                 is_action=is_action,
+                activity_class=activity_class,
             )
         )
 
@@ -1574,9 +1577,10 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 'action:dns-brute',
                 stage_started,
                 [StageFinding(StageFindingKind.HOSTNAME, host) for host in resolved_pair],
+                activity_class=ActivityClass.DNS,
             )
         except Exception as error:
-            record_stage_result('action:dns-brute', stage_started, error=error)
+            record_stage_result('action:dns-brute', stage_started, error=error, activity_class=ActivityClass.DNS)
             output_logger.info(f'[!] DNS brute force failed: {error}')
         db = stash.StashManager()
         temp = set()
@@ -1637,6 +1641,7 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
             stage_started,
             [StageFinding(StageFindingKind.HOSTNAME, host) for host in dnsrev],
             reverse_error,
+            activity_class=ActivityClass.DNS,
         )
         if reverse_error is not None:
             output_logger.info(f'[!] Reverse DNS lookup failed: {reverse_error}')
@@ -1663,9 +1668,10 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                     )
                     for host, result in takeover_results.items()
                 ],
+                activity_class=ActivityClass.DIRECT,
             )
         except Exception as error:
-            record_stage_result('action:take-over', stage_started, error=error)
+            record_stage_result('action:take-over', stage_started, error=error, activity_class=ActivityClass.DIRECT)
             output_logger.info(f'[!] Takeover check failed: {error}')
 
     # Screenshots
@@ -1729,6 +1735,7 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
             stage_started,
             [StageFinding(StageFindingKind.SCREENSHOT, host) for host in screenshot_hosts],
             screenshot_error,
+            activity_class=ActivityClass.DIRECT,
         )
 
     # Shodan
@@ -1780,6 +1787,7 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
             stage_started,
             shodan_findings,
             shodan_errors[0] if shodan_errors else None,
+            activity_class=ActivityClass.PASSIVE,
         )
     else:
         pass
@@ -1878,16 +1886,17 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                     *(StageFinding(StageFindingKind.HTTP_METHOD, method) for method in sorted(methods)),
                     *(StageFinding(StageFindingKind.HTTP_STATUS_CODE, str(status_code)) for status_code in sorted(status_codes)),
                 ],
+                activity_class=ActivityClass.DIRECT,
             )
             output_logger.info('\n[+] API scanning completed successfully.')
 
         except MissingKey as error:
-            record_stage_result('action:api-scan', stage_started, error=error)
+            record_stage_result('action:api-scan', stage_started, error=error, activity_class=ActivityClass.DIRECT)
             output_logger.info('\n[!] API endpoint scanning requires a wordlist. Use -w to specify a wordlist file.')
             output_logger.info('    Creating a basic wordlist and trying again...')
             # The wordlist creation code above could be used here
         except Exception as e:
-            record_stage_result('action:api-scan', stage_started, error=e)
+            record_stage_result('action:api-scan', stage_started, error=e, activity_class=ActivityClass.DIRECT)
             output_logger.info(f'\n[!] An exception has occurred in API Endpoints scanning: {e}')
             output_logger.info('    Continuing with the rest of the scan...')
             traceback.print_exc()  # More detailed error information for developers

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -695,7 +695,16 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 elif engineitem == 'certspotter':
                     try:
                         certspotter_search = certspottersearch.SearchCertspoter(word)
-                        stor_lst.append(store(certspotter_search, engineitem))
+                        source_spec = get_source_spec(engineitem)
+                        evidence_sources.append(
+                            LegacyHostnameSource(
+                                name=source_spec.name,
+                                legacy_name=source_spec.name,
+                                family=source_spec.family,
+                                search=certspotter_search,
+                                proxy=use_proxy,
+                            )
+                        )
                     except ConnectionError as ce:
                         if not args.quiet:
                             output_logger.info(f'Network connection error while accessing Certspotter: {ce}')

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -728,10 +728,14 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                 elif engineitem == 'commoncrawl':
                     try:
                         commoncrawl_search = commoncrawl.SearchCommoncrawl(word, limit)
-                        stor_lst.append(
-                            store(
-                                commoncrawl_search,
-                                engineitem,
+                        source_spec = get_source_spec(engineitem)
+                        evidence_sources.append(
+                            LegacyHostnameSource(
+                                name=source_spec.name,
+                                legacy_name=source_spec.name,
+                                family=source_spec.family,
+                                search=commoncrawl_search,
+                                proxy=use_proxy,
                             )
                         )
                     except Exception as e:

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -10,6 +10,8 @@ import time
 import traceback
 from collections.abc import Awaitable, Iterable
 from contextlib import AsyncExitStack
+from dataclasses import replace
+from datetime import UTC, datetime
 from typing import Any
 
 import anyio
@@ -349,6 +351,7 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
     all_urls: list = []
     vhost: list = []
     word: str = args.domain.rstrip('\n')
+    run_started_at = datetime.now(UTC)
     takeover_status = args.take_over
     use_proxy = args.proxies
     linkedin_people_list_tracker: list = []
@@ -1485,6 +1488,7 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
     await handler(lst=stor_lst)
     if completed_run_result is None:
         completed_run_result = await execute_run(word, ())
+    completed_run_result = replace(completed_run_result, started_at=run_started_at)
     recorded_sources = {result.source.casefold() for result in stage_results}
     recorded_sources.update(execution.source.casefold() for execution in completed_run_result.source_executions)
     for engine in engines:

--- a/theHarvester/discovery/certspottersearch.py
+++ b/theHarvester/discovery/certspottersearch.py
@@ -2,6 +2,7 @@ import logging
 from urllib.parse import urlencode
 
 from theHarvester.lib.core import AsyncFetcher
+from theHarvester.lib.run import SourceFinding, SourceIncompleteError, SourcePartialError, SourceRateLimitedError
 
 logger = logging.getLogger(__name__)
 
@@ -20,10 +21,16 @@ class SearchCertspoter:
         self.totalhosts: set = set()
         self.proxy = False
 
+    def _incomplete_error(self, message: str) -> SourceIncompleteError:
+        findings = tuple(SourceFinding(host) for host in sorted(self.totalhosts))
+        error_type = SourcePartialError if findings else SourceIncompleteError
+        return error_type(message, findings=findings)
+
     async def do_search(self) -> None:
         base_url = 'https://api.certspotter.com/v1/issuances'
         cursor = None
         seen_cursors: set[str] = set()
+        incomplete = False
         try:
             for _ in range(self.MAX_PAGES):
                 params = {
@@ -37,20 +44,27 @@ class SearchCertspoter:
                 responses = await AsyncFetcher.fetch_all([f'{base_url}?{urlencode(params)}'], json=True, proxy=self.proxy)
                 if not responses:
                     logger.warning('Cert Spotter stopped early; results may be incomplete.')
-                    break
+                    raise self._incomplete_error('Cert Spotter returned no response')
 
                 page = responses[0]
                 if isinstance(page, dict):
                     code = page.get('code')
                     if isinstance(code, str):
                         logger.warning(f'Cert Spotter stopped early ({code}); results may be incomplete.')
+                        if code == 'rate_limited':
+                            raise SourceRateLimitedError(
+                                'Cert Spotter rate limit reached',
+                                findings=tuple(SourceFinding(host) for host in sorted(self.totalhosts)),
+                            )
                     else:
                         logger.warning('Cert Spotter stopped early; results may be incomplete.')
-                    break
+                    raise self._incomplete_error('Cert Spotter returned an error response')
                 if not isinstance(page, list):
                     logger.warning('Cert Spotter stopped early; results may be incomplete.')
-                    break
+                    raise self._incomplete_error('Cert Spotter returned an invalid response')
                 if not page:
+                    if incomplete:
+                        raise self._incomplete_error('Cert Spotter returned malformed issuance data')
                     break
 
                 malformed_issuance = False
@@ -86,6 +100,7 @@ class SearchCertspoter:
                         ):
                             self.totalhosts.add(name)
                 if malformed_issuance:
+                    incomplete = True
                     logger.warning('Cert Spotter ignored malformed issuance data; results may be incomplete.')
 
                 last_issuance = page[-1]
@@ -97,20 +112,25 @@ class SearchCertspoter:
                         'Cert Spotter stopped early because the response did not provide a valid cursor; '
                         'results may be incomplete.'
                     )
-                    break
+                    raise self._incomplete_error('Cert Spotter response did not provide a valid cursor')
                 if next_cursor in seen_cursors:
                     logger.warning(
                         'Cert Spotter stopped early because the response repeated a cursor; results may be incomplete.'
                     )
-                    break
+                    raise self._incomplete_error('Cert Spotter response repeated a cursor')
                 seen_cursors.add(next_cursor)
                 cursor = next_cursor
             else:
                 logger.warning('Cert Spotter page limit reached; results may be incomplete.')
+                raise self._incomplete_error('Cert Spotter page limit reached')
+        except SourceIncompleteError:
+            raise
         except ConnectionError:
             logger.warning('Cert Spotter network connection failed; results may be incomplete.')
+            raise self._incomplete_error('Cert Spotter network connection failed') from None
         except Exception:
             logger.warning('Cert Spotter stopped after an unexpected error; results may be incomplete.')
+            raise self._incomplete_error('Cert Spotter stopped after an unexpected error') from None
 
     async def get_hostnames(self) -> set:
         return self.totalhosts

--- a/theHarvester/discovery/commoncrawl.py
+++ b/theHarvester/discovery/commoncrawl.py
@@ -126,17 +126,23 @@ class SearchCommoncrawl:
                 [f'{self.hostname}/collinfo.json'], headers=headers, proxy=self.proxy, json=True
             )
             if not catalog_response or not isinstance(catalog_response[0], list) or not catalog_response[0]:
-                logger.error('Common Crawl API error: invalid index catalog')
-                return
+                raise RuntimeError('invalid index catalog')
 
             indexes = self._select_indexes(catalog_response[0])
             if not indexes:
-                logger.error('Common Crawl API error: index catalog contains no usable entries')
-                return
+                raise RuntimeError('Common Crawl index catalog contains no usable entries')
 
             records_seen = 0
             successful_queries = 0
             incomplete = False
+
+            def raise_if_incomplete() -> None:
+                if incomplete:
+                    raise SourcePartialError(
+                        'some Common Crawl queries failed',
+                        findings=tuple(SourceFinding(host) for host in sorted(self.totalhosts)),
+                    )
+
             for index in indexes:
                 endpoint = index['cdx-api']
                 for query in (f'*.{self.word}', f'{self.word}/*'):
@@ -152,6 +158,7 @@ class SearchCommoncrawl:
                         for first_page in range(0, page_limit, self.PAGE_BATCH_SIZE):
                             remaining = self.limit - records_seen
                             if remaining == 0:
+                                raise_if_incomplete()
                                 return
                             pages_in_batch = min(self.PAGE_BATCH_SIZE, page_limit - first_page, remaining)
                             per_page_limit, pages_with_extra_result = divmod(remaining, pages_in_batch)
@@ -168,6 +175,7 @@ class SearchCommoncrawl:
                                         raise ValueError('empty page response')
                                     for record in self._safe_parse_json_lines(response):
                                         if records_seen >= self.limit:
+                                            raise_if_incomplete()
                                             return
                                         records_seen += 1
                                         if isinstance(record, dict):
@@ -197,16 +205,13 @@ class SearchCommoncrawl:
 
             if not successful_queries and not self.totalhosts:
                 raise RuntimeError('all Common Crawl queries failed')
-            if incomplete:
-                raise SourcePartialError(
-                    'some Common Crawl queries failed',
-                    findings=tuple(SourceFinding(host) for host in sorted(self.totalhosts)),
-                )
+            raise_if_incomplete()
 
         except (RuntimeError, SourcePartialError):
             raise
         except Exception as error:
             logger.error(f'Common Crawl API error: {error}')
+            raise RuntimeError(f'Common Crawl request failed: {error}') from error
 
     async def get_hostnames(self) -> set:
         return self.totalhosts

--- a/theHarvester/discovery/commoncrawl.py
+++ b/theHarvester/discovery/commoncrawl.py
@@ -5,6 +5,7 @@ from types import ModuleType
 from urllib.parse import urlencode, urlsplit
 
 from theHarvester.lib.core import AsyncFetcher, Core
+from theHarvester.lib.run import SourceFinding, SourcePartialError
 
 logger = logging.getLogger(__name__)
 
@@ -135,6 +136,7 @@ class SearchCommoncrawl:
 
             records_seen = 0
             successful_queries = 0
+            incomplete = False
             for index in indexes:
                 endpoint = index['cdx-api']
                 for query in (f'*.{self.word}', f'{self.word}/*'):
@@ -174,12 +176,15 @@ class SearchCommoncrawl:
                                                 self.totalhosts.add(domain)
                                     query_succeeded = True
                                 except ValueError as error:
+                                    incomplete = True
                                     logger.warning(f'Common Crawl page error for index {index.get("id", "unknown")}: {error}')
                                 except Exception:
+                                    incomplete = True
                                     logger.warning(
                                         f'Common Crawl page error for index {index.get("id", "unknown")}: unexpected page failure'
                                     )
                         if page_count > page_limit:
+                            incomplete = True
                             logger.warning(
                                 f'Common Crawl page limit reached for index {index.get("id", "unknown")}; '
                                 'results may be incomplete'
@@ -187,12 +192,18 @@ class SearchCommoncrawl:
                         if query_succeeded:
                             successful_queries += 1
                     except Exception as error:
+                        incomplete = True
                         logger.warning(f'Common Crawl API error for index {index.get("id", "unknown")}: {error}')
 
             if not successful_queries and not self.totalhosts:
                 raise RuntimeError('all Common Crawl queries failed')
+            if incomplete:
+                raise SourcePartialError(
+                    'some Common Crawl queries failed',
+                    findings=tuple(SourceFinding(host) for host in sorted(self.totalhosts)),
+                )
 
-        except RuntimeError:
+        except (RuntimeError, SourcePartialError):
             raise
         except Exception as error:
             logger.error(f'Common Crawl API error: {error}')

--- a/theHarvester/discovery/commoncrawl.py
+++ b/theHarvester/discovery/commoncrawl.py
@@ -183,6 +183,8 @@ class SearchCommoncrawl:
                                             if domain.endswith(f'.{self.word}') or domain == self.word:
                                                 self.totalhosts.add(domain)
                                     query_succeeded = True
+                                except SourcePartialError:
+                                    raise
                                 except ValueError as error:
                                     incomplete = True
                                     logger.warning(f'Common Crawl page error for index {index.get("id", "unknown")}: {error}')
@@ -199,6 +201,8 @@ class SearchCommoncrawl:
                             )
                         if query_succeeded:
                             successful_queries += 1
+                    except SourcePartialError:
+                        raise
                     except Exception as error:
                         incomplete = True
                         logger.warning(f'Common Crawl API error for index {index.get("id", "unknown")}: {error}')

--- a/theHarvester/lib/dns_validation.py
+++ b/theHarvester/lib/dns_validation.py
@@ -1,10 +1,16 @@
 """DNS consensus evidence for current addressability.
 
-Discovery providers can report historical, stale, or wildcard-backed names. This
-module therefore preserves each DNS answer as evidence instead of treating one
-resolver lookup as truth. Every candidate and synthetic wildcard control is
-queried through exactly three distinct resolver vantages; two matching vantages
-form the quorum used for an addressability classification.
+Discovery providers can report historical, stale, or wildcard-backed names, so
+one provider hit is not proof that a name is currently addressable. This module
+retains each DNS answer instead of treating one resolver lookup as truth. Every
+candidate and synthetic wildcard control is queried through exactly three
+distinct resolver vantages. Two vantages must agree on address presence for the
+current-addressability quorum; their exact A or AAAA values may differ because
+of load balancing, geolocation, or normal DNS rotation.
+
+Synthetic controls prevent a wildcard response from making an invented label
+look like an exact DNS node. Failed and disagreeing resolver answers are kept so
+operators can distinguish absent names from incomplete or disputed evidence.
 """
 
 from __future__ import annotations
@@ -201,6 +207,8 @@ def _signature(observation: DnsValidationObservation) -> tuple[object, ...]:
 
 
 def _record_presence_signature(observation: DnsValidationObservation) -> tuple[object, ...]:
+    """Describe record presence without requiring resolver answers to match byte for byte."""
+
     return (
         observation.rcode,
         bool(observation.ipv4),
@@ -232,6 +240,13 @@ def _classify(
     *,
     deterministic_exact: bool,
 ) -> Addressability:
+    """Classify one candidate from wildcard controls and a two-of-three presence quorum.
+
+    Resolver answers do not need identical addresses. Large domains commonly
+    rotate or geolocate A and AAAA records, while agreement that an address is
+    present still supplies independent evidence of current addressability.
+    """
+
     if not deterministic_exact and _overlaps_wildcard(candidate_observations, controls):
         return Addressability.WILDCARD_INDISTINGUISHABLE
     addressable = sum(
@@ -254,10 +269,11 @@ def _classify(
 class DnsValidator:
     """Classify candidates with three resolver views and wildcard controls.
 
-    A two-of-three quorum limits the effect of one resolver's cache, filtering,
-    outage, or inconsistent delegation view. Synthetic high-entropy names probe
-    the closest enclosing domain for wildcard behavior so a wildcard answer is
-    not promoted as evidence that the candidate exists as an exact DNS node.
+    A two-of-three address-presence quorum limits the effect of one resolver's
+    cache, filtering, outage, or inconsistent delegation view without rejecting
+    legitimate load-balanced answers. Synthetic high-entropy names probe the
+    closest enclosing domain for wildcard behavior so a wildcard answer is not
+    promoted as evidence that the candidate exists as an exact DNS node.
     """
 
     def __init__(

--- a/theHarvester/lib/output.py
+++ b/theHarvester/lib/output.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 from xml.etree.ElementTree import Element, SubElement, tostring
 
 from theHarvester.lib.dns_validation import Addressability
-from theHarvester.lib.run import ScopeClass, StageFindingKind, legacy_hostnames
+from theHarvester.lib.run import ActivityClass, ScopeClass, StageFindingKind, legacy_hostnames
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -128,6 +128,21 @@ def format_run_terminal(result: RunResult) -> str:
         for value in entity_values
     }
     standalone_selected = [observation for observation in result.selected_observations if observation.value not in entity_values]
+    passive_stages = [stage.stage for stage in result.stage_executions if stage.activity_class is ActivityClass.PASSIVE]
+    dns_activities = [
+        *(['dns-consensus'] if result.dns_validations else []),
+        *(stage.stage for stage in result.stage_executions if stage.activity_class is ActivityClass.DNS),
+    ]
+    direct_activities = [stage.stage for stage in result.stage_executions if stage.activity_class is ActivityClass.DIRECT]
+    source_count = len(result.source_executions)
+    passive_summary = f'{source_count} source{"s" if source_count != 1 else ""}'
+    if passive_stages:
+        passive_summary = f'{passive_summary}, {", ".join(passive_stages)}'
+    activity_summary = (
+        f'[*] Activity summary: {ActivityClass.PASSIVE}={passive_summary}; '
+        f'{ActivityClass.DNS}={", ".join(dns_activities) or "none"}; '
+        f'{ActivityClass.DIRECT}={", ".join(direct_activities) or "none"}'
+    )
     selected_sections: list[str] = []
     for kind, title in (
         (StageFindingKind.EMAIL, 'Emails found'),
@@ -155,6 +170,7 @@ def format_run_terminal(result: RunResult) -> str:
             selected_sections.append(f'{observation.value} [status=observed; sources={observation.source}{detail}]')
     sections = [
         f'[*] Run status: {result.status}',
+        activity_summary,
         f'[*] Currently addressable subdomains ({len(primary)})',
         *(_entity_line(entity, selected_by_entity[entity.value]) for entity in primary),
         f'[*] Secondary evidence / needs review ({len(secondary)})',
@@ -246,9 +262,21 @@ def legacy_json_result(result: RunResult, existing: Mapping[str, object] | None 
 def evidence_xml_fragment(result: RunResult) -> str:
     evidence_run = Element('evidence_run', run_id=result.run_id, status=result.status)
     for execution in result.source_executions:
-        SubElement(evidence_run, 'source', name=execution.source, status=execution.status)
+        SubElement(
+            evidence_run,
+            'source',
+            name=execution.source,
+            status=execution.status,
+            activity_class=execution.activity_class,
+        )
     for stage_execution in result.stage_executions:
-        SubElement(evidence_run, 'stage', name=stage_execution.stage, status=stage_execution.status)
+        SubElement(
+            evidence_run,
+            'stage',
+            name=stage_execution.stage,
+            status=stage_execution.status,
+            activity_class=stage_execution.activity_class,
+        )
     for entity in result.entities:
         attributes = {
             'value': entity.value,

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -51,6 +51,12 @@ class RunStatus(StrEnum):
     FAILED = 'failed'
 
 
+class ActivityClass(StrEnum):
+    PASSIVE = 'P0 passive collection'
+    DNS = 'P1 DNS interaction'
+    DIRECT = 'P2 direct interaction'
+
+
 @dataclass(frozen=True)
 class SourceFinding:
     value: str
@@ -185,6 +191,7 @@ class SourceExecution:
     result_count: int
     observation_count: int
     entity_count: int
+    activity_class: ActivityClass = ActivityClass.PASSIVE
     error_type: str | None = None
 
     def to_dict(self) -> dict[str, object]:
@@ -197,6 +204,7 @@ class SourceExecution:
             'result_count': self.result_count,
             'observation_count': self.observation_count,
             'entity_count': self.entity_count,
+            'activity_class': self.activity_class,
             'error_type': self.error_type,
         }
 
@@ -211,6 +219,7 @@ class StageExecution:
     observation_count: int
     entity_count: int
     completed_at: datetime
+    activity_class: ActivityClass
     error_type: str | None = None
 
     def to_dict(self) -> dict[str, object]:
@@ -223,6 +232,7 @@ class StageExecution:
             'observation_count': self.observation_count,
             'entity_count': self.entity_count,
             'completed_at': self.completed_at.isoformat(),
+            'activity_class': self.activity_class,
             'error_type': self.error_type,
         }
 
@@ -328,6 +338,7 @@ class RunResult:
                     'error': observation.error,
                     'is_wildcard_control': observation.is_wildcard_control,
                     'wildcard_depth': observation.wildcard_depth,
+                    'activity_class': ActivityClass.DNS,
                 }
                 for observation in self.dns_validations
             ],
@@ -628,6 +639,13 @@ def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -
                 observation_count=len(findings),
                 entity_count=entity_count,
                 completed_at=stage.completed_at,
+                activity_class=(
+                    ActivityClass.DNS
+                    if stage.source in {'action:dns-brute', 'action:dns-lookup'}
+                    else ActivityClass.DIRECT
+                    if stage.source in {'action:api-scan', 'action:screenshot', 'action:take-over'}
+                    else ActivityClass.PASSIVE
+                ),
                 error_type=stage.error_type,
             )
             if source_key in recorded_stages:

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -271,7 +271,11 @@ class MergedEntity:
 
     @property
     def independent_corroboration_count(self) -> int:
-        """Count independent datasets, not adapters backed by the same data."""
+        """Count independent datasets, not the number of reporting adapters.
+
+        Two adapters backed by one provider can corroborate transport or parser
+        behavior, but they cannot independently corroborate the discovered name.
+        """
 
         return len({observation.source_family for observation in self.observations})
 

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -639,6 +639,7 @@ def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -
             }
         )
         if stage.is_action:
+            assert stage.activity_class is not None
             stage_execution = StageExecution(
                 run_id=result.run_id,
                 stage=stage.source,
@@ -648,7 +649,7 @@ def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -
                 observation_count=len(findings),
                 entity_count=entity_count,
                 completed_at=stage.completed_at,
-                activity_class=stage.activity_class or ActivityClass.PASSIVE,
+                activity_class=stage.activity_class,
                 error_type=stage.error_type,
             )
             if source_key in recorded_stages:

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -101,7 +101,12 @@ class StageResult:
     source_family: str | None = None
     error_type: str | None = None
     is_action: bool = False
+    activity_class: ActivityClass | None = None
     completed_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def __post_init__(self) -> None:
+        if self.is_action and self.activity_class is None:
+            raise ValueError('action stages require an explicit activity class')
 
 
 class SourceIncompleteError(Exception):
@@ -643,13 +648,7 @@ def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -
                 observation_count=len(findings),
                 entity_count=entity_count,
                 completed_at=stage.completed_at,
-                activity_class=(
-                    ActivityClass.DNS
-                    if stage.source in {'action:dns-brute', 'action:dns-lookup'}
-                    else ActivityClass.DIRECT
-                    if stage.source in {'action:api-scan', 'action:screenshot', 'action:take-over'}
-                    else ActivityClass.PASSIVE
-                ),
+                activity_class=stage.activity_class or ActivityClass.PASSIVE,
                 error_type=stage.error_type,
             )
             if source_key in recorded_stages:

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -39,6 +39,7 @@ class ScopeClass(StrEnum):
 
 class SourceStatus(StrEnum):
     SUCCEEDED = 'succeeded'
+    PARTIAL = 'partial'
     EMPTY = 'empty'
     FAILED = 'failed'
     RATE_LIMITED = 'rate-limited'
@@ -107,6 +108,10 @@ class SourceIncompleteError(Exception):
 
 class SourceRateLimitedError(SourceIncompleteError):
     status = SourceStatus.RATE_LIMITED
+
+
+class SourcePartialError(SourceIncompleteError):
+    status = SourceStatus.PARTIAL
 
 
 class PassiveSource(Protocol):
@@ -289,7 +294,7 @@ class RunResult:
             *(execution.status for execution in self.source_executions),
             *(execution.status for execution in self.stage_executions),
         ]
-        incomplete = {SourceStatus.FAILED, SourceStatus.RATE_LIMITED}
+        incomplete = {SourceStatus.PARTIAL, SourceStatus.FAILED, SourceStatus.RATE_LIMITED}
         if statuses and all(status is SourceStatus.FAILED for status in statuses):
             return RunStatus.FAILED
         if any(status in incomplete for status in statuses):

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -25,10 +25,12 @@ _ROUTE_CAPABILITIES = {
 
 @dataclass(frozen=True)
 class SourceSpec:
-    """Discovery routes and the independent evidence family for one source.
+    """Discovery routes and the corroboration dependency for one source.
 
-    Sources sharing an upstream dataset share a family. For example, ``shodan``
-    and ``shodanInternetDB`` are separate adapters but not independent evidence.
+    ``family`` is used only to count independent evidence. Sources sharing an
+    upstream dataset share a value so adapter count cannot inflate confidence.
+    For example, ``shodan`` and ``shodanInternetDB`` are separate adapters over
+    Shodan-backed data and therefore represent one corroborating source.
     """
 
     name: str
@@ -95,6 +97,7 @@ _SPECS = (
     _spec('securityscorecard', ResultRoute.HOSTS, ResultRoute.IPS),
     _spec('sherlockeye', ResultRoute.HOSTS, ResultRoute.EMAILS, ResultRoute.IPS),
     _spec('shodan', ResultRoute.HOSTS),
+    # InternetDB is another Shodan-backed view, not an independent witness.
     _spec('shodanInternetDB', ResultRoute.HOSTS, ResultRoute.IPS, family='shodan'),
     _spec('subdomaincenter', ResultRoute.HOSTS),
     _spec('subdomainfinderc99', ResultRoute.HOSTS),


### PR DESCRIPTION
## Summary

- start the evidence run before provider collection
- preserve partial Common Crawl and Cert Spotter findings with incomplete status
- fail closed when providers cannot prove completion
- classify selected operator actions separately from passive collection

## Operator impact

Operators can distinguish empty, complete, partial, and failed provider work while retaining useful findings already returned.

## Stack

Layer 9 of 10. Base: fix/completed-run-finalization.

Fork tracking: https://github.com/NotoriousRebel/theHarvester/issues/63

## Verification

Focused regressions cover Common Crawl, Cert Spotter, action classification, and run start ordering. The complete stack passed all required checks and both reviews.