### PR TITLE
fix: retain typed DNS evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expanded offline regression coverage for discovery providers, configuration contracts, logging, output, documentation, workflow policy, and scope boundaries.
 
 ### Fixed
+- Fixed DNS candidate validation to omit names without usable A, AAAA, or CNAME evidence, normalize and deduplicate IPv4, IPv6, and canonical-name records, and preserve the existing `Checker.check()` and `DnsForce.run()` return shape.
 - Fixed REST `/query` requests with a filename so they no longer fail with an unbound local value and HTTP 500 response ([c358df80](https://github.com/laramies/theHarvester/commit/c358df80)).
 - Fixed Brave result limits, malformed Mojeek responses, DuckDuckGo provider and parser boundaries, Baidu verification status reporting, invalid Robtex reverse lookups, and transient crt.sh failures ([72c0d9eb](https://github.com/laramies/theHarvester/commit/72c0d9eb), [48be3ccd](https://github.com/laramies/theHarvester/commit/48be3ccd), [6e7945b5](https://github.com/laramies/theHarvester/commit/6e7945b5), [48f959cc](https://github.com/laramies/theHarvester/commit/48f959cc), [1d56dc78](https://github.com/laramies/theHarvester/commit/1d56dc78), [e8d5278b](https://github.com/laramies/theHarvester/commit/e8d5278b), [26adbc49](https://github.com/laramies/theHarvester/commit/26adbc49)).
 - Fixed IntelX hostname, email, IP, and URL result normalization and kept its routing source-scoped ([281f6d45](https://github.com/laramies/theHarvester/commit/281f6d45)).

--- a/README.md
+++ b/README.md
@@ -215,7 +215,9 @@ Treat collected OSINT as potentially sensitive. Keep report files, screenshots, 
 
 ### Report formats
 
-The JSON report is a single object and is the more complete format for automation. Host entries may be plain hostnames or `hostname:IP` pairs when DNS resolution is enabled.
+The JSON report is a single object and is the more complete format for automation. Host entries remain plain hostnames or `hostname:address[,address...]` values when DNS resolution is enabled. DNS resolution and DNS brute force retain candidates only when A, AAAA, or CNAME evidence is available; CNAME-only candidates remain plain hostnames in existing CLI, REST, JSON, and XML output.
+
+`Checker.check()` and `DnsForce.run()` retain their existing `(resolved, hosts, addresses)` return shape. Normalized A, AAAA, and CNAME values are available through each object's `records` mapping.
 
 | Field | Availability | Contents |
 | --- | --- | --- |

--- a/tests/lib/test_hostchecker.py
+++ b/tests/lib/test_hostchecker.py
@@ -1,0 +1,190 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from theHarvester.discovery import dnssearch
+from theHarvester.lib import hostchecker
+
+
+@pytest.mark.asyncio
+async def test_check_retains_a_record_and_excludes_missing_candidate(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResolver:
+        async def query_dns(self, host: str, record_type: str):
+            if host == 'missing.example.com' or record_type != 'A':
+                raise OSError('not found')
+            record = SimpleNamespace(data=SimpleNamespace(addr='192.0.2.10'))
+            return SimpleNamespace(answer=[record])
+
+    monkeypatch.setattr(hostchecker.aiodns, 'DNSResolver', lambda **_kwargs: FakeResolver())
+    checker = hostchecker.Checker(['found.example.com', 'missing.example.com'], nameservers=[])
+
+    resolved, hosts, addresses = await checker.check()
+
+    assert resolved == ['found.example.com:192.0.2.10']
+    assert hosts == ['found.example.com']
+    assert addresses == ['192.0.2.10']
+    assert checker.records['found.example.com'].ipv4 == ('192.0.2.10',)
+
+
+@pytest.mark.asyncio
+async def test_check_retains_aaaa_only_candidate(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResolver:
+        async def query_dns(self, _host: str, record_type: str):
+            if record_type == 'AAAA':
+                record = SimpleNamespace(data=SimpleNamespace(addr='2001:0db8::10'))
+                return SimpleNamespace(answer=[record])
+            raise OSError('no data')
+
+    monkeypatch.setattr(hostchecker.aiodns, 'DNSResolver', lambda **_kwargs: FakeResolver())
+    checker = hostchecker.Checker(['ipv6.example.com'], nameservers=[])
+
+    resolved, hosts, addresses = await checker.check()
+
+    assert resolved == ['ipv6.example.com:2001:db8::10']
+    assert hosts == ['ipv6.example.com']
+    assert addresses == ['2001:db8::10']
+    assert checker.records['ipv6.example.com'].ipv6 == ('2001:db8::10',)
+
+
+@pytest.mark.asyncio
+async def test_check_retains_cname_only_candidate(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResolver:
+        async def query_dns(self, _host: str, record_type: str):
+            if record_type == 'CNAME':
+                record = SimpleNamespace(data=SimpleNamespace(cname='Target.Example.NET.'))
+                return SimpleNamespace(answer=[record])
+            raise OSError('no data')
+
+    monkeypatch.setattr(hostchecker.aiodns, 'DNSResolver', lambda **_kwargs: FakeResolver())
+    checker = hostchecker.Checker(['alias.example.com'], nameservers=[])
+
+    resolved, hosts, addresses = await checker.check()
+
+    assert resolved == ['alias.example.com']
+    assert hosts == ['alias.example.com']
+    assert addresses == []
+    assert checker.records['alias.example.com'].cnames == ('target.example.net',)
+
+
+@pytest.mark.asyncio
+async def test_dns_force_preserves_legacy_result_and_typed_records(monkeypatch: pytest.MonkeyPatch) -> None:
+    records = {'www.example.com': hostchecker.HostDnsRecords(ipv4=('192.0.2.10',))}
+
+    class FakeChecker:
+        def __init__(self, _hosts: list[str], nameservers: list[str]) -> None:
+            assert nameservers == ['192.0.2.53']
+            self.records = records
+
+        async def check(self) -> tuple[list[str], list[str], list[str]]:
+            return ['www.example.com:192.0.2.10'], ['www.example.com'], ['192.0.2.10']
+
+    monkeypatch.setattr(dnssearch.hostchecker, 'Checker', FakeChecker)
+    dns_force = dnssearch.DnsForce('example.com', ['192.0.2.53'])
+    dns_force.list = ['www.example.com']
+
+    result = await dns_force.run()
+
+    assert result == (['www.example.com:192.0.2.10'], ['www.example.com'], ['192.0.2.10'])
+    assert dns_force.records is records
+
+
+@pytest.mark.asyncio
+async def test_check_normalizes_and_deduplicates_mixed_evidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    values = {
+        'A': [('addr', '192.0.2.10'), ('addr', '192.0.2.10'), ('addr', '999.0.0.1')],
+        'AAAA': [('addr', '2001:0db8::10'), ('addr', '2001:db8:0:0::10')],
+        'CNAME': [('cname', 'Target.Example.NET.'), ('cname', 'target.example.net')],
+    }
+
+    class FakeResolver:
+        async def query_dns(self, _host: str, record_type: str):
+            records = [SimpleNamespace(data=SimpleNamespace(**{field: value})) for field, value in values[record_type]]
+            return SimpleNamespace(answer=records)
+
+    monkeypatch.setattr(hostchecker.aiodns, 'DNSResolver', lambda **_kwargs: FakeResolver())
+    checker = hostchecker.Checker(['mixed.example.com'], nameservers=[])
+
+    resolved, hosts, addresses = await checker.check()
+
+    assert resolved == ['mixed.example.com:192.0.2.10,2001:db8::10']
+    assert hosts == ['mixed.example.com']
+    assert addresses == ['192.0.2.10', '2001:db8::10']
+    assert checker.records['mixed.example.com'] == hostchecker.HostDnsRecords(
+        ipv4=('192.0.2.10',),
+        ipv6=('2001:db8::10',),
+        cnames=('target.example.net',),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'outcome',
+    [
+        hostchecker.aiodns.error.DNSError(hostchecker.aiodns.error.ARES_ENOTFOUND, 'not found'),
+        hostchecker.aiodns.error.DNSError(hostchecker.aiodns.error.ARES_ENODATA, 'no data'),
+        SimpleNamespace(answer=[]),
+        OSError('resolver error'),
+        TimeoutError('timed out'),
+    ],
+)
+async def test_check_excludes_candidate_without_usable_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    outcome: object,
+) -> None:
+    class FakeResolver:
+        async def query_dns(self, _host: str, _record_type: str):
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return outcome
+
+    monkeypatch.setattr(hostchecker.aiodns, 'DNSResolver', lambda **_kwargs: FakeResolver())
+    checker = hostchecker.Checker(['missing.example.com'], nameservers=[])
+
+    assert await checker.check() == ([], [], [])
+    assert checker.records == {}
+
+
+@pytest.mark.asyncio
+async def test_check_propagates_cancellation(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResolver:
+        async def query_dns(self, _host: str, _record_type: str):
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(hostchecker.aiodns, 'DNSResolver', lambda **_kwargs: FakeResolver())
+    checker = hostchecker.Checker(['cancelled.example.com'], nameservers=[])
+
+    with pytest.raises(asyncio.CancelledError):
+        await checker.check()
+
+
+@pytest.mark.asyncio
+async def test_check_rejects_address_record_type_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    values = {'A': '2001:db8::10', 'AAAA': '192.0.2.10'}
+
+    class FakeResolver:
+        async def query_dns(self, _host: str, record_type: str):
+            if record_type == 'CNAME':
+                raise OSError('no data')
+            record = SimpleNamespace(data=SimpleNamespace(addr=values[record_type]))
+            return SimpleNamespace(answer=[record])
+
+    monkeypatch.setattr(hostchecker.aiodns, 'DNSResolver', lambda **_kwargs: FakeResolver())
+    checker = hostchecker.Checker(['mismatch.example.com'], nameservers=[])
+
+    assert await checker.check() == ([], [], [])
+
+
+@pytest.mark.asyncio
+async def test_check_rejects_empty_cname(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResolver:
+        async def query_dns(self, _host: str, record_type: str):
+            if record_type == 'CNAME':
+                record = SimpleNamespace(data=SimpleNamespace(cname='.'))
+                return SimpleNamespace(answer=[record])
+            raise OSError('no data')
+
+    monkeypatch.setattr(hostchecker.aiodns, 'DNSResolver', lambda **_kwargs: FakeResolver())
+    checker = hostchecker.Checker(['empty.example.com'], nameservers=[])
+
+    assert await checker.check() == ([], [], [])

--- a/theHarvester/discovery/dnssearch.py
+++ b/theHarvester/discovery/dnssearch.py
@@ -31,6 +31,7 @@ class DnsForce:
         self.domain = domain
         self.subdo = False
         self.verbose = verbose
+        self.records: dict[str, hostchecker.HostDnsRecords] = {}
         # self.dnsserver = [dnsserver] if isinstance(dnsserver, str) else dnsserver
         # self.dnsserver = list(map(str, dnsserver.split(','))) if isinstance(dnsserver, str) else dnsserver
         self.dnsserver = dnsserver
@@ -43,6 +44,7 @@ class DnsForce:
         logger.info(f'Starting DNS brute forcing with {len(self.list)} words')
         checker = hostchecker.Checker(self.list, nameservers=self.dnsserver)
         resolved_pair, hosts, ips = await checker.check()
+        self.records = checker.records
         return resolved_pair, hosts, ips
 
 

--- a/theHarvester/lib/hostchecker.py
+++ b/theHarvester/lib/hostchecker.py
@@ -7,7 +7,8 @@ Revised to use aiodns & asyncio on 2019-09-23
 from __future__ import annotations
 
 import asyncio
-import socket
+import ipaddress
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import aiodns
@@ -16,11 +17,29 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
+@dataclass(frozen=True)
+class HostDnsRecords:
+    ipv4: tuple[str, ...] = ()
+    ipv6: tuple[str, ...] = ()
+    cnames: tuple[str, ...] = ()
+
+    @property
+    def addresses(self) -> tuple[str, ...]:
+        return self.ipv4 + self.ipv6
+
+
 class Checker:
+    """Resolve hosts while preserving the legacy ``check()`` return tuple.
+
+    Normalized A, AAAA, and CNAME values are available in ``records``.
+    CNAME-only hosts retain the existing plain-host string form.
+    """
+
     def __init__(self, hosts: list[str], nameservers: list[str]) -> None:
         self.hosts: list[str] = hosts
         self.realhosts: list[str] = []
         self.addresses: set[str] = set()
+        self.records: dict[str, HostDnsRecords] = {}
         self.nameservers: list[str] = nameservers
 
     # @staticmethod
@@ -36,18 +55,38 @@ class Checker:
     #         return f"{host}", tuple()
 
     @staticmethod
-    async def resolve_host(host: str, resolver: aiodns.DNSResolver) -> str:
-        try:
-            # TODO add check for ipv6 addrs as well
-            result = await resolver.getaddrinfo(host, socket.AF_INET)
-            addresses_list: list[str] = [r.addr[0] for r in result.nodes]
-            if addresses_list == [] or addresses_list is None or result is None:
-                return f'{host}:'
-            else:
-                addresses_str = ','.join(map(str, list(sorted(set(addresses_list)))))
-                return f'{host}:{addresses_str}'
-        except Exception:
-            return f'{host}:'
+    async def resolve_host(host: str, resolver: aiodns.DNSResolver) -> tuple[str, HostDnsRecords] | None:
+        record_types = ('A', 'AAAA', 'CNAME')
+        results = await asyncio.gather(
+            *(resolver.query_dns(host, record_type) for record_type in record_types),
+            return_exceptions=True,
+        )
+        values: dict[str, set[str]] = {record_type: set() for record_type in record_types}
+        for record_type, result in zip(record_types, results, strict=True):
+            if isinstance(result, BaseException):
+                if isinstance(result, Exception):
+                    continue
+                raise result
+            for record in result.answer:
+                value = getattr(record.data, 'cname' if record_type == 'CNAME' else 'addr', None)
+                if value is None:
+                    continue
+                if record_type == 'CNAME':
+                    if normalized := value.rstrip('.').lower():
+                        values[record_type].add(normalized)
+                    continue
+                try:
+                    address = ipaddress.ip_address(value)
+                except ValueError:
+                    continue
+                if address.version == (4 if record_type == 'A' else 6):
+                    values[record_type].add(str(address))
+        records = HostDnsRecords(
+            ipv4=tuple(sorted(values['A'])),
+            ipv6=tuple(sorted(values['AAAA'])),
+            cnames=tuple(sorted(values['CNAME'])),
+        )
+        return (host, records) if records.addresses or records.cnames else None
 
     # https://stackoverflow.com/questions/312443/how-do-i-split-a-list-into-equally-sized-chunks
     @staticmethod
@@ -56,9 +95,9 @@ class Checker:
         for i in range(0, len(lst), n):
             yield lst[i : i + n]
 
-    async def query_all(self, resolver: aiodns.DNSResolver, hosts: list[str]) -> list[str]:
+    async def query_all(self, resolver: aiodns.DNSResolver, hosts: list[str]) -> list[tuple[str, HostDnsRecords] | None]:
         # TODO chunk list into 50 pieces regardless of IPs and subnets
-        results: list[str] = await asyncio.gather(*[asyncio.create_task(self.resolve_host(host, resolver)) for host in hosts])
+        results = await asyncio.gather(*[asyncio.create_task(self.resolve_host(host, resolver)) for host in hosts])
         return results
 
     async def check(self) -> tuple[list[str], list[str], list[str]]:
@@ -72,12 +111,15 @@ class Checker:
         for chunk in self.chunks(self.hosts, 50):
             # TODO split this to get IPs added total ips
             results = await self.query_all(resolver, chunk)
-            all_results.update(results)
-            for pair in results:
-                host, addresses = pair.split(':')
+            for result in results:
+                if result is None:
+                    continue
+                host, records = result
+                self.records[host] = records
+                all_results.add(f'{host}:{",".join(records.addresses)}' if records.addresses else host)
                 self.realhosts.append(host)
                 # address may be a list of ips; filter out empties
-                self.addresses.update({addr for addr in addresses.split(',') if addr})
+                self.addresses.update(records.addresses)
                 # address may be a list of ips
                 # and do a set comprehension to remove duplicates
         self.realhosts.sort()


### PR DESCRIPTION
## Summary

- retain DNS candidates only when A, AAAA, or CNAME evidence is usable
- normalize and deduplicate typed IPv4, IPv6, and canonical-name records
- preserve the existing `Checker.check()` and `DnsForce.run()` return tuples
- expose additive typed evidence through each object's `records` mapping

## Root cause

The current checker requests IPv4 only and converts every resolver failure into a `hostname:` result. That makes unresolved DNS candidates look valid and loses IPv6 and CNAME evidence.

This is a focused current-upstream port of the earlier fork implementation. It does not replay the stale branch or change CLI, REST, JSON, XML, or SQLite schemas.

## Compatibility

CNAME-only candidates remain plain hostnames in legacy output. Typed records are additive and remain in memory for later consumers.

## Tests

- `uv run pytest tests/lib/test_hostchecker.py -q` (13 passed)
- `uv run pytest` (261 passed, 6 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy theHarvester`
- `git diff --check`

Tracked in [NotoriousRebel/theHarvester#238](https://github.com/NotoriousRebel/theHarvester/issues/238). This supersedes the fork-only delivery recorded in [#55](https://github.com/NotoriousRebel/theHarvester/issues/55).
