### PR TITLE
fix: separate RapidDNS host and IP evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Read the **API key** column as follows:
 | `otx` | ✓ | No | ✓ | No | No | No | No | No |
 | `pentesttools` | ✓ | No | No | No | No | No | No | ✓ |
 | `projectdiscovery` | ✓ | No | No | No | No | No | No | ✓ |
-| `rapiddns` | ✓ | No | No | No | No | No | No | No |
+| `rapiddns` | ✓ | No | ✓ | No | No | No | No | No |
 | `robtex` | ✓ | No | ✓ | No | No | No | No | No |
 | `rocketreach` | No | ✓ | No | No | ✓ | No | No | ✓ |
 | `securityscorecard` | ✓ | No | ✓ | No | No | No | `POST /additional/security-score` response | ✓ |

--- a/tests/discovery/test_rapiddns.py
+++ b/tests/discovery/test_rapiddns.py
@@ -1,0 +1,140 @@
+import asyncio
+import json
+import sys
+import xml.etree.ElementTree as ElementTree
+from argparse import Namespace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import theHarvester.__main__ as theharvester_main
+from theHarvester.discovery import rapiddns
+from theHarvester.lib.output import configure_logging
+
+RAPID_DNS_HTML = """
+<table><tbody>
+  <tr><td>api.example.com</td><td>192.0.2.1</td><td>A</td></tr>
+  <tr><td>broken.example.com</td><td>not-an-ip</td><td>A</td></tr>
+  <tr><td>alias.example.com</td><td>target.example.net</td><td>CNAME</td></tr>
+</tbody></table>
+"""
+
+
+async def fake_fetch_all(_urls: list[str], **_kwargs: Any) -> list[str]:
+    await asyncio.sleep(0)
+    return [RAPID_DNS_HTML]
+
+
+@pytest.mark.asyncio
+async def test_rapiddns_separates_hostnames_ips_and_associations(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rapiddns.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = rapiddns.SearchRapidDns('example.com')
+
+    await search.process()
+
+    hostnames = await search.get_hostnames()
+    assert isinstance(hostnames, list)
+    assert set(hostnames) == {
+        'alias.example.com',
+        'api.example.com',
+        'broken.example.com',
+    }
+    assert await search.get_ips() == {'192.0.2.1'}
+    assert await search.get_host_ip_pairs() == {('api.example.com', '192.0.2.1')}
+
+
+@pytest.mark.asyncio
+async def test_rapiddns_evidence_reaches_existing_outputs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    stored: list[tuple[str, tuple[str, ...], str]] = []
+
+    class FakeStash:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, _domain: str, values: list[str], result_type: str, source: str) -> None:
+            stored.append((result_type, tuple(sorted(values)), source))
+
+        async def store(self, _domain: str, value: str, result_type: str, source: str) -> None:
+            stored.append((result_type, (value,), source))
+
+    class UnexpectedChecker:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            raise AssertionError('DNS resolution requires the explicit --dns-resolve flag')
+
+    class FakeDehashed:
+        def __init__(self, _domain: str) -> None:
+            pass
+
+        async def process(self, _proxy: bool) -> None:
+            return None
+
+        async def get_ips(self) -> set[str]:
+            return {'198.51.100.2'}
+
+    report = tmp_path / 'rapiddns-report'
+    monkeypatch.setattr(rapiddns.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(theharvester_main.stash, 'StashManager', FakeStash)
+    monkeypatch.setattr(theharvester_main.hostchecker, 'Checker', UnexpectedChecker)
+    monkeypatch.setattr(theharvester_main.search_dehashed, 'SearchDehashed', FakeDehashed)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['theHarvester', '-d', 'example.com', '-b', 'rapiddns', '-f', str(report)],
+    )
+    configure_logging(verbose=False)
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    assert stored == [
+        ('host', ('alias.example.com', 'api.example.com', 'broken.example.com'), 'rapiddns'),
+        ('ip', ('192.0.2.1',), 'rapiddns'),
+    ]
+
+    report_json = json.loads(report.with_suffix('.json').read_text())
+    assert report_json['hosts'] == ['alias.example.com', 'api.example.com', 'broken.example.com']
+    assert report_json['ips'] == ['192.0.2.1']
+
+    xml_hosts = {
+        (element.findtext('hostname') or (element.text or '').strip(), element.findtext('ip'))
+        for element in ElementTree.parse(report.with_suffix('.xml')).getroot().findall('host')
+    }
+    assert xml_hosts == {
+        ('alias.example.com', None),
+        ('api.example.com', '192.0.2.1'),
+        ('broken.example.com', None),
+    }
+
+    console = capsys.readouterr().out
+    assert {'alias.example.com', 'api.example.com', 'broken.example.com', '192.0.2.1'} <= set(console.splitlines())
+
+    rest_results = await theharvester_main.start(
+        Namespace(
+            source='dehashed,rapiddns',
+            dns_brute=False,
+            filename='',
+            quiet=True,
+            dns_lookup=False,
+            dns_server=None,
+            dns_resolve='',
+            limit=500,
+            shodan=False,
+            start=0,
+            domain='example.com',
+            take_over=False,
+            proxies=False,
+        )
+    )
+    assert set(rest_results[6]) == {'192.0.2.1', '198.51.100.2'}
+    assert rest_results[8] == ['alias.example.com', 'api.example.com', 'broken.example.com']
+    assert stored[2:] == [
+        ('ip', ('198.51.100.2',), 'dehashed'),
+        ('host', ('alias.example.com', 'api.example.com', 'broken.example.com'), 'rapiddns'),
+        ('ip', ('192.0.2.1',), 'rapiddns'),
+    ]

--- a/tests/lib/test_source_catalog.py
+++ b/tests/lib/test_source_catalog.py
@@ -55,6 +55,10 @@ def test_source_specs_describe_consolidated_routes_not_getter_presence() -> None
     )
 
 
+def test_rapiddns_declares_separate_subdomain_and_ip_routes() -> None:
+    assert SOURCE_SPECS['rapiddns'].routes == frozenset({ResultRoute.SUBDOMAINS, ResultRoute.IPS})
+
+
 def test_capability_selection_preserves_every_declared_route() -> None:
     assert 'venacus' in Core.expand_source_selection('emails')
     assert get_source_spec('venacus').routes == frozenset(

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -316,6 +316,7 @@ async def start(rest_args: argparse.Namespace | None = None):
     engines: list = []
     # If the user specifies
     full: list = []
+    reported_host_ip_pairs: set[tuple[str, str]] = set()
     ips: list = []
     host_ip: list = []
     limit: int = args.limit
@@ -363,7 +364,13 @@ async def start(rest_args: argparse.Namespace | None = None):
         if ResultRoute.SUBDOMAINS in routes:
             discovered_hosts = await search_engine.get_hostnames()
             host_names = list(_normalize_hosts_for_storage(discovered_hosts, word))
-            if source != 'hackertarget' and source != 'pentesttools' and source != 'rapiddns':
+            if source == 'rapiddns':
+                for host, address in await search_engine.get_host_ip_pairs():
+                    normalized = normalize_scoped_hostname(host, word)
+                    if normalized and normalized in host_names:
+                        reported_host_ip_pairs.add((normalized, address))
+                full.extend(host_names)
+            elif source != 'hackertarget' and source != 'pentesttools':
                 # If a source is inside this conditional, it means the hosts returned must be resolved to obtain ip
                 # This should only be checked if --dns-resolve has a wordlist
                 if dnsresolve is None or len(final_dns_resolver_list) > 0:
@@ -393,7 +400,7 @@ async def start(rest_args: argparse.Namespace | None = None):
         if ResultRoute.IPS in routes:
             ips_list = await search_engine.get_ips()
             all_ip.extend(ips_list)
-            await db_stash.store_all(word, all_ip, 'ip', source)
+            await db_stash.store_all(word, ips_list, 'ip', source)
 
         if ResultRoute.PEOPLE in routes:
             people_list = await search_engine.get_people()
@@ -1610,7 +1617,12 @@ async def start(rest_args: argparse.Namespace | None = None):
                 await file.write('<cmd>' + ' '.join(sanitized_args) + '</cmd>')
                 for email in all_emails:
                     await file.write('<email>' + sanitize_for_xml(email) + '</email>')
+                paired_hosts = {host for host, _ip in reported_host_ip_pairs}
+                for host, ip in sorted(reported_host_ip_pairs):
+                    await file.write(f'<host><ip>{sanitize_for_xml(ip)}</ip><hostname>{sanitize_for_xml(host)}</hostname></host>')
                 for x in full:
+                    if x in paired_hosts:
+                        continue
                     host, ip = x.split(':', 1) if ':' in x else (x, '')
                     if ip and len(ip) > 3:
                         await file.write(

--- a/theHarvester/discovery/rapiddns.py
+++ b/theHarvester/discovery/rapiddns.py
@@ -1,3 +1,4 @@
+import ipaddress
 import logging
 
 from bs4 import BeautifulSoup
@@ -11,7 +12,9 @@ logger = logging.getLogger(__name__)
 class SearchRapidDns:
     def __init__(self, word) -> None:
         self.word = word
-        self.total_results: list = []
+        self.totalhosts: set[str] = set()
+        self.totalips: set[str] = set()
+        self.host_ip_pairs: set[tuple[str, str]] = set()
         self.proxy = False
 
     async def do_search(self):
@@ -22,14 +25,14 @@ class SearchRapidDns:
             urls = [f'https://rapiddns.io/subdomain/{self.word}?full=1#result']
             responses = await AsyncFetcher.fetch_all(urls, headers=headers, proxy=self.proxy)
             if len(responses[0]) <= 1:
-                return self.total_results
+                return
             soup = BeautifulSoup(responses[0], 'html.parser')
             table_el = soup.find('table')
             if not isinstance(table_el, Tag):
-                return self.total_results
+                return
             tbody_el = table_el.find('tbody')
             if not isinstance(tbody_el, Tag):
-                return self.total_results
+                return
             rows = tbody_el.find_all('tr')
             if rows:
                 # Validation check
@@ -37,14 +40,20 @@ class SearchRapidDns:
                     if not isinstance(row, Tag):
                         continue
                     cells = row.find_all('td')
-                    if len(cells) > 0:
-                        # sanity check
-                        subdomain = str(cells[0].get_text())
-                        if cells[-1].get_text() == 'CNAME':
-                            self.total_results.append(f'{subdomain}')
-                        else:
-                            self.total_results.append(f'{subdomain}:{str(cells[1].get_text()).strip()}')
-                self.total_results = list({domain for domain in self.total_results})
+                    if len(cells) < 2:
+                        continue
+                    subdomain = cells[0].get_text(strip=True)
+                    if not subdomain:
+                        continue
+                    self.totalhosts.add(subdomain)
+                    if cells[-1].get_text(strip=True).upper() not in {'A', 'AAAA'}:
+                        continue
+                    try:
+                        address = str(ipaddress.ip_address(cells[1].get_text(strip=True)))
+                    except ValueError:
+                        continue
+                    self.totalips.add(address)
+                    self.host_ip_pairs.add((subdomain, address))
         except Exception as e:
             logger.info(f'An exception has occurred: {e!s}')
 
@@ -52,5 +61,11 @@ class SearchRapidDns:
         self.proxy = proxy
         await self.do_search()
 
-    async def get_hostnames(self):
-        return self.total_results
+    async def get_hostnames(self) -> list[str]:
+        return list(self.totalhosts)
+
+    async def get_ips(self) -> set[str]:
+        return self.totalips
+
+    async def get_host_ip_pairs(self) -> set[tuple[str, str]]:
+        return self.host_ip_pairs

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -80,7 +80,7 @@ _SPECS = (
     _spec('otx', ResultRoute.SUBDOMAINS, ResultRoute.IPS),
     _spec('pentesttools', ResultRoute.SUBDOMAINS),
     _spec('projectdiscovery', ResultRoute.SUBDOMAINS),
-    _spec('rapiddns', ResultRoute.SUBDOMAINS),
+    _spec('rapiddns', ResultRoute.SUBDOMAINS, ResultRoute.IPS),
     _spec('robtex', ResultRoute.SUBDOMAINS, ResultRoute.IPS),
     _spec('rocketreach', ResultRoute.EMAILS, ResultRoute.LINKS),
     _spec('securityTrails', ResultRoute.SUBDOMAINS, ResultRoute.IPS),


### PR DESCRIPTION
## Summary

- return RapidDNS hostnames without legacy `hostname:IP` composites
- expose validated IP addresses and host/IP associations through explicit getters
- route RapidDNS IP evidence through the existing source catalog
- preserve console, REST, JSON, XML, and SQLite behavior
- keep each provider's SQLite IP rows attributed to the provider that reported them

## Root cause

RapidDNS placed A-record values inside `get_hostnames()`. The central orchestrator then treated a provider-specific composite as a hostname, and the shared hostname normalizer rejected it. Enabling the normal IP route also exposed cumulative IP persistence that could attribute an earlier provider's address to a later provider.

## Compatibility

- `get_hostnames()` remains list-compatible
- JSON and REST continue returning separate `hosts` and `ips` collections
- XML retains RapidDNS host/IP associations
- SQLite retains separate host and IP rows with RapidDNS source attribution
- tests use mocked provider HTML and reserved example data only

## Verification

- focused RapidDNS, source-catalog, and README tests
- full pytest: 248 passed, 6 skipped
- Ruff lint
- Ruff format check
- mypy
- `git diff --check`

Tracking context: https://github.com/NotoriousRebel/theHarvester/issues/112
