### PR TITLE
fix: retain CNAME screenshot candidates

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,10 @@
+import sys
+from pathlib import Path
+
 import pytest
 
 from theHarvester import __main__ as theharvester_main
+from theHarvester.lib.completed_result import CompletedResult
 
 
 @pytest.mark.parametrize('target', ['Example.COM.', 'WWW.Example.COM.'])
@@ -14,3 +18,108 @@ def test_normalize_hosts_for_storage_uses_the_parser_scope(target: str) -> None:
     }
 
     assert theharvester_main._normalize_hosts_for_storage(discovered_hosts, target) == {'api.example.com'}
+
+
+@pytest.mark.asyncio
+async def test_dns_proven_cname_hosts_reach_screenshot_filter(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    visited: set[str] = set()
+
+    class FakeStash:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args) -> None:
+            return None
+
+        async def store(self, *_args) -> None:
+            return None
+
+        async def store_completed_result(self, _result: CompletedResult) -> None:
+            return None
+
+    class FakeCrtsh:
+        def __init__(self, _word: str) -> None:
+            pass
+
+        async def process(self, _proxy: bool) -> None:
+            return None
+
+        async def get_hostnames(self) -> set[str]:
+            return {'address.example.com', 'alias.example.com', 'unresolved.example.com'}
+
+    class FakeChecker:
+        def __init__(self, hosts: list[str], _nameservers: list[str]) -> None:
+            assert set(hosts) == {'address.example.com', 'alias.example.com', 'unresolved.example.com'}
+
+        async def check(self) -> tuple[list[str], list[str], list[str]]:
+            return (
+                ['address.example.com:192.0.2.1', 'alias.example.com'],
+                ['address.example.com', 'alias.example.com'],
+                ['192.0.2.1'],
+            )
+
+    class FakeScreenShotter:
+        slash = '/'
+
+        def __init__(self, output: str) -> None:
+            self.output = output
+
+        def verify_path(self) -> bool:
+            return True
+
+        async def verify_installation(self) -> None:
+            return None
+
+        async def visit(self, host: str) -> tuple[str, str]:
+            visited.add(host)
+            return host, 'https'
+
+        @staticmethod
+        def chunk_list(values: list[str], _size: int) -> list[list[str]]:
+            return [values]
+
+        async def take_screenshot(self, host: str) -> tuple[str, str]:
+            return host, f'{host}.png'
+
+    class FakePool:
+        def __init__(self, _workers: int) -> None:
+            pass
+
+        async def __aenter__(self) -> 'FakePool':
+            return self
+
+        async def __aexit__(self, *_args) -> None:
+            return None
+
+        async def map(self, function, values):
+            return [await function(value) for value in values]
+
+    monkeypatch.setattr(theharvester_main.stash, 'StashManager', FakeStash)
+    monkeypatch.setattr(theharvester_main.crtsh, 'SearchCrtsh', FakeCrtsh)
+    monkeypatch.setattr(theharvester_main.hostchecker, 'Checker', FakeChecker)
+    monkeypatch.setattr(theharvester_main, 'ScreenShotter', FakeScreenShotter)
+    monkeypatch.setattr(theharvester_main, 'Pool', FakePool)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'theHarvester',
+            '-d',
+            'example.com',
+            '-b',
+            'crtsh',
+            '-r',
+            '192.0.2.53',
+            '--screenshot',
+            str(tmp_path),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    assert visited == {'address.example.com', 'alias.example.com'}

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -332,6 +332,7 @@ async def start(rest_args: argparse.Namespace | None = None):
     engines: list = []
     # If the user specifies
     full: list = []
+    resolved_screenshot_hosts: set[str] = set()
     reported_host_ip_pairs: set[tuple[str, str]] = set()
     ips: list = []
     host_ip: list = []
@@ -395,12 +396,12 @@ async def start(rest_args: argparse.Namespace | None = None):
                     # If full, this is only getting resolved hosts
                     (
                         resolved_pair,
-                        _temp_hosts,
+                        resolved_hosts,
                         temp_ips,
                     ) = await full_hosts_checker.check()
                     all_ip.extend(temp_ips)
                     full.extend(resolved_pair)
-                    # full.extend(temp_hosts)
+                    resolved_screenshot_hosts.update(resolved_hosts)
                 else:
                     full.extend(host_names)
             else:
@@ -1464,6 +1465,7 @@ async def start(rest_args: argparse.Namespace | None = None):
         output_logger.info('\n[*] Starting DNS brute force.')
         dns_force = dnssearch.DnsForce(word, final_dns_resolver_list, verbose=True)
         resolved_pair, hosts, ips = await dns_force.run()
+        resolved_screenshot_hosts.update(hosts)
         # Check if Rest API is being used if so return found hosts
         if dnsbrute[1]:
             return resolved_pair
@@ -1542,7 +1544,7 @@ async def start(rest_args: argparse.Namespace | None = None):
             start_time = time.perf_counter()
             output_logger.info('Filtering domains for ones we can reach')
             if dnsresolve is None or len(final_dns_resolver_list) > 0:
-                unique_resolved_domains = {url.split(':')[0] for url in full if ':' in url}
+                unique_resolved_domains = resolved_screenshot_hosts
             else:
                 # Technically not resolved in this case, which is not ideal
                 # You should always use dns resolve when doing screenshotting


### PR DESCRIPTION
## Summary

- retain the resolved hostname set returned by the DNS checker
- include both address-backed and CNAME-only hosts in screenshot reachability checks
- include resolved DNS brute-force hosts through the same candidate set
- continue excluding unresolved hosts when DNS resolution is enabled

## Why

The DNS checker already preserves CNAME-only results, but screenshot selection rebuilt candidates only from `host:ip` strings. That discarded DNS-proven aliases before `ScreenShotter.visit()` could test them.

## Verification

- focused pytest: 16 passed
- full pytest: 302 passed, 6 skipped
- Ruff check and format check passed
- mypy passed
- `git diff --check` passed
- parallel Standards and Spec reviews: zero findings

The DNS and screenshot boundaries are mocked. No live reconnaissance was performed.