### PR TITLE
feat: make completed output result first

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Never commit populated configuration files, API keys, account details, or provid
 ## Results and local data
 
 - Terminal output shows consolidated findings. Separately selected actions, such as `-s` / `--shodan`, may print their own enrichment.
-- `-f NAME` writes `NAME.json` and `NAME.xml`.
+- `-f NAME` writes `NAME.json`, `NAME.xml`, and `NAME.jsonl`.
 - Screenshots are written to the directory passed to `--screenshot`.
 - Host, email, IP, and related scan records are stored in `~/.local/share/theHarvester/stash.sqlite`.
 - REST queries return JSON.
@@ -228,6 +228,27 @@ The JSON report is a single object and is the more complete format for automatio
 | `takeover_results` | When non-empty | Optional takeover-check results. |
 
 The XML report contains the command, emails, hosts, and virtual hosts. Use JSON when you need the additional result types above.
+
+The JSONL report is a compact result stream. Its first line is a run summary;
+every remaining line is a flat result with a `type` and `value`. Common result
+types are `hostname`, `email`, `ip-address`, `asn`, `person`, `url`, and
+`interesting-url`. The `hostname` type is reserved for in-scope names beneath
+the target; the target itself appears only in the summary. Out-of-scope records
+use `scope-extension` or `external-relationship`.
+
+Extract subdomains, ASNs, or IP addresses directly:
+
+```bash
+jq -r 'select(.type == "hostname") | .value' report.jsonl
+jq -r 'select(.type == "asn") | .value' report.jsonl
+jq -r 'select(.type == "ip-address") | .value' report.jsonl
+```
+
+Export every result as tab-separated type and value columns:
+
+```bash
+jq -r 'select(.type != "summary") | [.type, .value] | @tsv' report.jsonl
+```
 
 List discovered hosts with [`jq`](https://jqlang.org/):
 

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -264,6 +264,10 @@ async def test_terminal_keeps_recognizable_non_host_sections() -> None:
 
 @pytest.mark.asyncio
 async def test_jsonl_is_a_compact_result_first_export() -> None:
+    class JsonlRunSource(TerminalRunSource):
+        async def collect(self, target: str) -> list[SourceFinding]:
+            return [*await super().collect(target), SourceFinding(target)]
+
     class ResultResolver(TerminalResolver):
         async def query(self, hostname: str) -> DnsResponse:
             if hostname == 'api.example.com':
@@ -273,7 +277,7 @@ async def test_jsonl_is_a_compact_result_first_export() -> None:
             return DnsResponse(ipv4=('198.51.100.99',))
 
     validator = DnsValidator(tuple(ResultResolver(f'resolver-{index}') for index in range(3)))
-    result = await execute_run('example.com', (CompletedRunSource(),), dns_validator=validator)
+    result = await execute_run('example.com', (JsonlRunSource(),), dns_validator=validator)
     result = complete_run(
         result,
         (
@@ -296,15 +300,28 @@ async def test_jsonl_is_a_compact_result_first_export() -> None:
         'status': 'complete',
         'started_at': result.started_at.isoformat(),
         'completed_at': result.completed_at.isoformat(),
-        'counts': {'email': 1, 'hostname': 2, 'ip-address': 1},
+        'counts': {
+            'email': 1,
+            'external-relationship': 1,
+            'hostname': 2,
+            'ip-address': 1,
+            'scope-extension': 1,
+        },
     }
     assert records[1:] == [
         {'type': 'hostname', 'value': 'api.example.com', 'status': 'currently-addressable'},
+        {'type': 'external-relationship', 'value': 'cdn.vendor.test', 'status': 'external-relationship'},
         {'type': 'hostname', 'value': 'old.example.com', 'status': 'not-currently-addressable'},
+        {'type': 'scope-extension', 'value': 'related.example.net', 'status': 'scope-extension-candidate'},
         {'type': 'email', 'value': 'ops@example.com'},
         {'type': 'ip-address', 'value': '192.0.2.10'},
     ]
+    assert [record['value'] for record in records if record['type'] == 'hostname'] == [
+        'api.example.com',
+        'old.example.com',
+    ]
     assert all('run_id' not in record and 'source' not in record for record in records)
+    assert all(record.get('value') != result.target for record in records)
     assert all(record.get('value') != '198.51.100.99' for record in records)
 
 

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -264,7 +264,15 @@ async def test_terminal_keeps_recognizable_non_host_sections() -> None:
 
 @pytest.mark.asyncio
 async def test_jsonl_is_a_compact_result_first_export() -> None:
-    validator = DnsValidator(tuple(TerminalResolver(f'resolver-{index}') for index in range(3)))
+    class ResultResolver(TerminalResolver):
+        async def query(self, hostname: str) -> DnsResponse:
+            if hostname == 'api.example.com':
+                return DnsResponse(ipv4=('192.0.2.10',))
+            if hostname == 'old.example.com':
+                return DnsResponse(rcode='NXDOMAIN')
+            return DnsResponse(ipv4=('198.51.100.99',))
+
+    validator = DnsValidator(tuple(ResultResolver(f'resolver-{index}') for index in range(3)))
     result = await execute_run('example.com', (CompletedRunSource(),), dns_validator=validator)
     result = complete_run(
         result,
@@ -297,6 +305,7 @@ async def test_jsonl_is_a_compact_result_first_export() -> None:
         {'type': 'ip-address', 'value': '192.0.2.10'},
     ]
     assert all('run_id' not in record and 'source' not in record for record in records)
+    assert all(record.get('value') != '198.51.100.99' for record in records)
 
 
 @pytest.mark.asyncio

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -204,14 +204,10 @@ async def test_activity_classes_are_serialized_and_summarized() -> None:
         ),
     )
 
-    records = [json.loads(line) for line in run_result_jsonl(result).splitlines()]
-    source = next(record['data'] for record in records if record['record_type'] == 'source_execution')
-    stages = {
-        record['data']['stage']: record['data']['activity_class']
-        for record in records
-        if record['record_type'] == 'stage_execution'
-    }
-    validations = [record['data'] for record in records if record['record_type'] == 'dns_validation_observation']
+    serialized = result.to_dict()
+    source = serialized['source_executions'][0]
+    stages = {record['stage']: record['activity_class'] for record in serialized['stage_executions']}
+    validations = serialized['dns_validations']
 
     assert source['activity_class'] == 'P0 passive collection'
     assert stages == {
@@ -267,30 +263,40 @@ async def test_terminal_keeps_recognizable_non_host_sections() -> None:
 
 
 @pytest.mark.asyncio
-async def test_jsonl_preserves_typed_records_provenance_and_timestamps() -> None:
+async def test_jsonl_is_a_compact_result_first_export() -> None:
     validator = DnsValidator(tuple(TerminalResolver(f'resolver-{index}') for index in range(3)))
     result = await execute_run('example.com', (CompletedRunSource(),), dns_validator=validator)
+    result = complete_run(
+        result,
+        (
+            StageResult(
+                'fixture-results',
+                SourceStatus.SUCCEEDED,
+                1,
+                1,
+                (StageFinding(StageFindingKind.EMAIL, 'ops@example.com'),),
+            ),
+        ),
+    )
 
     records = [json.loads(line) for line in run_result_jsonl(result).splitlines()]
 
-    assert {record['record_type'] for record in records} == {
-        'run',
-        'source_execution',
-        'discovery_observation',
-        'dns_validation_observation',
-        'merged_result',
+    assert records[0] == {
+        'schema_version': 'theharvester-results-v1',
+        'type': 'summary',
+        'target': 'example.com',
+        'status': 'complete',
+        'started_at': result.started_at.isoformat(),
+        'completed_at': result.completed_at.isoformat(),
+        'counts': {'email': 1, 'hostname': 2, 'ip-address': 1},
     }
-    assert all(record['schema_version'] == 'theharvester-evidence-v1' for record in records)
-    assert all(record['run_id'] == result.run_id for record in records)
-    discovery = [record['data'] for record in records if record['record_type'] == 'discovery_observation']
-    assert all(record['collected_at'] for record in discovery)
-    assert discovery[0]['provider_observed_at'] == '2026-07-15T12:00:00+00:00'
-    assert 'provider_observed_at' not in discovery[1]
-    validations = [record['data'] for record in records if record['record_type'] == 'dns_validation_observation']
-    assert all(record['validated_at'] for record in validations)
-    assert all('queried_at' not in record for record in validations)
-    merged = [record['data'] for record in records if record['record_type'] == 'merged_result']
-    assert all(record['provenance'] for record in merged)
+    assert records[1:] == [
+        {'type': 'hostname', 'value': 'api.example.com', 'status': 'currently-addressable'},
+        {'type': 'hostname', 'value': 'old.example.com', 'status': 'not-currently-addressable'},
+        {'type': 'email', 'value': 'ops@example.com'},
+        {'type': 'ip-address', 'value': '192.0.2.10'},
+    ]
+    assert all('run_id' not in record and 'source' not in record for record in records)
 
 
 @pytest.mark.asyncio
@@ -567,7 +573,10 @@ async def test_cli_finishes_selected_stages_before_persisting_and_reporting(
     jsonl = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
     assert legacy_json['evidence_run']['run_id'] == result.run_id
     assert evidence_xml.attrib['run_id'] == result.run_id
-    assert {record['record_type'] for record in jsonl} >= {'run', 'stage_execution', 'selected_observation'}
+    assert jsonl[0]['type'] == 'summary'
+    assert jsonl[0]['status'] == result.status
+    assert {record['type'] for record in jsonl[1:]} >= {'hostname', 'takeover', 'api-endpoint'}
+    assert all('run_id' not in record and 'source' not in record for record in jsonl)
     assert terminal.count('https://example.com/v1/status') == 1
     assert 'raw-provider-secret' not in terminal
     assert '[*] Interesting Urls found: 1' in terminal
@@ -698,12 +707,18 @@ async def test_cli_dns_validates_legacy_source_before_reporting(
     assert result.entities[0].addressability == 'currently-addressable'
     assert legacy_json['hosts'] == [f'{candidate}:192.0.2.10']
     assert [item.attrib['value'] for item in evidence_xml.findall('merged_result')] == [candidate]
-    assert '\n'.join(terminal_messages).count(f'{candidate} [status=currently-addressable') == 1
+    terminal = '\n'.join(terminal_messages)
+    assert terminal.count(f'{candidate} [status=currently-addressable') == 1
+    assert (
+        f'Command: theHarvester -d example.com -b certspotter -r 192.0.2.53,192.0.2.54,192.0.2.55 '
+        f'-f {report} -q'
+    ) in terminal
+    assert 'DNS: resolve (-r)=on (192.0.2.53,192.0.2.54,192.0.2.55); lookup (-n)=off; brute force (-c)=off' in terminal
     assert FakeRunStore.saved == [result]
 
 
 @pytest.mark.asyncio
-async def test_cli_records_provider_people_in_the_completed_run(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_cli_reports_effective_options_and_keeps_dns_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     import theHarvester.__main__ as main_module
 
     class FakeVenacusSearch:
@@ -736,9 +751,17 @@ async def test_cli_records_provider_people_in_the_completed_run(monkeypatch: pyt
         async def save(self, _result) -> None:
             return None
 
+    class UnexpectedDns:
+        def __init__(self, *_args) -> None:
+            raise AssertionError('DNS must remain off unless -r is supplied')
+
+    terminal_messages: list[str] = []
     monkeypatch.setattr(main_module.venacussearch, 'SearchVenacus', FakeVenacusSearch)
+    monkeypatch.setattr(main_module, 'AioDnsResolverVantage', UnexpectedDns)
+    monkeypatch.setattr(main_module.hostchecker, 'Checker', UnexpectedDns)
     monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
     monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore)
+    monkeypatch.setattr(main_module.output_logger, 'info', lambda message, *_args: terminal_messages.append(str(message)))
 
     response = await main_module.start(
         SimpleNamespace(
@@ -767,6 +790,14 @@ async def test_cli_records_provider_people_in_the_completed_run(monkeypatch: pyt
         (StageFindingKind.PERSON, '{"name":"Alice"}')
     }
     assert all(item.collected_at >= result.started_at for item in result.selected_observations)
+    terminal = '\n'.join(terminal_messages)
+    assert '[*] Run configuration' in terminal
+    assert 'Target (-d): example.com' in terminal
+    assert 'Sources (-b): venacus' in terminal
+    assert 'Search: start (-S)=0; limit (-l)=500; proxies (-p)=off' in terminal
+    assert 'DNS: resolve (-r)=off; lookup (-n)=off; brute force (-c)=off' in terminal
+    assert 'Actions: Shodan (-s)=off; takeover (-t)=off; screenshots (--screenshot)=off; API scan (-a)=off' in terminal
+    assert 'Output (-f): terminal only' in terminal
 
 
 @pytest.mark.asyncio
@@ -903,7 +934,7 @@ async def test_cli_serializes_incomplete_provider_findings(
     assert result.status is RunStatus.PARTIAL
     assert result.source_executions[0].status is expected_status
     records = [json.loads(line) for line in run_result_jsonl(result).splitlines()]
-    assert any(record['data'].get('value') == 'survivor.example.com' for record in records)
+    assert any(record.get('value') == 'survivor.example.com' for record in records)
 
 
 @pytest.mark.asyncio
@@ -1055,7 +1086,7 @@ async def test_incomplete_source_states_remain_visible_on_every_output(
 
     assert f'Run status: {expected_run_status}' in terminal
     assert f'fixture [status={expected_source_status}' in terminal
-    assert records[0]['data']['status'] == expected_run_status
+    assert records[0]['status'] == expected_run_status
     assert legacy['evidence_run']['status'] == expected_run_status
     assert evidence_xml.attrib['status'] == expected_run_status
 

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -245,6 +245,13 @@ async def test_terminal_keeps_recognizable_non_host_sections() -> None:
                     StageFinding(StageFindingKind.INTERESTING_URL, 'https://example.com/status'),
                 ),
             ),
+            StageResult(
+                'second-fixture',
+                SourceStatus.SUCCEEDED,
+                1,
+                1,
+                (StageFinding(StageFindingKind.IP_ADDRESS, '192.0.2.10'),),
+            ),
         ),
     )
 
@@ -256,6 +263,7 @@ async def test_terminal_keeps_recognizable_non_host_sections() -> None:
     assert '[*] People found: 1' in terminal
     assert '[*] Interesting Urls found: 1' in terminal
     assert 'ops@example.com [status=observed; sources=fixture]' in terminal
+    assert terminal.count('192.0.2.10 [status=observed; sources=fixture,second-fixture]') == 1
 
 
 @pytest.mark.asyncio

--- a/tests/lib/test_output.py
+++ b/tests/lib/test_output.py
@@ -27,7 +27,7 @@ class CompletedOutputSource:
 
 
 @pytest.mark.asyncio
-async def test_completed_run_adapters_share_one_versioned_result() -> None:
+async def test_completed_run_adapters_share_one_result() -> None:
     result = await execute_run('example.com', (CompletedOutputSource(),))
 
     records = [json.loads(line) for line in run_result_jsonl(result).splitlines()]
@@ -35,13 +35,10 @@ async def test_completed_run_adapters_share_one_versioned_result() -> None:
     evidence_xml = ElementTree.fromstring(evidence_xml_fragment(result))
     terminal = format_run_terminal(result)
 
-    assert {record['record_type'] for record in records} == {
-        'run',
-        'source_execution',
-        'discovery_observation',
-        'merged_result',
-    }
-    assert all(record['schema_version'] == 'theharvester-evidence-v1' for record in records)
+    assert records[0]['schema_version'] == 'theharvester-results-v1'
+    assert records[0]['counts'] == {'hostname': 1}
+    assert records[1] == {'type': 'hostname', 'value': 'api.example.com', 'status': 'needs-review'}
+    assert all('run_id' not in record and 'source' not in record for record in records)
     assert legacy['emails'] == ['ops@example.com']
     assert legacy['hosts'] == ['api.example.com']
     assert evidence_xml.attrib['run_id'] == result.run_id

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -92,6 +92,15 @@ def test_readme_api_key_markers_match_configuration() -> None:
     assert {source for source, marker in requirements.items() if marker == 'Optional'} == OPTIONAL_API_KEY_SOURCES
 
 
+def test_readme_documents_flat_jsonl_result_filters() -> None:
+    readme = Path('README.md').read_text()
+
+    assert '`NAME.jsonl`' in readme
+    assert "select(.type == \"hostname\") | .value" in readme
+    assert "select(.type == \"asn\") | .value" in readme
+    assert "select(.type == \"ip-address\") | .value" in readme
+
+
 def test_wiki_navigation_and_readme_links_resolve() -> None:
     wiki_dir = Path('docs/wiki')
     assert {path.name for path in wiki_dir.glob('*.md')} == WIKI_PAGES

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import secrets
+import shlex
 import string
 import sys
 import time
@@ -225,7 +226,7 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
     parser.add_argument(
         '-f',
         '--filename',
-        help='Save XML, legacy JSON, and normalized JSONL reports.',
+        help='Save XML, legacy JSON, and compact JSONL result reports.',
         default='',
         type=str,
     )
@@ -590,7 +591,32 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
         engines = Core.expand_source_selection(args.source)
         # Iterate through search engines in order
         if set(engines).issubset(Core.get_supportedengines()):
-            output_logger.info(f'\n[*] Target: {word} \n')
+            if dnsresolve == '':
+                dns_resolution = 'off'
+            elif dnsresolve is None:
+                dns_resolution = 'on (system resolver)'
+            elif final_dns_resolver_list:
+                dns_resolution = f'on ({",".join(final_dns_resolver_list)})'
+            else:
+                dns_resolution = 'off (no valid resolvers)'
+            output_logger.info(
+                '\n'.join(
+                    (
+                        '\n[*] Run configuration',
+                        *((f'Command: {shlex.join(sys.argv)}',) if rest_args is None else ()),
+                        f'Target (-d): {word}',
+                        f'Sources (-b): {",".join(engines)}',
+                        f'Search: start (-S)={start}; limit (-l)={limit}; proxies (-p)={"on" if use_proxy else "off"}',
+                        f'DNS: resolve (-r)={dns_resolution}; lookup (-n)={"on" if dnslookup else "off"}; '
+                        f'brute force (-c)={"on" if dnsbrute[0] else "off"}',
+                        f'Actions: Shodan (-s)={"on" if shodan else "off"}; '
+                        f'takeover (-t)={"on" if takeover_status else "off"}; '
+                        f'screenshots (--screenshot)={getattr(args, "screenshot", "") or "off"}; '
+                        f'API scan (-a)={"on" if getattr(args, "api_scan", False) else "off"}',
+                        f'Output (-f): {filename or "terminal only"}',
+                    )
+                )
+            )
 
             for engineitem in engines:
                 if engineitem == 'baidu':

--- a/theHarvester/lib/output.py
+++ b/theHarvester/lib/output.py
@@ -164,10 +164,15 @@ def format_run_terminal(result: RunResult) -> str:
         observations = [observation for observation in standalone_selected if observation.kind is kind]
         if not observations:
             continue
-        selected_sections.append(f'[*] {title}: {len(observations)}')
+        by_value: dict[str, list[SelectedObservation]] = {}
         for observation in observations:
-            detail = f'; detail={observation.detail}' if observation.detail is not None else ''
-            selected_sections.append(f'{observation.value} [status=observed; sources={observation.source}{detail}]')
+            by_value.setdefault(observation.value, []).append(observation)
+        selected_sections.append(f'[*] {title}: {len(by_value)}')
+        for value, value_observations in sorted(by_value.items()):
+            sources = ','.join(sorted({observation.source for observation in value_observations}))
+            details = ', '.join(sorted({observation.detail for observation in value_observations if observation.detail}))
+            detail = f'; detail={details}' if details else ''
+            selected_sections.append(f'{value} [status=observed; sources={sources}{detail}]')
     sections = [
         f'[*] Run status: {result.status}',
         activity_summary,

--- a/theHarvester/lib/output.py
+++ b/theHarvester/lib/output.py
@@ -205,10 +205,16 @@ def format_run_terminal(result: RunResult) -> str:
 
 def run_result_jsonl(result: RunResult) -> str:
     """Serialize one summary followed by deduplicated operator results."""
-    result_records: list[dict[str, object]] = [
-        {'type': 'hostname', 'value': entity.value, 'status': _entity_status(entity)}
-        for entity in sorted(result.entities, key=lambda entity: entity.value)
-    ]
+    result_records: list[dict[str, object]] = []
+    for entity in sorted(result.entities, key=lambda entity: entity.value):
+        if entity.value == result.target:
+            continue
+        result_type = str(StageFindingKind.HOSTNAME)
+        if ScopeClass.SCOPE_EXTENSION in entity.scope_classes:
+            result_type = str(ScopeClass.SCOPE_EXTENSION)
+        elif ScopeClass.EXTERNAL_RELATIONSHIP in entity.scope_classes:
+            result_type = str(ScopeClass.EXTERNAL_RELATIONSHIP)
+        result_records.append({'type': result_type, 'value': entity.value, 'status': _entity_status(entity)})
     selected: dict[tuple[str, str], set[str]] = {}
     for observation in result.selected_observations:
         details = selected.setdefault((str(observation.kind), observation.value), set())

--- a/theHarvester/lib/output.py
+++ b/theHarvester/lib/output.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, TypeVar
 from xml.etree.ElementTree import Element, SubElement, tostring
 
 from theHarvester.lib.dns_validation import Addressability
-from theHarvester.lib.run import ActivityClass, ScopeClass, StageFindingKind, legacy_hostnames
+from theHarvester.lib.run import ActivityClass, ScopeClass, StageFindingKind, legacy_dns_results, legacy_hostnames
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -214,9 +214,8 @@ def run_result_jsonl(result: RunResult) -> str:
         details = selected.setdefault((str(observation.kind), observation.value), set())
         if observation.detail:
             details.add(observation.detail)
-    for dns_observation in result.dns_validations:
-        for address in (*dns_observation.ipv4, *dns_observation.ipv6):
-            selected.setdefault((str(StageFindingKind.IP_ADDRESS), address), set())
+    for address in legacy_dns_results(result)[2]:
+        selected.setdefault((str(StageFindingKind.IP_ADDRESS), address), set())
     for (kind, value), details in sorted(selected.items()):
         record: dict[str, object] = {'type': kind, 'value': value}
         if details:

--- a/theHarvester/lib/output.py
+++ b/theHarvester/lib/output.py
@@ -4,7 +4,7 @@ import json
 import logging
 import sys
 from collections.abc import Hashable, Iterable, Sequence
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, TypeVar
 from xml.etree.ElementTree import Element, SubElement, tostring
 
 from theHarvester.lib.dns_validation import Addressability
@@ -87,15 +87,19 @@ def print_linkedin_sections(
             output_logger.info(link)
 
 
-def _entity_line(entity: MergedEntity, selected: Sequence[SelectedObservation] = ()) -> str:
-    sources = ','.join(sorted({observation.source for observation in entity.observations}))
-    selected_status = ''.join(f'; {observation.kind}={observation.detail or "observed"}' for observation in selected)
-    status = (
+def _entity_status(entity: MergedEntity) -> str:
+    return str(
         entity.addressability
         or ('scope-extension-candidate' if ScopeClass.SCOPE_EXTENSION in entity.scope_classes else None)
         or ('external-relationship' if ScopeClass.EXTERNAL_RELATIONSHIP in entity.scope_classes else None)
         or 'needs-review'
     )
+
+
+def _entity_line(entity: MergedEntity, selected: Sequence[SelectedObservation] = ()) -> str:
+    sources = ','.join(sorted({observation.source for observation in entity.observations}))
+    selected_status = ''.join(f'; {observation.kind}={observation.detail or "observed"}' for observation in selected)
+    status = _entity_status(entity)
     return f'{entity.value} [status={status}; sources={sources}{selected_status}]'
 
 
@@ -200,33 +204,39 @@ def format_run_terminal(result: RunResult) -> str:
 
 
 def run_result_jsonl(result: RunResult) -> str:
-    """Serialize a completed run as versioned, normalized evidence records."""
-    serialized = result.to_dict()
-    records: list[tuple[str, dict[str, Any]]] = [('run', _run_record(result))]
-    records.extend(('source_execution', item) for item in cast('list[dict[str, Any]]', serialized['source_executions']))
-    records.extend(('stage_execution', item) for item in cast('list[dict[str, Any]]', serialized['stage_executions']))
-    records.extend(('discovery_observation', item) for item in cast('list[dict[str, Any]]', serialized['observations']))
-    for item in cast('list[dict[str, Any]]', serialized['dns_validations']):
-        validation = dict(item)
-        validation['validated_at'] = validation.pop('queried_at')
-        records.append(('dns_validation_observation', validation))
-    for item in cast('list[dict[str, Any]]', serialized['entities']):
-        merged = dict(item)
-        merged['provenance'] = merged.pop('observations')
-        records.append(('merged_result', merged))
-    records.extend(('selected_observation', item) for item in cast('list[dict[str, Any]]', serialized['selected_observations']))
-    return '\n'.join(
-        json.dumps(
-            {
-                'schema_version': 'theharvester-evidence-v1',
-                'run_id': result.run_id,
-                'target': result.target,
-                'record_type': record_type,
-                'data': data,
-            }
-        )
-        for record_type, data in records
-    )
+    """Serialize one summary followed by deduplicated operator results."""
+    result_records: list[dict[str, object]] = [
+        {'type': 'hostname', 'value': entity.value, 'status': _entity_status(entity)}
+        for entity in sorted(result.entities, key=lambda entity: entity.value)
+    ]
+    selected: dict[tuple[str, str], set[str]] = {}
+    for observation in result.selected_observations:
+        details = selected.setdefault((str(observation.kind), observation.value), set())
+        if observation.detail:
+            details.add(observation.detail)
+    for dns_observation in result.dns_validations:
+        for address in (*dns_observation.ipv4, *dns_observation.ipv6):
+            selected.setdefault((str(StageFindingKind.IP_ADDRESS), address), set())
+    for (kind, value), details in sorted(selected.items()):
+        record: dict[str, object] = {'type': kind, 'value': value}
+        if details:
+            record['details'] = sorted(details)
+        result_records.append(record)
+
+    counts: dict[str, int] = {}
+    for record in result_records:
+        kind = str(record['type'])
+        counts[kind] = counts.get(kind, 0) + 1
+    summary = {
+        'schema_version': 'theharvester-results-v1',
+        'type': 'summary',
+        'target': result.target,
+        'status': result.status,
+        'started_at': result.started_at.isoformat(),
+        'completed_at': result.completed_at.isoformat(),
+        'counts': dict(sorted(counts.items())),
+    }
+    return '\n'.join(json.dumps(record) for record in (summary, *result_records))
 
 
 def _run_record(result: RunResult) -> dict[str, object]:


### PR DESCRIPTION
## Summary

- show the exact command and effective configuration in terminal output
- make JSONL a compact summary followed by flat type and value result records
- omit repeated run IDs, sources, wildcard controls, and disputed DNS addresses from compact JSONL
- document direct jq extraction for hostnames, ASNs, IP addresses, and all results

## Operator impact

People can understand how a run was invoked from the terminal and parse the result types they care about with one jq selector. Full provenance remains available through RunResult, SQLite, REST, JSON, and XML.

## Stack

Layer 10 of 10. Base: fix/completed-evidence-semantics.

Fork tracking: https://github.com/NotoriousRebel/theHarvester/issues/63

## Verification

The complete stack at d7a38459 passed 308 tests with 6 skipped, Ruff, formatting, mypy, git diff --check, zero em dashes, and parallel Standards and Spec reviews.