### PR TITLE
fix: preserve hostname evidence

### DIFF
--- a/tests/discovery/test_criminalip.py
+++ b/tests/discovery/test_criminalip.py
@@ -63,7 +63,14 @@ async def test_parser_handles_missing_legacy_fields(monkeypatch) -> None:
     ips = await search.get_ips()
     asns = await search.get_asns()
 
-    assert {'api.example.com', 'blog.example.com', 'cdn.example.com', 'docs.example.com', 'login.example.com'}.issubset(hostnames)
+    assert {
+        'api.example.com',
+        'blog.example.com',
+        'cdn.example.com',
+        'docs.example.com',
+        'login.example.com',
+        'www.example.com',
+    }.issubset(hostnames)
     assert {'93.184.216.34', '198.51.100.10', '203.0.113.10'}.issubset(ips)
     assert {'15133', '64500'}.issubset(asns)
 

--- a/tests/discovery/test_crtsh.py
+++ b/tests/discovery/test_crtsh.py
@@ -59,12 +59,11 @@ class TestCrtshSearch:
         assert set(await search.get_hostnames()) == {'a.example.com', 'b.example.com'}
 
     @pytest.mark.asyncio
-    async def test_numeric_prefixed_entries_are_filtered(self, monkeypatch):
+    async def test_numeric_prefixed_entries_are_preserved(self, monkeypatch):
         _patch_fetch(monkeypatch, [{'name_value': '1234.example.com'}, {'name_value': 'good.example.com'}])
         search = crtsh.SearchCrtsh('example.com')
         await search.process()
-        # The numeric-prefixed entry is filtered out, leaving only the valid hostname.
-        assert set(await search.get_hostnames()) == {'good.example.com'}
+        assert set(await search.get_hostnames()) == {'1234.example.com', 'good.example.com'}
 
     @pytest.mark.asyncio
     async def test_empty_response_returns_no_hostnames(self, monkeypatch):

--- a/tests/discovery/test_sherlockeye.py
+++ b/tests/discovery/test_sherlockeye.py
@@ -94,7 +94,7 @@ async def test_process_extracts_domain_intelligence(monkeypatch) -> None:
     search = sherlockeye.SearchSherlockeye('example.com')
     await search.process()
 
-    assert await search.get_hostnames() == {'sub.example.com', 'example.com', 'api.example.com'}
+    assert await search.get_hostnames() == {'sub.example.com', 'www.example.com', 'api.example.com'}
     assert await search.get_emails() == {'user@example.com'}
     assert await search.get_ips() == {'203.0.113.10'}
 

--- a/tests/discovery/test_subdomaincenter.py
+++ b/tests/discovery/test_subdomaincenter.py
@@ -1,0 +1,16 @@
+import pytest
+
+from theHarvester.discovery import subdomaincenter
+
+
+@pytest.mark.asyncio
+async def test_process_preserves_www_hostname(monkeypatch):
+    async def fake_fetch_all(urls, headers=None, proxy=False, json=False):
+        return [['www.example.com']]
+
+    monkeypatch.setattr(subdomaincenter.AsyncFetcher, 'fetch_all', staticmethod(fake_fetch_all))
+    search = subdomaincenter.SubdomainCenter('example.com')
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'www.example.com'}

--- a/tests/discovery/test_virustotal.py
+++ b/tests/discovery/test_virustotal.py
@@ -1,0 +1,24 @@
+import pytest
+
+from theHarvester.discovery import virustotal
+
+
+@pytest.mark.asyncio
+async def test_parse_hostnames_preserves_www_evidence() -> None:
+    data = [
+        {
+            'id': 'www.example.com',
+            'attributes': {
+                'last_dns_records': [{'value': 'www.api.example.com'}],
+                'last_https_certificate': {
+                    'extensions': {'subject_alternative_name': ['www.mail.example.com']}
+                },
+            },
+        }
+    ]
+
+    assert await virustotal.SearchVirustotal.parse_hostnames(data, 'example.com') == [
+        'www.api.example.com',
+        'www.example.com',
+        'www.mail.example.com',
+    ]

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -1313,8 +1313,7 @@ async def start(rest_args: argparse.Namespace | None = None):
         # cast to string so Rest API can understand the type
         return_ips.extend([str(ip) for ip in sorted([netaddr.IPAddress(ip.strip()) for ip in set(all_ip)])])
         # return list(set(all_emails)), return_ips, full, '', ''
-        all_hosts = [host.replace('www.', '') for host in all_hosts if host.replace('www.', '') in all_hosts]
-        all_hosts = list(sorted(set(all_hosts)))
+        all_hosts = sorted_unique(all_hosts)
         return (
             total_asns,
             interesting_urls,
@@ -1423,12 +1422,8 @@ async def start(rest_args: argparse.Namespace | None = None):
                         temp.add(subdomain + ':' + addr)
                         continue
                 if host.endswith(word):
-                    if host[:4] == 'www.':
-                        if host[4:] in all_hosts or host[4:] in full:
-                            temp.add(host[4:])
-                            continue
                     temp.add(host)
-            full = list(sorted(temp))
+            full = sorted_unique(temp)
             full.sort(key=lambda el: el.split(':')[0])
             output_logger.info('\n[*] Hosts found: ' + str(len(full)))
             output_logger.info('---------------------')
@@ -1442,8 +1437,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                     output_logger.info(f'An exception has occurred while attempting to insert: {host} IP into DB: {e}')
                     continue
         else:
-            all_hosts = [host.replace('www.', '') for host in all_hosts if host.replace('www.', '') in all_hosts]
-            all_hosts = list(sorted(set(all_hosts)))
+            all_hosts = sorted_unique(all_hosts)
             output_logger.info('\n[*] Hosts found: ' + str(len(all_hosts)))
             output_logger.info('---------------------')
             for host in all_hosts:
@@ -1472,9 +1466,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                         all_hosts.append(host)
                     continue
             if host.endswith(word):
-                if host[:4] == 'www.':
-                    if host[4:] in all_hosts or host[4:] in full:
-                        continue
                 if host not in full:
                     full.append(host)
                     temp.add(host)
@@ -1862,7 +1853,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                     output_logger.info(f'An exception has occurred in BuiltWith scanning: {e}')
 
     if rest_args is not None:
-        all_hosts = sorted({host.replace('www.', '') for host in all_hosts})
+        all_hosts = sorted_unique(all_hosts)
         return (
             total_asns,
             interesting_urls,

--- a/theHarvester/discovery/criminalip.py
+++ b/theHarvester/discovery/criminalip.py
@@ -303,7 +303,7 @@ class SearchCriminalIP:
                 if isinstance(redirect, dict):
                     self._add_host_from_url(redirect.get('url'))
 
-        self.totalhosts = {host.removeprefix('www.') for host in self.totalhosts if '*.' + self.word != host}
+        self.totalhosts = {host for host in self.totalhosts if '*.' + self.word != host}
 
     async def get_asns(self) -> set:
         return self.asns

--- a/theHarvester/discovery/crtsh.py
+++ b/theHarvester/discovery/crtsh.py
@@ -31,7 +31,7 @@ class SearchCrtsh:
                 return []
 
             data = set([(dct['name_value'][2:] if dct['name_value'][:2] == '*.' else dct['name_value']) for dct in response])
-            data = {domain for domain in data if (domain[0] != '*' and str(domain[0:4]).isnumeric() is False)}
+            data = {domain for domain in data if domain[0] != '*'}
         except KeyError as ke:
             logger.info(f'Missing expected key in response: {ke}')
         except Exception as e:

--- a/theHarvester/discovery/sherlockeye.py
+++ b/theHarvester/discovery/sherlockeye.py
@@ -55,7 +55,7 @@ class SearchSherlockeye:
         return None
 
     def _add_hostname(self, hostname: str) -> None:
-        hostname = hostname.strip().lower().removeprefix('www.')
+        hostname = hostname.strip().lower()
         if hostname.endswith(f'.{self.word}') or hostname == self.word:
             self.totalhosts.add(hostname)
 

--- a/theHarvester/discovery/subdomaincenter.py
+++ b/theHarvester/discovery/subdomaincenter.py
@@ -17,8 +17,7 @@ class SubdomainCenter:
         try:
             current_url = f'{self.server}{self.word}'
             resp = await AsyncFetcher.fetch_all([current_url], headers=headers, proxy=self.proxy, json=True)
-            self.results = resp[0]
-            self.results = {sub[4:] if sub[:4] == 'www.' and sub[4:] else sub for sub in self.results}
+            self.results = set(resp[0])
         except Exception as e:
             logger.info(f'An exception has occurred in SubdomainCenter on : {e}')
 

--- a/theHarvester/discovery/virustotal.py
+++ b/theHarvester/discovery/virustotal.py
@@ -67,19 +67,15 @@ class SearchVirustotal:
     async def parse_hostnames(data, word):
         total_subdomains: set[str] = set()
         for attribute in data:
-            total_subdomains.add(attribute['id'].replace('"', '').replace('www.', ''))
+            total_subdomains.add(attribute['id'].replace('"', ''))
             attributes = attribute['attributes']
             total_subdomains.update(
-                {
-                    value['value'].replace('"', '').replace('www.', '')
-                    for value in attributes['last_dns_records']
-                    if word in value['value']
-                }
+                {value['value'].replace('"', '') for value in attributes['last_dns_records'] if word in value['value']}
             )
             if 'last_https_certificate' in attributes:
                 total_subdomains.update(
                     {
-                        value.replace('"', '').replace('www.', '')
+                        value.replace('"', '')
                         for value in attributes['last_https_certificate']['extensions']['subject_alternative_name']
                         if word in value
                     }


### PR DESCRIPTION
## Summary

- retain valid numeric-prefixed crt.sh hostnames
- preserve exact `www.` observations from Subdomain Center, Criminal IP, SherlockEye, and VirusTotal
- deduplicate exact hostnames without rewriting DNS labels across CLI, REST, DNS-resolved, and DNS-brute output
- keep target normalization, output formats, response shapes, and source identifiers unchanged

## Root cause

Several provider and output paths treated a leading `www.` label as interchangeable with the target apex. That discarded provider evidence or attributed it to a different DNS name before shared normalization and output.

## Standards basis

DNS defines a domain name as the sequence of labels identifying one node, with resource records owned by that particular name. A CNAME can explicitly relate two names, but the relationship must come from DNS data rather than deleting a label. See [RFC 1034 section 3.1](https://www.rfc-editor.org/rfc/rfc1034.html#section-3.1) and [section 3.6.2](https://www.rfc-editor.org/rfc/rfc1034.html#section-3.6.2).

Web origins require identical hosts, so an apex and its `www` name can remain separate security origins. See [RFC 6454 section 5](https://www.rfc-editor.org/rfc/rfc6454.html#section-5).

TLS service identity also requires DNS labels to match in order and explicitly treats a `www` hostname as its own reference identifier. See [RFC 9525 section 6.1.2](https://www.rfc-editor.org/rfc/rfc9525.html#section-6.1.2) and [section 6.3](https://www.rfc-editor.org/rfc/rfc9525.html#section-6.3).

## Compatibility

The existing CLI options, REST tuple shape, JSON, XML, SQLite schemas, source identifiers, target-input normalization, and active screenshot behavior are unchanged. No dependency or live provider request was added.

## Verification

- focused hostname tests: 23 passed
- full pytest: 250 passed, 6 skipped
- Ruff: passed
- formatting check: passed
- mypy: passed
- `git diff --check`: passed
- zero em dashes: passed
- parallel Standards review: zero findings after fixing one helper-reuse finding
- parallel Spec review: zero findings

Tracked in [NotoriousRebel/theHarvester#230](https://github.com/NotoriousRebel/theHarvester/issues/230).
