### PR TITLE
test: use Mozilla for live provider smoke

### DIFF
--- a/.github/workflows/provider-smoke.yml
+++ b/.github/workflows/provider-smoke.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      # IANA-reserved test data; keep this job passive.
-      SMOKE_TEST_DOMAIN: example.com
+      # Mozilla publishes a bug bounty and safe harbor; keep this job passive.
+      SMOKE_TEST_DOMAIN: mozilla.org
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ipaddress
+import os
 import socket
 from typing import Any
 
@@ -31,6 +32,11 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=False,
         help='run tests that contact external services',
     )
+
+
+@pytest.fixture
+def live_test_domain() -> str:
+    return os.environ.get('SMOKE_TEST_DOMAIN', 'mozilla.org')
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:

--- a/tests/discovery/test_certspotter.py
+++ b/tests/discovery/test_certspotter.py
@@ -19,8 +19,8 @@ class TestCertspotter(object):
 
 class TestCertspotterSearch(object):
     @pytest.mark.live_network
-    def test_api(self) -> None:
-        base_url = f"https://api.certspotter.com/v1/issuances?domain={TestCertspotter.domain()}&expand=dns_names"
+    def test_api(self, live_test_domain: str) -> None:
+        base_url = f'https://api.certspotter.com/v1/issuances?domain={live_test_domain}&expand=dns_names'
         headers = {"User-Agent": Core.get_user_agent()}
         request = httpx.get(base_url, headers=headers, timeout=30)
         assert request.status_code == 200

--- a/tests/discovery/test_otx.py
+++ b/tests/discovery/test_otx.py
@@ -15,8 +15,8 @@ class TestOtx(object):
         return 'example.com'
 
     @pytest.mark.live_network
-    def test_api(self) -> None:
-        url = f'https://otx.alienvault.com/api/v1/indicators/domain/{self.domain()}/passive_dns'
+    def test_api(self, live_test_domain: str) -> None:
+        url = f'https://otx.alienvault.com/api/v1/indicators/domain/{live_test_domain}/passive_dns'
         response = httpx.get(url, headers={'User-Agent': Core.get_user_agent()}, timeout=30)
 
         assert response.status_code == 200

--- a/tests/discovery/test_thc.py
+++ b/tests/discovery/test_thc.py
@@ -75,31 +75,31 @@ def fake_thc_session(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestThcApi:
     """Tests to validate that the THC API responds correctly."""
 
-    def test_api_subdomains_download_endpoint_responds(self) -> None:
+    def test_api_subdomains_download_endpoint_responds(self, live_test_domain: str) -> None:
         """Verify that the subdomain download endpoint responds."""
-        url = 'https://ip.thc.org/api/v1/subdomains/download?domain=example.com&limit=10&hide_header=true'
+        url = f'https://ip.thc.org/api/v1/subdomains/download?domain={live_test_domain}&limit=10&hide_header=true'
         headers = {'User-Agent': Core.get_user_agent()}
         response = httpx.get(url, headers=headers, timeout=30)
         assert response.status_code == 200
 
-    def test_api_subdomains_returns_text_format(self) -> None:
+    def test_api_subdomains_returns_text_format(self, live_test_domain: str) -> None:
         """Verify that the response is plain text."""
-        url = 'https://ip.thc.org/api/v1/subdomains/download?domain=example.com&limit=5&hide_header=true'
+        url = f'https://ip.thc.org/api/v1/subdomains/download?domain={live_test_domain}&limit=5&hide_header=true'
         headers = {'User-Agent': Core.get_user_agent()}
         response = httpx.get(url, headers=headers, timeout=30)
         content_type = response.headers.get('content-type', '')
         assert 'text' in content_type or 'octet-stream' in content_type
 
-    def test_api_cli_subdomain_endpoint(self) -> None:
+    def test_api_cli_subdomain_endpoint(self, live_test_domain: str) -> None:
         """Verify CLI endpoint /sb/{domain}."""
-        url = 'https://ip.thc.org/sb/example.com?l=5&noheader'
+        url = f'https://ip.thc.org/sb/{live_test_domain}?l=5&noheader'
         headers = {'User-Agent': Core.get_user_agent()}
         response = httpx.get(url, headers=headers, timeout=30)
         assert response.status_code == 200
 
-    def test_api_returns_rate_limit_headers(self) -> None:
+    def test_api_returns_rate_limit_headers(self, live_test_domain: str) -> None:
         """Verify that the API returns rate limit headers."""
-        url = 'https://ip.thc.org/api/v1/subdomains/download?domain=example.com&limit=1&hide_header=true'
+        url = f'https://ip.thc.org/api/v1/subdomains/download?domain={live_test_domain}&limit=1&hide_header=true'
         headers = {'User-Agent': Core.get_user_agent()}
         response = httpx.get(url, headers=headers, timeout=30)
         assert 'x-ratelimit-limit' in response.headers

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -45,3 +45,9 @@ def test_loopback_network_remains_available(tmp_path: Path) -> None:
     if hasattr(socket, 'AF_UNIX'):
         with socket.socket(socket.AF_UNIX) as unix_client, suppress(OSError):
             unix_client.connect(str(tmp_path / 'missing.sock'))
+
+
+def test_live_test_domain_defaults_to_mozilla(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest) -> None:
+    monkeypatch.delenv('SMOKE_TEST_DOMAIN', raising=False)
+
+    assert request.getfixturevalue('live_test_domain') == 'mozilla.org'

--- a/tests/test_workflow_contract.py
+++ b/tests/test_workflow_contract.py
@@ -33,5 +33,5 @@ def test_live_provider_smoke_requires_manual_dispatch() -> None:
 
     assert set(workflow['on']) == {'workflow_dispatch'}
     assert workflow['permissions'] == {'contents': 'read'}
-    assert smoke_job['env']['SMOKE_TEST_DOMAIN'] == 'example.com'
+    assert smoke_job['env']['SMOKE_TEST_DOMAIN'] == 'mozilla.org'
     assert 'pytest --run-live-network -m live_network' in commands


### PR DESCRIPTION
## Summary

- set the manual passive-provider smoke target to `mozilla.org`
- expose the same target through a shared `live_test_domain` pytest fixture
- use that fixture for the CertSpotter, OTX, and THC opt-in live checks
- keep routine offline fixtures on RFC-reserved example data

## Why

The CLI smoke steps honored `SMOKE_TEST_DOMAIN`, but the opt-in live pytest checks still embedded a different domain. This gives the full manual smoke harness one explicit target while preserving the existing network guard and manual-only execution.

## Verification

- focused pytest: 42 passed, 6 skipped
- full pytest: 302 passed, 6 skipped
- Ruff check and format check passed
- mypy passed
- `git diff --check` passed
- parallel Standards and Spec reviews: zero findings

No live provider requests were performed during routine verification.