### PR TITLE
Harden public passive provider contracts

### DIFF
--- a/tests/discovery/test_otx.py
+++ b/tests/discovery/test_otx.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # coding=utf-8
+import logging
 from typing import Any
 
 import httpx
@@ -42,6 +43,43 @@ class TestOtx(object):
         await search.process()
         assert await search.get_hostnames() == {'api.example.com', 'www.example.com'}
         assert await search.get_ips() == {'192.0.2.1', '2001:db8::1'}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('payload', [None, [], {}, {'passive_dns': None}])
+    async def test_malformed_results_return_no_evidence(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        payload: Any,
+    ) -> None:
+        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[Any]:
+            return [payload]
+
+        monkeypatch.setattr(otxsearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        search = otxsearch.SearchOtx(TestOtx.domain())
+
+        await search.process()
+
+        assert await search.get_hostnames() == set()
+        assert await search.get_ips() == set()
+
+    @pytest.mark.asyncio
+    async def test_provider_failures_are_attributed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        async def failed_fetch(*_args: Any, **_kwargs: Any) -> list[Any]:
+            raise OSError('provider unavailable')
+
+        monkeypatch.setattr(otxsearch.AsyncFetcher, 'fetch_all', failed_fetch)
+        search = otxsearch.SearchOtx(TestOtx.domain())
+
+        with caplog.at_level(logging.INFO, logger=otxsearch.__name__):
+            await search.process()
+
+        assert await search.get_hostnames() == set()
+        assert await search.get_ips() == set()
+        assert 'OTX request failed' in caplog.text
 
 
 if __name__ == "__main__":

--- a/tests/discovery/test_rapiddns.py
+++ b/tests/discovery/test_rapiddns.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import sys
 import xml.etree.ElementTree as ElementTree
 from argparse import Namespace
@@ -44,6 +45,44 @@ async def test_rapiddns_separates_hostnames_ips_and_associations(monkeypatch: py
     }
     assert await search.get_ips() == {'192.0.2.1'}
     assert await search.get_host_ip_pairs() == {('api.example.com', '192.0.2.1')}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('payload', ['', '<html><p>no results</p></html>'])
+async def test_rapiddns_handles_empty_or_malformed_html(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: str,
+) -> None:
+    async def fake_response(*_args: Any, **_kwargs: Any) -> list[str]:
+        return [payload]
+
+    monkeypatch.setattr(rapiddns.AsyncFetcher, 'fetch_all', fake_response)
+    search = rapiddns.SearchRapidDns('example.com')
+
+    await search.process()
+
+    assert await search.get_hostnames() == []
+    assert await search.get_ips() == set()
+    assert await search.get_host_ip_pairs() == set()
+
+
+@pytest.mark.asyncio
+async def test_rapiddns_attributes_provider_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def failed_fetch(*_args: Any, **_kwargs: Any) -> list[str]:
+        raise OSError('provider unavailable')
+
+    monkeypatch.setattr(rapiddns.AsyncFetcher, 'fetch_all', failed_fetch)
+    search = rapiddns.SearchRapidDns('example.com')
+
+    with caplog.at_level(logging.INFO, logger=rapiddns.__name__):
+        await search.process()
+
+    assert await search.get_hostnames() == []
+    assert await search.get_ips() == set()
+    assert 'RapidDNS error' in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/discovery/test_robtex.py
+++ b/tests/discovery/test_robtex.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import pytest
@@ -20,3 +21,40 @@ async def test_robtex_does_not_send_domain_to_reverse_ip_endpoint(monkeypatch: p
     assert requested_urls == ['https://freeapi.robtex.com/pdns/forward/example.com']
     assert await search.get_hostnames() == {'api.example.com'}
     assert await search.get_ips() == {'192.0.2.1'}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('response', [[], [''], ['not-json\n{}\n[]']])
+async def test_robtex_handles_empty_or_malformed_responses(
+    monkeypatch: pytest.MonkeyPatch,
+    response: list[str],
+) -> None:
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[str]:
+        return response
+
+    monkeypatch.setattr(robtex.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = robtex.SearchRobtex('example.com')
+
+    await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert await search.get_ips() == set()
+
+
+@pytest.mark.asyncio
+async def test_robtex_attributes_provider_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def failed_fetch(*_args: Any, **_kwargs: Any) -> list[str]:
+        raise OSError('provider unavailable')
+
+    monkeypatch.setattr(robtex.AsyncFetcher, 'fetch_all', failed_fetch)
+    search = robtex.SearchRobtex('example.com')
+
+    with caplog.at_level(logging.INFO, logger=robtex.__name__):
+        await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert await search.get_ips() == set()
+    assert 'Robtex API error' in caplog.text

--- a/tests/discovery/test_subdomaincenter.py
+++ b/tests/discovery/test_subdomaincenter.py
@@ -1,3 +1,6 @@
+import logging
+from typing import Any
+
 import pytest
 
 from theHarvester.discovery import subdomaincenter
@@ -14,3 +17,48 @@ async def test_process_preserves_www_hostname(monkeypatch):
     await search.process()
 
     assert await search.get_hostnames() == {'www.example.com'}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('payload', 'expected'),
+    [
+        (None, set()),
+        ({'unexpected': 'shape'}, set()),
+        ('api.example.com', set()),
+        (['api.example.com', None], {'api.example.com'}),
+    ],
+)
+async def test_process_rejects_malformed_results(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: Any,
+    expected: set[str],
+) -> None:
+    async def fake_fetch_all(urls: list[str], **_kwargs: Any) -> list[Any]:
+        assert urls == ['https://api.subdomain.center/?domain=example.com']
+        return [payload]
+
+    monkeypatch.setattr(subdomaincenter.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = subdomaincenter.SubdomainCenter('example.com')
+
+    await search.process()
+
+    assert await search.get_hostnames() == expected
+
+
+@pytest.mark.asyncio
+async def test_process_attributes_provider_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def failed_fetch(*_args: Any, **_kwargs: Any) -> list[Any]:
+        raise OSError('provider unavailable')
+
+    monkeypatch.setattr(subdomaincenter.AsyncFetcher, 'fetch_all', failed_fetch)
+    search = subdomaincenter.SubdomainCenter('example.com')
+
+    with caplog.at_level(logging.INFO, logger=subdomaincenter.__name__):
+        await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert 'SubdomainCenter' in caplog.text

--- a/tests/discovery/test_threatcrowd.py
+++ b/tests/discovery/test_threatcrowd.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import Any
 
 import pytest
@@ -8,7 +9,7 @@ from theHarvester.discovery import threatcrowd
 
 _REPORT = {
     'response_code': '1',
-    'subdomains': [],
+    'subdomains': ['api.example.com', 'api.example.com', 'outside.test'],
     'resolutions': [
         {'ip_address': '192.0.2.1'},
         {'ip_address': '2001:0db8::1'},
@@ -32,4 +33,42 @@ async def test_process_retains_only_valid_ip_addresses(monkeypatch: pytest.Monke
 
     await search.process()
 
+    assert await search.get_hostnames() == {'api.example.com'}
     assert await search.get_ips() == {'192.0.2.1', '2001:db8::1', '2001:db8::2'}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('payload', ['', 'not-json', '[]', '{"subdomains":"wrong-shape"}'])
+async def test_process_handles_empty_or_malformed_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: str,
+) -> None:
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[str]:
+        return [payload]
+
+    monkeypatch.setattr(threatcrowd.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = threatcrowd.SearchThreatcrowd('example.com')
+
+    await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert await search.get_ips() == set()
+
+
+@pytest.mark.asyncio
+async def test_process_attributes_provider_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[dict[str, str]]:
+        return [{'response_code': '0'}]
+
+    monkeypatch.setattr(threatcrowd.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = threatcrowd.SearchThreatcrowd('example.com')
+
+    with caplog.at_level(logging.INFO, logger=threatcrowd.__name__):
+        await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert await search.get_ips() == set()
+    assert 'ThreatCrowd API returned error code' in caplog.text

--- a/theHarvester/discovery/otxsearch.py
+++ b/theHarvester/discovery/otxsearch.py
@@ -1,7 +1,10 @@
+import logging
 from ipaddress import ip_address
 from typing import Any
 
 from theHarvester.lib.core import AsyncFetcher
+
+logger = logging.getLogger(__name__)
 
 
 class SearchOtx:
@@ -18,6 +21,7 @@ class SearchOtx:
         except (OSError, RuntimeError, ValueError):
             self.totalhosts = set()
             self.totalips = set()
+            logger.info('OTX request failed')
             return
 
         # Expect a list with one JSON-decoded dict

--- a/theHarvester/discovery/rapiddns.py
+++ b/theHarvester/discovery/rapiddns.py
@@ -55,7 +55,7 @@ class SearchRapidDns:
                     self.totalips.add(address)
                     self.host_ip_pairs.add((subdomain, address))
         except Exception as e:
-            logger.info(f'An exception has occurred: {e!s}')
+            logger.info(f'RapidDNS error: {e!s}')
 
     async def process(self, proxy: bool = False) -> None:
         self.proxy = proxy

--- a/theHarvester/discovery/subdomaincenter.py
+++ b/theHarvester/discovery/subdomaincenter.py
@@ -17,7 +17,12 @@ class SubdomainCenter:
         try:
             current_url = f'{self.server}{self.word}'
             resp = await AsyncFetcher.fetch_all([current_url], headers=headers, proxy=self.proxy, json=True)
-            self.results = set(resp[0])
+            payload = resp[0] if resp else []
+            self.results = (
+                {hostname for hostname in payload if isinstance(hostname, str) and hostname.strip()}
+                if isinstance(payload, list)
+                else set()
+            )
         except Exception as e:
             logger.info(f'An exception has occurred in SubdomainCenter on : {e}')
 


### PR DESCRIPTION
## Summary

- add deterministic offline success, empty or malformed response, deduplication, and provider-failure contracts for OTX, RapidDNS, Robtex, Subdomain Center, and ThreatCrowd
- reject non-list and non-string Subdomain Center payload data
- make OTX and RapidDNS transport failures source-attributable
- preserve existing public getters, central hostname normalization, CLI, REST, JSON, JSONL, XML, and SQLite behavior

## Why

These public passive providers had shallow or missing failure contracts. Subdomain Center could expose dictionary keys, individual string characters, or None values through its public getter when the provider returned an unexpected shape.

Fork tracking issue: https://github.com/NotoriousRebel/theHarvester/issues/98

## Remaining follow-up

HTTP 429, 5xx, and rate-limit attribution requires the opt-in shared metadata seam in upstream PR #2471 and a later provider-adoption slice. This PR does not add retry policy or claim that final criterion.

## Verification

- focused pytest: 29 passed, 1 opt-in live test skipped
- full pytest: 329 passed, 6 opt-in live tests skipped
- Ruff check and format: passed
- mypy theHarvester: passed
- git diff check and zero em-dash check: passed
- parallel Standards and Spec reviews: zero findings

All new provider contracts are offline and use reserved example data.