### PR TITLE
fix: validate provider IP evidence

### DIFF
--- a/tests/discovery/test_otx.py
+++ b/tests/discovery/test_otx.py
@@ -24,12 +24,15 @@ class TestOtx(object):
 
     @pytest.mark.asyncio
     async def test_search(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[dict[str, list[dict[str, str]]]]:
+        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[dict[str, list[dict[str, Any]]]]:
             return [
                 {
                     'passive_dns': [
                         {'hostname': 'api.example.com', 'address': '192.0.2.1'},
+                        {'hostname': 'api.example.com', 'address': '2001:0db8::1'},
+                        {'hostname': 'api.example.com', 'address': '999.0.0.1'},
                         {'hostname': 'www.example.com', 'address': 'NXDOMAIN'},
+                        {'hostname': 'www.example.com', 'address': 1234},
                     ]
                 }
             ]
@@ -38,7 +41,7 @@ class TestOtx(object):
         search = otxsearch.SearchOtx(TestOtx.domain())
         await search.process()
         assert await search.get_hostnames() == {'api.example.com', 'www.example.com'}
-        assert await search.get_ips() == {'192.0.2.1'}
+        assert await search.get_ips() == {'192.0.2.1', '2001:db8::1'}
 
 
 if __name__ == "__main__":

--- a/tests/discovery/test_threatcrowd.py
+++ b/tests/discovery/test_threatcrowd.py
@@ -1,0 +1,35 @@
+import json
+from typing import Any
+
+import pytest
+
+from theHarvester.discovery import threatcrowd
+
+
+_REPORT = {
+    'response_code': '1',
+    'subdomains': [],
+    'resolutions': [
+        {'ip_address': '192.0.2.1'},
+        {'ip_address': '2001:0db8::1'},
+        {'ip_address': '999.0.0.1'},
+        '2001:db8::2',
+        'NXDOMAIN',
+        {'ip_address': 1234},
+        1234,
+    ],
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('payload', [_REPORT, json.dumps(_REPORT)])
+async def test_process_retains_only_valid_ip_addresses(monkeypatch: pytest.MonkeyPatch, payload: object) -> None:
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[object]:
+        return [payload]
+
+    monkeypatch.setattr(threatcrowd.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = threatcrowd.SearchThreatcrowd('example.com')
+
+    await search.process()
+
+    assert await search.get_ips() == {'192.0.2.1', '2001:db8::1', '2001:db8::2'}

--- a/theHarvester/discovery/otxsearch.py
+++ b/theHarvester/discovery/otxsearch.py
@@ -1,4 +1,4 @@
-import re
+from ipaddress import ip_address
 from typing import Any
 
 from theHarvester.lib.core import AsyncFetcher
@@ -35,15 +35,14 @@ class SearchOtx:
 
         try:
             self.totalhosts = {host['hostname'] for host in passive if isinstance(host, dict) and 'hostname' in host}
-            # filter out ips that are just called NXDOMAIN and ensure they look like IPv4
-            self.totalips = {
-                ip['address']
-                for ip in passive
-                if isinstance(ip, dict)
-                and (addr := ip.get('address'))
-                and isinstance(addr, str)
-                and re.match(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$', addr)
-            }
+            self.totalips = set()
+            for record in passive:
+                if not isinstance(record, dict) or not isinstance(address := record.get('address'), str):
+                    continue
+                try:
+                    self.totalips.add(str(ip_address(address.strip())))
+                except ValueError:
+                    continue
         except (KeyError, TypeError, ValueError):
             self.totalhosts = set()
             self.totalips = set()

--- a/theHarvester/discovery/threatcrowd.py
+++ b/theHarvester/discovery/threatcrowd.py
@@ -1,5 +1,6 @@
 import json as _stdlib_json
 import logging
+from ipaddress import ip_address
 from types import ModuleType
 
 from theHarvester.lib.core import AsyncFetcher, Core
@@ -76,13 +77,17 @@ class SearchThreatcrowd:
                     if isinstance(resolutions, list):
                         for resolution in resolutions:
                             if isinstance(resolution, dict):
-                                ip = resolution.get('ip_address', '')
-                                if ip and ip.strip():
-                                    self.totalips.add(ip.strip())
+                                value = resolution.get('ip_address')
                             elif isinstance(resolution, str):
-                                # Sometimes IPs are directly in the list
-                                if resolution.strip():
-                                    self.totalips.add(resolution.strip())
+                                value = resolution
+                            else:
+                                continue
+                            if not isinstance(value, str):
+                                continue
+                            try:
+                                self.totalips.add(str(ip_address(value.strip())))
+                            except ValueError:
+                                continue
 
             except Exception as e:
                 logger.info(f'Failed to parse ThreatCrowd response: {e}')


### PR DESCRIPTION
## Summary

- validate OTX and ThreatCrowd address evidence with Python's `ipaddress` module
- retain canonical IPv4 and IPv6 strings
- reject malformed addresses, sentinel values, and non-string payload values

## Root cause

OTX used an IPv4-shaped regular expression that accepted invalid octets and rejected IPv6. ThreatCrowd accepted any non-empty string as an address. Both paths could pass invalid provider values into CLI, REST, JSON, XML, and SQLite results.

## Tests

- `uv run pytest tests/discovery/test_otx.py tests/discovery/test_threatcrowd.py -q` (3 passed, 1 live-network test skipped)
- `uv run pytest` (250 passed, 6 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy theHarvester`
- `git diff --check`

Tracked in [NotoriousRebel/theHarvester#231](https://github.com/NotoriousRebel/theHarvester/issues/231).
