### PR TITLE
test: isolate configuration copy logging

### DIFF
--- a/tests/lib/test_core.py
+++ b/tests/lib/test_core.py
@@ -10,6 +10,7 @@ import yaml
 
 import theHarvester.lib.core as core_module
 from theHarvester.lib.core import CONFIG_DIRS, DATA_DIR, AsyncFetcher, Core
+from theHarvester.lib.output import configure_logging
 
 
 @pytest.fixture(autouse=True)
@@ -109,6 +110,7 @@ def test_read_config_searches_config_dirs(
 
 @pytest.mark.parametrize("name", ("api-keys", "proxies"))
 def test_read_config_copies_default_to_home(name: str, capsys):
+    configure_logging(verbose=False)
     file = Path(f"~/.theHarvester/{name}.yaml").expanduser()
     config_files = [d.expanduser() / file.name for d in CONFIG_DIRS]
     side_effect = mock_read_text({f: FileNotFoundError() for f in config_files})


### PR DESCRIPTION
## Summary

- configure operator logging explicitly in the configuration-copy test
- keep library imports free of logging configuration side effects

## Root cause

The configuration-copy test observed operator output without establishing the public logging precondition. It passed in the full suite only because an earlier test had already configured the logger, so isolated execution failed.

## Impact

This makes the test order-independent without changing provider behavior, CLI wording, dependencies, or production logging initialization.

## Verification

- focused configuration tests: 30 passed
- full pytest: 248 passed, 6 skipped
- Ruff check
- Ruff formatting check
- mypy
- git diff --check
- Standards review: 0 findings
- Spec review: 0 findings
