### PR TITLE
fix: preserve generic people in completed results

### DIFF
--- a/tests/discovery/test_venacus_people_output.py
+++ b/tests/discovery/test_venacus_people_output.py
@@ -1,0 +1,66 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from theHarvester import __main__ as theharvester_main
+from theHarvester.lib.completed_result import CompletedResult
+
+
+@pytest.mark.asyncio
+async def test_generic_people_reach_completed_result_and_jsonl(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    completed_results: list[CompletedResult] = []
+
+    class FakeStash:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args) -> None:
+            return None
+
+        async def store_completed_result(self, result: CompletedResult) -> None:
+            completed_results.append(result)
+
+    class FakeVenacus:
+        def __init__(self, *, word: str, limit: int, offset_doc: int) -> None:
+            assert (word, limit, offset_doc) == ('example.com', 500, 0)
+
+        async def process(self, _proxy: bool) -> None:
+            return None
+
+        async def get_people(self) -> list[dict[str, str]]:
+            return [
+                {'lastname': 'Lovelace', 'firstname': 'Ada'},
+                {'firstname': 'Ada', 'lastname': 'Lovelace'},
+            ]
+
+        async def get_emails(self) -> set[str]:
+            return set()
+
+        async def get_ips(self) -> set[str]:
+            return set()
+
+        async def get_interestingurls(self) -> set[str]:
+            return set()
+
+    report = tmp_path / 'people-report'
+    monkeypatch.setattr(theharvester_main.stash, 'StashManager', FakeStash)
+    monkeypatch.setattr(theharvester_main.venacussearch, 'SearchVenacus', FakeVenacus)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['theHarvester', '-d', 'example.com', '-b', 'venacus', '-f', str(report)],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    person = '{"firstname":"Ada","lastname":"Lovelace"}'
+    assert completed_results[0].results.count(('person', person)) == 1
+    records = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
+    assert {'type': 'person', 'value': person} in records

--- a/tests/lib/test_completed_persistence.py
+++ b/tests/lib/test_completed_persistence.py
@@ -17,6 +17,7 @@ def completed_result(run_id: str = 'f047261c-0afb-4e18-89d5-28a7d977f51f') -> Co
         groups={
             'hostname': ['api.example.com'],
             'ip-address': ['192.0.2.1'],
+            'person': ['{"firstname":"Ada","lastname":"Lovelace"}'],
         },
     )
 
@@ -68,4 +69,4 @@ async def test_completed_result_write_is_atomic_and_rejects_duplicate_run_id(tmp
     async with aiosqlite.connect(manager.db) as db:
         parent_count = (await db.execute_fetchall('SELECT COUNT(*) FROM completed_results'))[0][0]
         item_count = (await db.execute_fetchall('SELECT COUNT(*) FROM completed_result_items'))[0][0]
-    assert (parent_count, item_count) == (1, 2)
+    assert (parent_count, item_count) == (1, 3)

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+import json
 import logging
 import os
 import re
@@ -1876,6 +1877,7 @@ async def start(rest_args: argparse.Namespace | None = None):
         'ip-address': _normalize_ip_addresses(all_ip),
         'linkedin-link': map(str, linkedin_links_tracker),
         'linkedin-person': map(str, linkedin_people_list_tracker),
+        'person': (json.dumps(person, ensure_ascii=False, separators=(',', ':'), sort_keys=True) for person in all_people),
         'twitter-person': map(str, twitter_people_list_tracker),
         'url': map(str, all_urls),
         'vhost': map(str, vhost),

--- a/theHarvester/lib/completed_result.py
+++ b/theHarvester/lib/completed_result.py
@@ -14,6 +14,7 @@ ResultKind = Literal[
     'ip-address',
     'linkedin-link',
     'linkedin-person',
+    'person',
     'twitter-person',
     'url',
     'vhost',


### PR DESCRIPTION
## Summary

- add the generic `person` result kind to `CompletedResult`
- serialize each existing person mapping as compact JSON with sorted keys
- include generic people in canonical JSONL and completed-result persistence
- verify deterministic deduplication and SQLite round-trip behavior

## Why

Sources such as Venacus can add generic people to legacy output, but the canonical completed-result aggregation omitted them. The compact sorted JSON value preserves the existing `(type, value)` model without inventing provider provenance or changing the schema version.

## Verification

- focused pytest: 3 passed
- full pytest: 302 passed, 6 skipped
- Ruff check and format check passed
- mypy passed
- `git diff --check` passed
- parallel Standards and Spec reviews: zero findings

All provider behavior is mocked and offline.