### PR TITLE
fix: preserve www and prefer HTTPS screenshots

### DIFF
--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import theHarvester.screenshot.screenshot as screenshot_module
+from theHarvester.screenshot.screenshot import ScreenShotter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize(
+    ('platform', 'expected_separator'),
+    [('darwin', '/'), ('linux', '/'), ('win32', '\\')],
+)
+def test_screenshot_output_separator_matches_platform(
+    monkeypatch: pytest.MonkeyPatch,
+    platform: str,
+    expected_separator: str,
+) -> None:
+    monkeypatch.setattr(screenshot_module.sys, 'platform', platform)
+
+    assert ScreenShotter('screenshots').slash == expected_separator
+
+
+@pytest.mark.asyncio
+async def test_visit_prefers_https_and_returns_final_www_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = MagicMock()
+    response.url = 'https://www.example.com/landing'
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=False)
+    response.text = AsyncMock(return_value='reachable')
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    session.get.return_value = response
+    monkeypatch.setattr(screenshot_module.aiohttp, 'ClientSession', MagicMock(return_value=session))
+    monkeypatch.setattr(screenshot_module.aiohttp, 'TCPConnector', MagicMock())
+    monkeypatch.setattr(screenshot_module.ssl, 'create_default_context', MagicMock())
+
+    result = await ScreenShotter.visit('www.example.com')
+
+    assert result == ('https://www.example.com/landing', 'reachable')
+    assert session.get.call_args.args[0] == 'https://www.example.com'
+
+
+@pytest.mark.asyncio
+async def test_visit_falls_back_to_http_when_https_is_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = MagicMock()
+    response.url = 'http://www.example.com'
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=False)
+    response.text = AsyncMock(return_value='reachable')
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    session.get.side_effect = [screenshot_module.aiohttp.ClientError('TLS unavailable'), response]
+    monkeypatch.setattr(screenshot_module.aiohttp, 'ClientSession', MagicMock(return_value=session))
+    monkeypatch.setattr(screenshot_module.aiohttp, 'TCPConnector', MagicMock())
+    monkeypatch.setattr(screenshot_module.ssl, 'create_default_context', MagicMock())
+
+    result = await ScreenShotter.visit('www.example.com')
+
+    assert result == ('http://www.example.com', 'reachable')
+    assert [call.args[0] for call in session.get.call_args_list] == [
+        'https://www.example.com',
+        'http://www.example.com',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_take_screenshot_preserves_www_hostname(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    page = AsyncMock()
+    context = AsyncMock()
+    context.new_page.return_value = page
+    browser = AsyncMock()
+    browser.new_context.return_value = context
+    playwright = MagicMock()
+    playwright.chromium.launch = AsyncMock(return_value=browser)
+    manager = MagicMock()
+    manager.__aenter__ = AsyncMock(return_value=playwright)
+    manager.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(screenshot_module, 'async_playwright', MagicMock(return_value=manager))
+
+    await ScreenShotter(str(tmp_path)).take_screenshot('www.example.com')
+
+    page.goto.assert_awaited_once_with('https://www.example.com', timeout=35000)
+    screenshot_path = page.screenshot.await_args.kwargs['path']
+    assert screenshot_path.endswith('www.example.com.png')

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -1542,7 +1542,7 @@ async def start(rest_args: argparse.Namespace | None = None):
             start_time = time.perf_counter()
             output_logger.info('Filtering domains for ones we can reach')
             if dnsresolve is None or len(final_dns_resolver_list) > 0:
-                unique_resolved_domains = {url.split(':')[0] for url in full if ':' in url and 'www.' not in url}
+                unique_resolved_domains = {url.split(':')[0] for url in full if ':' in url}
             else:
                 # Technically not resolved in this case, which is not ideal
                 # You should always use dns resolve when doing screenshotting

--- a/theHarvester/screenshot/screenshot.py
+++ b/theHarvester/screenshot/screenshot.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 class ScreenShotter:
     def __init__(self, output) -> None:
         self.output = output
-        self.slash = '\\' if 'win' in sys.platform else '/'
+        self.slash = '\\' if sys.platform.startswith('win') else '/'
         self.slash = '' if (self.output[-1] == '\\' or self.output[-1] == '/') else self.slash
 
     def verify_path(self) -> bool:
@@ -57,12 +57,7 @@ class ScreenShotter:
     async def visit(url: str, proxy: str | None = None) -> tuple[str, str]:
         try:
             timeout = aiohttp.ClientTimeout(total=35)
-            headers = {
-                'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) '
-                'Chrome/122.0.0.0 Safari/537.36'
-            }
-            url = f'http://{url}' if not url.startswith('http') else url
-            url = url.replace('www.', '')
+            urls = (url,) if url.startswith(('http://', 'https://')) else (f'https://{url}', f'http://{url}')
             sslcontext = ssl.create_default_context(cafile=certifi.where())
 
             # Create connector based on proxy type
@@ -78,23 +73,21 @@ class ScreenShotter:
             else:
                 connector = aiohttp.TCPConnector(ssl=sslcontext)
 
-            async with (
-                aiohttp.ClientSession(
-                    timeout=timeout,
-                    headers=headers,
-                    connector=connector,
-                ) as session,
-                session.get(url, ssl=False, proxy=proxy_param) as resp,
-            ):
-                text = await resp.text('UTF-8')
-                return f'http://{url}' if not url.startswith('http') else url, text
+            async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
+                for candidate in urls:
+                    try:
+                        async with session.get(candidate, proxy=proxy_param) as resp:
+                            text = await resp.text('UTF-8')
+                            return str(resp.url), text
+                    except (aiohttp.ClientError, TimeoutError) as e:
+                        logger.info(f'An exception has occurred while attempting to visit {candidate} : {e}')
+            return '', ''
         except Exception as e:
             logger.info(f'An exception has occurred while attempting to visit {url} : {e}')
             return '', ''
 
     async def take_screenshot(self, url: str) -> None:
-        url = f'http://{url}' if not url.startswith('http') else url
-        url = url.replace('www.', '')
+        url = f'https://{url}' if not url.startswith(('http://', 'https://')) else url
         logger.info(f'Attempting to take a screenshot of: {url}')
         async with async_playwright() as p:
             browser = await p.chromium.launch(headless=True)


### PR DESCRIPTION
## Summary

- retain resolved `www` hostnames as screenshot candidates
- prefer HTTPS for scheme-less targets, falling back to HTTP only when HTTPS cannot connect or times out
- preserve explicit schemes and use aiohttp's final redirected URL for Playwright navigation
- remove the stale Chrome 122 preflight header and the per-request TLS verification bypass
- carry the macOS path separator fix from #2453 into the `dev` branch

## Why

The screenshot path previously rewrote `www.example.com` to `example.com` and forced scheme-less targets through HTTP. It also sent a hardcoded browser-like user agent from aiohttp even though the actual screenshot is taken by Chromium, which supplies its own default browser user agent.

The aiohttp request remains a lightweight reachability check before launching Chromium. It now uses aiohttp's normal generated headers and the configured SSL context. An HTTPS response is considered reachable regardless of HTTP status, preserving the existing behavior for screenshotting error pages. HTTP fallback occurs only for connection errors or timeouts.

Playwright documents that browser contexts have a default user agent which can be overridden when needed: https://playwright.dev/python/docs/emulation

aiohttp documents generated `User-Agent` headers and redirect handling in its client reference: https://docs.aiohttp.org/en/stable/client_reference.html

This is the active-screenshot follow-up to #2458 and remains separate from provider and output normalization.

## Verification

- `uv run pytest tests/test_screenshot.py`: 6 passed
- `uv run pytest`: 278 passed, 6 skipped
- `uv run ruff check .`: passed
- direct Ruff on changed files: passed
- `uv run ruff format --check .`: passed
- `uv run mypy theHarvester`: passed
- `git diff --check`: passed
- zero em dashes: passed

All screenshot tests mock the HTTP and browser boundaries. No live reconnaissance was performed.
