### PR TITLE
feat: persist completed results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added transactional SQLite storage and loading for completed full-pipeline runs without changing legacy result rows.
 - Added deterministic JSONL report companions finalized after selected one-shot actions complete.
 - Added DNSDB passive DNS discovery with API key configuration, shared transport handling, result parsing, and offline tests ([9b41b78e](https://github.com/laramies/theHarvester/commit/9b41b78e), [aba9fec6](https://github.com/laramies/theHarvester/commit/aba9fec6)).
 - Added `--verbose` diagnostic logging while keeping normal operator output available at the default log level ([8a7b8b71](https://github.com/laramies/theHarvester/commit/8a7b8b71)).

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Never commit populated configuration files, API keys, account details, or provid
 - `-f NAME` writes `NAME.json`, `NAME.xml`, and `NAME.jsonl`.
 - Screenshots are written to the directory passed to `--screenshot`.
 - Host, email, IP, and related scan records are stored in `~/.local/share/theHarvester/stash.sqlite`.
+- Full-pipeline runs are also stored transactionally by run UUID with their completed, deduplicated findings. Early REST returns and DNS-brute utility requests are not recorded as completed runs.
 - REST queries return JSON.
 
 Treat collected OSINT as potentially sensitive. Keep report files, screenshots, and the local database out of source control and share them only within the authorized engagement.

--- a/tests/discovery/test_rapiddns.py
+++ b/tests/discovery/test_rapiddns.py
@@ -11,6 +11,7 @@ import pytest
 
 import theHarvester.__main__ as theharvester_main
 from theHarvester.discovery import rapiddns
+from theHarvester.lib.completed_result import CompletedResult
 from theHarvester.lib.output import configure_logging
 
 RAPID_DNS_HTML = """
@@ -52,8 +53,11 @@ async def test_rapiddns_evidence_reaches_existing_outputs(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     stored: list[tuple[str, tuple[str, ...], str]] = []
+    completed_results: list[CompletedResult] = []
 
     class FakeStash:
+        fail_completed_write = False
+
         async def do_init(self) -> None:
             return None
 
@@ -62,6 +66,11 @@ async def test_rapiddns_evidence_reaches_existing_outputs(
 
         async def store(self, _domain: str, value: str, result_type: str, source: str) -> None:
             stored.append((result_type, (value,), source))
+
+        async def store_completed_result(self, result: CompletedResult) -> None:
+            if self.fail_completed_write:
+                raise OSError('forced completed-result failure')
+            completed_results.append(result)
 
     class UnexpectedChecker:
         def __init__(self, *_args: object, **_kwargs: object) -> None:
@@ -175,6 +184,7 @@ async def test_rapiddns_evidence_reaches_existing_outputs(
     assert jsonl_records[0]['type'] == 'summary'
     assert jsonl_records[0]['target'] == 'example.com'
     UUID(jsonl_records[0]['run_id'])
+    assert [str(result.run_id) for result in completed_results] == [jsonl_records[0]['run_id']]
     assert {'type': 'interesting-url', 'value': 'https://example.com/health'} in jsonl_records
     assert {'type': 'url', 'value': 'https://example.com/health'} in jsonl_records
     assert {'type': 'hostname', 'value': 'reverse.example.com'} in jsonl_records
@@ -221,3 +231,18 @@ async def test_rapiddns_evidence_reaches_existing_outputs(
         ('host', ('alias.example.com', 'api.example.com', 'broken.example.com'), 'rapiddns'),
         ('ip', ('192.0.2.1',), 'rapiddns'),
     ]
+    assert len(completed_results) == 1
+
+    monkeypatch.setattr(sys, 'argv', ['theHarvester', '-d', 'example.com', '-b', 'rapiddns'])
+    with pytest.raises(SystemExit) as no_file_exit:
+        await theharvester_main.start()
+    assert no_file_exit.value.code == 0
+    assert len(completed_results) == 2
+    assert completed_results[1].target == 'example.com'
+
+    FakeStash.fail_completed_write = True
+    with pytest.raises(SystemExit) as failed_write_exit:
+        await theharvester_main.start()
+    assert failed_write_exit.value.code == 0
+    assert len(completed_results) == 2
+    assert 'forced completed-result failure' in capsys.readouterr().out

--- a/tests/lib/test_completed_persistence.py
+++ b/tests/lib/test_completed_persistence.py
@@ -1,0 +1,71 @@
+from datetime import UTC, datetime
+from uuid import UUID
+
+import aiosqlite
+import pytest
+
+from theHarvester.lib.completed_result import CompletedResult
+from theHarvester.lib.stash import StashManager
+
+
+def completed_result(run_id: str = 'f047261c-0afb-4e18-89d5-28a7d977f51f') -> CompletedResult:
+    return CompletedResult.finish(
+        run_id=UUID(run_id),
+        target='example.com',
+        started_at=datetime(2026, 8, 5, 12, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 8, 5, 12, 1, tzinfo=UTC),
+        groups={
+            'hostname': ['api.example.com'],
+            'ip-address': ['192.0.2.1'],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_completed_result_round_trip_preserves_legacy_results(tmp_path) -> None:
+    manager = StashManager()
+    manager.db = str(tmp_path / 'stash.sqlite')
+    await manager.do_init()
+    await manager.store('example.com', 'legacy.example.com', 'host', 'legacy-source')
+    result = completed_result()
+
+    await manager.store_completed_result(result)
+
+    assert await manager.load_completed_result(result.run_id) == result
+    async with aiosqlite.connect(manager.db) as db:
+        legacy = await db.execute_fetchall('SELECT domain, resource, type, source FROM results')
+    assert legacy == [('example.com', 'legacy.example.com', 'host', 'legacy-source')]
+
+
+@pytest.mark.asyncio
+async def test_completed_result_write_is_atomic_and_rejects_duplicate_run_id(tmp_path) -> None:
+    manager = StashManager()
+    manager.db = str(tmp_path / 'stash.sqlite')
+    await manager.do_init()
+    result = completed_result()
+    await manager.store_completed_result(result)
+
+    with pytest.raises(aiosqlite.IntegrityError):
+        await manager.store_completed_result(result)
+
+    failing = completed_result('f9b33a33-e6d6-4a48-b04f-1a4a3012bc1f')
+    async with aiosqlite.connect(manager.db) as db:
+        await db.execute(
+            '''
+            CREATE TRIGGER fail_completed_item
+            BEFORE INSERT ON completed_result_items
+            WHEN NEW.run_id = 'f9b33a33-e6d6-4a48-b04f-1a4a3012bc1f'
+            BEGIN
+                SELECT RAISE(ABORT, 'forced failure');
+            END
+            '''
+        )
+        await db.commit()
+
+    with pytest.raises(aiosqlite.IntegrityError, match='forced failure'):
+        await manager.store_completed_result(failing)
+
+    async with aiosqlite.connect(manager.db) as db:
+        parent_count = (await db.execute_fetchall('SELECT COUNT(*) FROM completed_results'))[0][0]
+        item_count = (await db.execute_fetchall('SELECT COUNT(*) FROM completed_result_items'))[0][0]
+    assert (parent_count, item_count) == (1, 2)

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -284,7 +284,7 @@ async def start(rest_args: argparse.Namespace | None = None):
         else:
             # For relative paths, sanitize the entire filename
             filename = sanitize_filename(filename)
-    report_started_at = datetime.now(UTC) if filename else None
+    run_started_at = datetime.now(UTC)
 
     all_emails: list = []
     all_hosts: list = []
@@ -1868,32 +1868,44 @@ async def start(rest_args: argparse.Namespace | None = None):
                 else:
                     output_logger.info(f'An exception has occurred in BuiltWith scanning: {e}')
 
-    if filename and report_started_at is not None:
+    groups: dict[ResultKind, Iterable[str]] = {
+        'asn': map(str, total_asns),
+        'email': map(str, all_emails),
+        'hostname': _normalize_hosts_for_storage((*all_hosts, *dnsrev), word),
+        'interesting-url': map(str, interesting_urls),
+        'ip-address': _normalize_ip_addresses(all_ip),
+        'linkedin-link': map(str, linkedin_links_tracker),
+        'linkedin-person': map(str, linkedin_people_list_tracker),
+        'twitter-person': map(str, twitter_people_list_tracker),
+        'url': map(str, all_urls),
+        'vhost': map(str, vhost),
+    }
+    try:
+        completed_result = CompletedResult.finish(
+            target=word,
+            started_at=run_started_at,
+            completed_at=datetime.now(UTC),
+            groups=groups,
+        )
+    except (ValueError, TypeError) as error:
+        completed_result = None
+        output_logger.info(f'[!] An error occurred while completing the result: {error}')
+
+    if filename and completed_result is not None:
         try:
-            groups: dict[ResultKind, Iterable[str]] = {
-                'asn': map(str, total_asns),
-                'email': map(str, all_emails),
-                'hostname': _normalize_hosts_for_storage((*all_hosts, *dnsrev), word),
-                'interesting-url': map(str, interesting_urls),
-                'ip-address': _normalize_ip_addresses(all_ip),
-                'linkedin-link': map(str, linkedin_links_tracker),
-                'linkedin-person': map(str, linkedin_people_list_tracker),
-                'twitter-person': map(str, twitter_people_list_tracker),
-                'url': map(str, all_urls),
-                'vhost': map(str, vhost),
-            }
-            completed_result = CompletedResult.finish(
-                target=word,
-                started_at=report_started_at,
-                completed_at=datetime.now(UTC),
-                groups=groups,
-            )
             jsonl_filename = filename.rsplit('.', 1)[0] + '.jsonl'
             async with await anyio.open_file(jsonl_filename, 'w+', encoding='UTF-8') as fp:
                 await fp.write(completed_result.jsonl())
             output_logger.info('[*] JSONL File saved.')
         except (OSError, ValueError, TypeError, UnicodeEncodeError) as error:
             output_logger.info(f'[!] An error occurred while saving the JSONL file: {error}')
+
+    if completed_result is not None:
+        try:
+            completed_db = stash.StashManager()
+            await completed_db.store_completed_result(completed_result)
+        except Exception as error:
+            output_logger.info(f'[!] An error occurred while storing the completed result: {error}')
 
     if rest_args is not None:
         all_hosts = sorted_unique(all_hosts)

--- a/theHarvester/lib/stash.py
+++ b/theHarvester/lib/stash.py
@@ -3,8 +3,12 @@ import logging
 import os
 from collections.abc import Iterable
 from sqlite3.dbapi2 import Row
+from typing import cast
+from uuid import UUID
 
 import aiosqlite
+
+from theHarvester.lib.completed_result import CompletedResult, ResultKind
 
 logger = logging.getLogger(__name__)
 
@@ -41,10 +45,77 @@ class StashManager:
 
     async def do_init(self) -> None:
         async with aiosqlite.connect(self.db) as db:
+            await db.execute('PRAGMA foreign_keys = ON')
             await db.execute(
                 'CREATE TABLE IF NOT EXISTS results (domain text, resource text, type text, find_date date, source text)'
             )
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS completed_results (
+                    run_id TEXT PRIMARY KEY,
+                    target TEXT NOT NULL,
+                    started_at TEXT NOT NULL,
+                    completed_at TEXT NOT NULL
+                )
+                """
+            )
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS completed_result_items (
+                    run_id TEXT NOT NULL REFERENCES completed_results(run_id) ON DELETE CASCADE,
+                    position INTEGER NOT NULL,
+                    kind TEXT NOT NULL,
+                    value TEXT NOT NULL,
+                    PRIMARY KEY (run_id, position),
+                    UNIQUE (run_id, kind, value)
+                )
+                """
+            )
             await db.commit()
+
+    async def store_completed_result(self, result: CompletedResult) -> None:
+        async with aiosqlite.connect(self.db, timeout=30) as db:
+            await db.execute('PRAGMA foreign_keys = ON')
+            try:
+                await db.execute(
+                    'INSERT INTO completed_results (run_id, target, started_at, completed_at) VALUES (?, ?, ?, ?)',
+                    (
+                        str(result.run_id),
+                        result.target,
+                        result.started_at.isoformat(),
+                        result.completed_at.isoformat(),
+                    ),
+                )
+                await db.executemany(
+                    'INSERT INTO completed_result_items (run_id, position, kind, value) VALUES (?, ?, ?, ?)',
+                    [(str(result.run_id), position, kind, value) for position, (kind, value) in enumerate(result.results)],
+                )
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+
+    async def load_completed_result(self, run_id: UUID) -> CompletedResult:
+        async with aiosqlite.connect(self.db, timeout=30) as db:
+            cursor = await db.execute(
+                'SELECT run_id, target, started_at, completed_at FROM completed_results WHERE run_id = ?',
+                (str(run_id),),
+            )
+            parent = await cursor.fetchone()
+            if parent is None:
+                raise LookupError(f'completed result not found: {run_id}')
+            cursor = await db.execute(
+                'SELECT kind, value FROM completed_result_items WHERE run_id = ? ORDER BY position',
+                (str(run_id),),
+            )
+            rows = await cursor.fetchall()
+        return CompletedResult(
+            run_id=UUID(parent[0]),
+            target=parent[1],
+            started_at=datetime.datetime.fromisoformat(parent[2]),
+            completed_at=datetime.datetime.fromisoformat(parent[3]),
+            results=tuple((cast('ResultKind', kind), value) for kind, value in rows),
+        )
 
     async def store(self, domain, resource, res_type, source) -> None:
         self.domain = domain


### PR DESCRIPTION
## Summary

- add additive `completed_results` and `completed_result_items` SQLite tables keyed by the completed-result run UUID
- store each completed result and its ordered items in one transaction, rejecting duplicates and rolling back partial writes
- load completed results through `StashManager.load_completed_result`
- persist successful full-pipeline CLI and file-producing REST completions even when JSONL output is not requested
- preserve legacy result rows, existing JSON/XML/JSONL output, terminal behavior, REST tuples, and early REST/DNS-brute exits

## Verification

- focused tests: 11 passed
- full pytest: 280 passed, 6 skipped
- Ruff: passed
- formatting check: passed
- mypy: passed
- `git diff --check`: passed
- zero em dashes: passed
- parallel Standards review: zero findings
- parallel Spec review: zero findings

Tracking: https://github.com/NotoriousRebel/theHarvester/issues/240