### PR TITLE
Fix screenshot paths on macOS

### DIFF
--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from theHarvester.screenshot import screenshot
+
+
+@pytest.mark.parametrize(
+    ('platform', 'expected_separator'),
+    [
+        ('darwin', '/'),
+        ('linux', '/'),
+        ('win32', '\\'),
+    ],
+)
+def test_screenshot_output_separator_matches_platform(monkeypatch, platform: str, expected_separator: str) -> None:
+    monkeypatch.setattr(screenshot.sys, 'platform', platform)
+
+    shotter = screenshot.ScreenShotter('screenshots')
+
+    assert shotter.slash == expected_separator

--- a/theHarvester/screenshot/screenshot.py
+++ b/theHarvester/screenshot/screenshot.py
@@ -17,7 +17,7 @@ from playwright.async_api import async_playwright
 class ScreenShotter:
     def __init__(self, output) -> None:
         self.output = output
-        self.slash = '\\' if 'win' in sys.platform else '/'
+        self.slash = '\\' if sys.platform.startswith('win') else '/'
         self.slash = '' if (self.output[-1] == '\\' or self.output[-1] == '/') else self.slash
 
     def verify_path(self) -> bool:


### PR DESCRIPTION
## Summary

- treat only `win*` platform identifiers as Windows when constructing screenshot output paths
- add regression coverage for Darwin, Linux, and Windows platform strings

## Root cause

The screenshot module selected the Windows path separator with `"win" in sys.platform`. On macOS, `sys.platform` is `darwin`, which also contains the substring `win`. As a result, screenshot output paths used backslashes on macOS and could create files with backslashes in their names instead of placing them in the requested directory.

Using `sys.platform.startswith("win")` preserves the Windows behavior without misclassifying Darwin.

## Validation

- `pytest`: 123 passed
- `ruff check`: passed
- `ruff format --check`: passed
- `mypy`: passed for the changed source module
- `git diff --check`: passed
