### PR TITLE
Bound OTX rate-limit retries

### DIFF
--- a/tests/discovery/test_otx.py
+++ b/tests/discovery/test_otx.py
@@ -7,7 +7,7 @@ import httpx
 import pytest
 
 from theHarvester.discovery import otxsearch
-from theHarvester.lib.core import Core
+from theHarvester.lib.core import Core, FetcherResponse
 
 
 class TestOtx(object):
@@ -25,17 +25,21 @@ class TestOtx(object):
 
     @pytest.mark.asyncio
     async def test_search(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[dict[str, list[dict[str, Any]]]]:
+        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
             return [
-                {
-                    'passive_dns': [
-                        {'hostname': 'api.example.com', 'address': '192.0.2.1'},
-                        {'hostname': 'api.example.com', 'address': '2001:0db8::1'},
-                        {'hostname': 'api.example.com', 'address': '999.0.0.1'},
-                        {'hostname': 'www.example.com', 'address': 'NXDOMAIN'},
-                        {'hostname': 'www.example.com', 'address': 1234},
-                    ]
-                }
+                FetcherResponse(
+                    body={
+                        'passive_dns': [
+                            {'hostname': 'api.example.com', 'address': '192.0.2.1'},
+                            {'hostname': 'api.example.com', 'address': '2001:0db8::1'},
+                            {'hostname': 'api.example.com', 'address': '999.0.0.1'},
+                            {'hostname': 'www.example.com', 'address': 'NXDOMAIN'},
+                            {'hostname': 'www.example.com', 'address': 1234},
+                        ]
+                    },
+                    status=200,
+                    headers={},
+                )
             ]
 
         monkeypatch.setattr(otxsearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
@@ -51,8 +55,8 @@ class TestOtx(object):
         monkeypatch: pytest.MonkeyPatch,
         payload: Any,
     ) -> None:
-        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[Any]:
-            return [payload]
+        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+            return [FetcherResponse(body=payload, status=200, headers={})]
 
         monkeypatch.setattr(otxsearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
         search = otxsearch.SearchOtx(TestOtx.domain())
@@ -81,6 +85,75 @@ class TestOtx(object):
         assert await search.get_ips() == set()
         assert 'OTX request failed' in caplog.text
 
+    @pytest.mark.asyncio
+    async def test_rate_limit_waits_once_then_returns_evidence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        responses = [
+            FetcherResponse(body={'error': 'rate limited'}, status=429, headers={'retry-after': '2'}),
+            FetcherResponse(
+                body={'passive_dns': [{'hostname': 'api.example.com', 'address': '192.0.2.1'}]},
+                status=200,
+                headers={},
+            ),
+        ]
+        waits: list[float] = []
 
-if __name__ == "__main__":
+        async def fake_fetch_all(*_args: Any, **kwargs: Any) -> list[FetcherResponse]:
+            assert kwargs['include_metadata'] is True
+            return [responses.pop(0)]
+
+        async def fake_sleep(seconds: float) -> None:
+            waits.append(seconds)
+
+        monkeypatch.setattr(otxsearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        monkeypatch.setattr(otxsearch.asyncio, 'sleep', fake_sleep)
+        search = otxsearch.SearchOtx(TestOtx.domain())
+
+        await search.process()
+
+        assert waits == [2]
+        assert await search.get_hostnames() == {'api.example.com'}
+        assert await search.get_ips() == {'192.0.2.1'}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ('retry_after', 'expected_waits', 'response_count'),
+        [
+            (None, [5], 2),
+            ('invalid', [5], 2),
+            ('61', [], 1),
+        ],
+    )
+    async def test_rate_limit_retry_is_bounded(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        retry_after: str | None,
+        expected_waits: list[int],
+        response_count: int,
+    ) -> None:
+        headers = {} if retry_after is None else {'retry-after': retry_after}
+        responses = [FetcherResponse(body={}, status=429, headers=headers) for _ in range(response_count)]
+        waits: list[float] = []
+
+        async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+            return [responses.pop(0)]
+
+        async def fake_sleep(seconds: float) -> None:
+            waits.append(seconds)
+
+        monkeypatch.setattr(otxsearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        monkeypatch.setattr(otxsearch.asyncio, 'sleep', fake_sleep)
+        search = otxsearch.SearchOtx(TestOtx.domain())
+
+        with caplog.at_level(logging.INFO, logger=otxsearch.__name__):
+            await search.process()
+
+        assert responses == []
+        assert waits == expected_waits
+        assert await search.get_hostnames() == set()
+        assert await search.get_ips() == set()
+        assert 'OTX request failed with HTTP 429' in caplog.text
+
+
+if __name__ == '__main__':
     pytest.main()

--- a/theHarvester/discovery/otxsearch.py
+++ b/theHarvester/discovery/otxsearch.py
@@ -1,13 +1,17 @@
+import asyncio
 import logging
 from ipaddress import ip_address
 from typing import Any
 
-from theHarvester.lib.core import AsyncFetcher
+from theHarvester.lib.core import AsyncFetcher, FetcherResponse
 
 logger = logging.getLogger(__name__)
 
 
 class SearchOtx:
+    DEFAULT_RETRY_DELAY_SECONDS = 5
+    MAX_RETRY_DELAY_SECONDS = 60
+
     def __init__(self, word) -> None:
         self.word = word
         self.totalhosts: set = set()
@@ -17,15 +21,44 @@ class SearchOtx:
     async def do_search(self) -> None:
         url = f'https://otx.alienvault.com/api/v1/indicators/domain/{self.word}/passive_dns'
         try:
-            response_list = await AsyncFetcher.fetch_all([url], json=True, proxy=self.proxy)
+            response_list = await AsyncFetcher.fetch_all(
+                [url],
+                json=True,
+                proxy=self.proxy,
+                include_metadata=True,
+            )
+            response = response_list[0] if response_list and isinstance(response_list[0], FetcherResponse) else None
+            if response is not None and response.status == 429:
+                retry_after = response.headers.get('retry-after')
+                try:
+                    retry_delay = int(retry_after) if retry_after is not None else self.DEFAULT_RETRY_DELAY_SECONDS
+                except ValueError:
+                    retry_delay = self.DEFAULT_RETRY_DELAY_SECONDS
+                if 0 <= retry_delay <= self.MAX_RETRY_DELAY_SECONDS:
+                    logger.info(f'OTX rate limited; retrying once in {retry_delay} seconds')
+                    await asyncio.sleep(retry_delay)
+                    response_list = await AsyncFetcher.fetch_all(
+                        [url],
+                        json=True,
+                        proxy=self.proxy,
+                        include_metadata=True,
+                    )
+                    response = response_list[0] if response_list and isinstance(response_list[0], FetcherResponse) else None
         except (OSError, RuntimeError, ValueError):
             self.totalhosts = set()
             self.totalips = set()
             logger.info('OTX request failed')
             return
 
+        if response is None:
+            logger.info('OTX request failed')
+            return
+        if not 200 <= response.status < 300:
+            logger.info(f'OTX request failed with HTTP {response.status}')
+            return
+
         # Expect a list with one JSON-decoded dict
-        dct: Any = response_list[0] if response_list else {}
+        dct: Any = response.body
         if not isinstance(dct, dict):
             self.totalhosts = set()
             self.totalips = set()


### PR DESCRIPTION
## Summary

- request shared response metadata from OTX
- retry one HTTP 429 after a bounded delay
- honor numeric `Retry-After` values through 60 seconds and use a 5-second fallback when the header is absent or malformed
- stop without retrying when the requested delay is negative or exceeds the ceiling
- keep final HTTP failures attributable to OTX without retaining response payloads

OTX performs one request per target, so an unconditional pause between requests cannot prevent the first 429. The public OTX API documentation does not publish a numeric pacing interval, and an authorized `mozilla.org` request returned 429 without `Retry-After` or quota headers. This policy therefore retries conservatively once instead of slowing every successful run. The official OTX Python SDK retries 429 and selected 5xx responses more aggressively; this adapter intentionally stays bounded so `-b all` remains finite.

Tracks NotoriousRebel/theHarvester#98.

## Verification

- focused pytest: 10 passed, 1 skipped
- full pytest: 340 passed, 6 skipped
- Ruff check and format check
- mypy
- `git diff --check`
- zero em dashes
- parallel Standards and Spec reviews against `8ba887f3ec235fb5390b1164b8f09f9d39f90123`: zero findings
- live OTX adapter run against `mozilla.org`: waited 5 seconds, retried once, reported final HTTP 429, returned zero results, and exited cleanly

Tests are offline and no response payloads were retained.