### PR TITLE
Attribute public provider HTTP failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expanded offline regression coverage for discovery providers, configuration contracts, logging, output, documentation, workflow policy, and scope boundaries.
 
 ### Fixed
+- Made RapidDNS, Robtex, and Subdomain Center HTTP failures report the source and response status before parsing.
 - Fixed GitHub code-search fragment limits, boundary separation, and malformed-page termination with offline provider tests.
 - Fixed GitLab public discovery scope normalization, request bounds, and default-branch README requests.
 - Fixed Baidu, Mojeek, and Yahoo page-response separation and Brave missing-credential reporting, with offline web-search provider contract coverage.

--- a/tests/discovery/test_rapiddns.py
+++ b/tests/discovery/test_rapiddns.py
@@ -13,6 +13,7 @@ import pytest
 import theHarvester.__main__ as theharvester_main
 from theHarvester.discovery import rapiddns
 from theHarvester.lib.completed_result import CompletedResult
+from theHarvester.lib.core import FetcherResponse
 from theHarvester.lib.output import configure_logging
 
 RAPID_DNS_HTML = """
@@ -24,9 +25,9 @@ RAPID_DNS_HTML = """
 """
 
 
-async def fake_fetch_all(_urls: list[str], **_kwargs: Any) -> list[str]:
+async def fake_fetch_all(_urls: list[str], **_kwargs: Any) -> list[FetcherResponse]:
     await asyncio.sleep(0)
-    return [RAPID_DNS_HTML]
+    return [FetcherResponse(body=RAPID_DNS_HTML, status=200, headers={})]
 
 
 @pytest.mark.asyncio
@@ -53,8 +54,8 @@ async def test_rapiddns_handles_empty_or_malformed_html(
     monkeypatch: pytest.MonkeyPatch,
     payload: str,
 ) -> None:
-    async def fake_response(*_args: Any, **_kwargs: Any) -> list[str]:
-        return [payload]
+    async def fake_response(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        return [FetcherResponse(body=payload, status=200, headers={})]
 
     monkeypatch.setattr(rapiddns.AsyncFetcher, 'fetch_all', fake_response)
     search = rapiddns.SearchRapidDns('example.com')
@@ -83,6 +84,26 @@ async def test_rapiddns_attributes_provider_failures(
     assert await search.get_hostnames() == []
     assert await search.get_ips() == set()
     assert 'RapidDNS error' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_rapiddns_attributes_http_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def rate_limited_fetch(*_args: Any, **kwargs: Any) -> list[FetcherResponse]:
+        assert kwargs['include_metadata'] is True
+        return [FetcherResponse(body='rate limited', status=429, headers={})]
+
+    monkeypatch.setattr(rapiddns.AsyncFetcher, 'fetch_all', rate_limited_fetch)
+    search = rapiddns.SearchRapidDns('example.com')
+
+    with caplog.at_level(logging.INFO, logger=rapiddns.__name__):
+        await search.process()
+
+    assert await search.get_hostnames() == []
+    assert await search.get_ips() == set()
+    assert 'RapidDNS request failed with HTTP 429' in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/discovery/test_robtex.py
+++ b/tests/discovery/test_robtex.py
@@ -4,15 +4,22 @@ from typing import Any
 import pytest
 
 from theHarvester.discovery import robtex
+from theHarvester.lib.core import FetcherResponse
 
 
 @pytest.mark.asyncio
 async def test_robtex_does_not_send_domain_to_reverse_ip_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
     requested_urls: list[str] = []
 
-    async def fake_fetch_all(urls: list[str], **_kwargs: Any) -> list[str]:
+    async def fake_fetch_all(urls: list[str], **_kwargs: Any) -> list[FetcherResponse]:
         requested_urls.extend(urls)
-        return ['{"rrname":"api.example.com","rrtype":"A","rrdata":"192.0.2.1"}']
+        return [
+            FetcherResponse(
+                body='{"rrname":"api.example.com","rrtype":"A","rrdata":"192.0.2.1"}',
+                status=200,
+                headers={},
+            )
+        ]
 
     monkeypatch.setattr(robtex.AsyncFetcher, 'fetch_all', fake_fetch_all)
     search = robtex.SearchRobtex('example.com')
@@ -29,8 +36,8 @@ async def test_robtex_handles_empty_or_malformed_responses(
     monkeypatch: pytest.MonkeyPatch,
     response: list[str],
 ) -> None:
-    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[str]:
-        return response
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        return [FetcherResponse(body=payload, status=200, headers={}) for payload in response]
 
     monkeypatch.setattr(robtex.AsyncFetcher, 'fetch_all', fake_fetch_all)
     search = robtex.SearchRobtex('example.com')
@@ -58,3 +65,23 @@ async def test_robtex_attributes_provider_failures(
     assert await search.get_hostnames() == set()
     assert await search.get_ips() == set()
     assert 'Robtex API error' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_robtex_attributes_http_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def failed_fetch(*_args: Any, **kwargs: Any) -> list[FetcherResponse]:
+        assert kwargs['include_metadata'] is True
+        return [FetcherResponse(body='service unavailable', status=503, headers={})]
+
+    monkeypatch.setattr(robtex.AsyncFetcher, 'fetch_all', failed_fetch)
+    search = robtex.SearchRobtex('example.com')
+
+    with caplog.at_level(logging.INFO, logger=robtex.__name__):
+        await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert await search.get_ips() == set()
+    assert 'Robtex request failed with HTTP 503' in caplog.text

--- a/tests/discovery/test_subdomaincenter.py
+++ b/tests/discovery/test_subdomaincenter.py
@@ -4,12 +4,13 @@ from typing import Any
 import pytest
 
 from theHarvester.discovery import subdomaincenter
+from theHarvester.lib.core import FetcherResponse
 
 
 @pytest.mark.asyncio
 async def test_process_preserves_www_hostname(monkeypatch):
-    async def fake_fetch_all(urls, headers=None, proxy=False, json=False):
-        return [['www.example.com']]
+    async def fake_fetch_all(urls, **_kwargs):
+        return [FetcherResponse(body=['www.example.com'], status=200, headers={})]
 
     monkeypatch.setattr(subdomaincenter.AsyncFetcher, 'fetch_all', staticmethod(fake_fetch_all))
     search = subdomaincenter.SubdomainCenter('example.com')
@@ -34,9 +35,9 @@ async def test_process_rejects_malformed_results(
     payload: Any,
     expected: set[str],
 ) -> None:
-    async def fake_fetch_all(urls: list[str], **_kwargs: Any) -> list[Any]:
+    async def fake_fetch_all(urls: list[str], **_kwargs: Any) -> list[FetcherResponse]:
         assert urls == ['https://api.subdomain.center/?domain=example.com']
-        return [payload]
+        return [FetcherResponse(body=payload, status=200, headers={})]
 
     monkeypatch.setattr(subdomaincenter.AsyncFetcher, 'fetch_all', fake_fetch_all)
     search = subdomaincenter.SubdomainCenter('example.com')
@@ -62,3 +63,22 @@ async def test_process_attributes_provider_failures(
 
     assert await search.get_hostnames() == set()
     assert 'SubdomainCenter' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_process_attributes_http_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def failed_fetch(*_args: Any, **kwargs: Any) -> list[FetcherResponse]:
+        assert kwargs['include_metadata'] is True
+        return [FetcherResponse(body=[], status=429, headers={})]
+
+    monkeypatch.setattr(subdomaincenter.AsyncFetcher, 'fetch_all', failed_fetch)
+    search = subdomaincenter.SubdomainCenter('example.com')
+
+    with caplog.at_level(logging.INFO, logger=subdomaincenter.__name__):
+        await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert 'SubdomainCenter request failed with HTTP 429' in caplog.text

--- a/theHarvester/discovery/rapiddns.py
+++ b/theHarvester/discovery/rapiddns.py
@@ -4,7 +4,7 @@ import logging
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 
-from theHarvester.lib.core import AsyncFetcher, Core
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
 
 logger = logging.getLogger(__name__)
 
@@ -23,10 +23,22 @@ class SearchRapidDns:
             # TODO see if it's worth adding sameip searches
             # f'{self.hostname}/sameip/{self.word}?full=1#result'
             urls = [f'https://rapiddns.io/subdomain/{self.word}?full=1#result']
-            responses = await AsyncFetcher.fetch_all(urls, headers=headers, proxy=self.proxy)
-            if len(responses[0]) <= 1:
+            responses: list[FetcherResponse | None] = await AsyncFetcher.fetch_all(
+                urls,
+                headers=headers,
+                proxy=self.proxy,
+                include_metadata=True,
+            )
+            response = responses[0] if responses else None
+            if response is None:
+                logger.info('RapidDNS request failed')
                 return
-            soup = BeautifulSoup(responses[0], 'html.parser')
+            if not 200 <= response.status < 300:
+                logger.info(f'RapidDNS request failed with HTTP {response.status}')
+                return
+            if not isinstance(response.body, str) or len(response.body) <= 1:
+                return
+            soup = BeautifulSoup(response.body, 'html.parser')
             table_el = soup.find('table')
             if not isinstance(table_el, Tag):
                 return

--- a/theHarvester/discovery/robtex.py
+++ b/theHarvester/discovery/robtex.py
@@ -4,7 +4,7 @@ from types import ModuleType
 
 import aiohttp
 
-from theHarvester.lib.core import AsyncFetcher, Core
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
 
 logger = logging.getLogger(__name__)
 
@@ -50,14 +50,25 @@ class SearchRobtex:
 
             # Use passive DNS forward lookup to get subdomains
             url = f'{self.hostname}/pdns/forward/{self.word}'
-            response = await AsyncFetcher.fetch_all([url], headers=headers, proxy=self.proxy)
-
-            if not response or not isinstance(response, list) or not response[0]:
+            responses: list[FetcherResponse | None] = await AsyncFetcher.fetch_all(
+                [url],
+                headers=headers,
+                proxy=self.proxy,
+                include_metadata=True,
+            )
+            response = responses[0] if responses else None
+            if response is None:
+                logger.info(f'No response from Robtex API for: {url}')
+                return
+            if not 200 <= response.status < 300:
+                logger.info(f'Robtex request failed with HTTP {response.status}')
+                return
+            if not isinstance(response.body, str) or not response.body:
                 logger.info(f'No response from Robtex API for: {url}')
                 return
 
             try:
-                data = self._safe_parse_json_lines(response[0])
+                data = self._safe_parse_json_lines(response.body)
             except (TypeError, ValueError) as e:
                 logger.info(f'Failed to parse JSON lines from Robtex response: {e}')
                 return

--- a/theHarvester/discovery/subdomaincenter.py
+++ b/theHarvester/discovery/subdomaincenter.py
@@ -1,6 +1,6 @@
 import logging
 
-from theHarvester.lib.core import AsyncFetcher, Core
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
 
 logger = logging.getLogger(__name__)
 
@@ -16,8 +16,21 @@ class SubdomainCenter:
         headers = {'User-Agent': Core.get_user_agent()}
         try:
             current_url = f'{self.server}{self.word}'
-            resp = await AsyncFetcher.fetch_all([current_url], headers=headers, proxy=self.proxy, json=True)
-            payload = resp[0] if resp else []
+            responses: list[FetcherResponse | None] = await AsyncFetcher.fetch_all(
+                [current_url],
+                headers=headers,
+                proxy=self.proxy,
+                json=True,
+                include_metadata=True,
+            )
+            response = responses[0] if responses else None
+            if response is None:
+                logger.info('SubdomainCenter request failed')
+                return
+            if not 200 <= response.status < 300:
+                logger.info(f'SubdomainCenter request failed with HTTP {response.status}')
+                return
+            payload = response.body
             self.results = (
                 {hostname for hostname in payload if isinstance(hostname, str) and hostname.strip()}
                 if isinstance(payload, list)


### PR DESCRIPTION
## Summary

- opt RapidDNS, Robtex, and Subdomain Center into the shared response-metadata seam from #2471
- reject non-2xx responses before parsing and log each provider with its HTTP status
- keep transport failures source-attributable without retaining response payloads
- preserve existing public getters and CLI, REST, JSON, JSONL, XML, and SQLite behavior

This completes the remaining shared-fetch status-adoption follow-up identified in #2472 after OTX received its provider-specific bounded retry policy in #2473. No retry policy is added here because these providers do not share one documented pacing contract.

ThreatCrowd was removed from this PR after research showed that both service hostnames terminate at deleted AWS ELBs and return NXDOMAIN, so there is no HTTP response whose status can be attributed. Its removal is being handled as a separate focused change. Retries, pacing, credentials, or redirecting it to OTX would not repair that DNS-level failure, and OTX already has a distinct adapter.

Tracks NotoriousRebel/theHarvester#98.

## Verification

- focused pytest: 19 passed
- full pytest: 343 passed, 6 skipped
- Ruff check and format check
- mypy
- `git diff --check`
- zero em dashes
- parallel Standards and Spec reviews against `c8d4cbebaaf9e060852d817add959b1c5994fee3`: pass
- authorized P0 live smoke against `mozilla.org`: RapidDNS returned 94 hosts; Robtex returned 1 host and 6 IPs; Subdomain Center returned 491 hosts

All committed tests are offline. No live response payloads were retained or published.
