### PR TITLE
fix: narrow API endpoint HTTP fallback

### DIFF
--- a/tests/discovery/test_api_endpoints.py
+++ b/tests/discovery/test_api_endpoints.py
@@ -1,6 +1,33 @@
 from types import SimpleNamespace
 
+import aiohttp
+import pytest
+
 from theHarvester.discovery import api_endpoints
+
+
+class FakeResponse:
+    async def __aenter__(self) -> 'FakeResponse':
+        return self
+
+    async def __aexit__(self, *_args) -> None:
+        return None
+
+
+class FakeSession:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+
+    async def __aenter__(self) -> 'FakeSession':
+        return self
+
+    async def __aexit__(self, *_args) -> None:
+        return None
+
+    def get(self, *_args, **_kwargs) -> FakeResponse:
+        if self.error:
+            raise self.error
+        return FakeResponse()
 
 
 def test_process_response_extracts_only_string_json_parameter_names(monkeypatch):
@@ -17,3 +44,25 @@ def test_process_response_extracts_only_string_json_parameter_names(monkeypatch)
 
     assert result is not None
     assert result.parameters == ['name']
+
+
+@pytest.mark.parametrize('error', [aiohttp.ClientConnectionError(), TimeoutError()])
+@pytest.mark.asyncio
+async def test_detect_schema_falls_back_only_when_https_cannot_connect(monkeypatch, error: Exception) -> None:
+    monkeypatch.setattr(api_endpoints.aiohttp, 'ClientSession', lambda **_kwargs: FakeSession(error))
+    search = api_endpoints.SearchApiEndpoints('example.com')
+
+    assert await search._detect_schema() == 'http'
+
+
+@pytest.mark.asyncio
+async def test_detect_schema_does_not_downgrade_after_https_client_error(monkeypatch) -> None:
+    monkeypatch.setattr(
+        api_endpoints.aiohttp,
+        'ClientSession',
+        lambda **_kwargs: FakeSession(aiohttp.ClientPayloadError('bad payload')),
+    )
+    search = api_endpoints.SearchApiEndpoints('example.com')
+
+    with pytest.raises(aiohttp.ClientPayloadError, match='bad payload'):
+        await search._detect_schema()

--- a/theHarvester/discovery/api_endpoints.py
+++ b/theHarvester/discovery/api_endpoints.py
@@ -426,22 +426,20 @@ class SearchApiEndpoints:
 
     async def _detect_schema(self) -> str:
         """Detect if the domain supports HTTPS or fall back to HTTP."""
+        https_url = f'https://{self.word}'
         try:
-            https_url = f'https://{self.word}'
-            headers = self._get_headers()
-
-            response = await AsyncFetcher.fetch(
-                url=https_url, headers=headers, proxy=self.proxy, verify=self.verify_ssl, request_timeout=self.timeout
-            )
-
-            if response and getattr(response, 'status', 0) < 400:
-                return 'https'
-            else:
-                self.logger.info(f'[*] HTTPS request to {https_url} returned status: {getattr(response, "status", "No status")}')
-        except (aiohttp.ClientError, TimeoutError, OSError, TypeError, ValueError, AttributeError) as e:
-            self.logger.error(f"Failed to fetch HTTPS URL '{https_url}': {e}")
-
-        return 'http'  # Fallback to HTTP if HTTPS fails
+            timeout = aiohttp.ClientTimeout(total=self.timeout)
+            async with aiohttp.ClientSession(headers=self._get_headers(), timeout=timeout) as session:
+                async with session.get(
+                    https_url,
+                    proxy=self.proxy,
+                    ssl=self.verify_ssl,
+                    allow_redirects=self.follow_redirects,
+                ):
+                    return 'https'
+        except (aiohttp.ClientConnectionError, TimeoutError) as error:
+            self.logger.error(f"Failed to connect to HTTPS URL '{https_url}': {error}")
+            return 'http'
 
     async def _check_endpoint_with_semaphore(self, url: str) -> EndpointResult | None:
         """Execute endpoint check with semaphore for controlled concurrency."""


### PR DESCRIPTION
## Summary

- treat any connected HTTPS response as sufficient to keep HTTPS
- fall back to HTTP only for an HTTPS connection error or timeout
- propagate non-connection aiohttp client failures instead of silently downgrading
- cover the scheme decision with an offline fake HTTP boundary

## Why

The shared fetcher suppresses the distinction between connection failures and later client failures. The previous scheme check could therefore retry insecure HTTP after HTTPS connectivity had already succeeded. The probe now preserves that distinction and fails closed.

## Verification

- focused pytest: 4 passed
- full pytest: 304 passed, 6 skipped
- Ruff check and format check passed
- mypy passed
- `git diff --check` passed
- parallel Standards and Spec reviews: zero findings

No live provider requests were performed.