### PR TITLE
Stop THC retries before the final sleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the nonfunctional ThreatCrowd source because its service hostnames terminate at deleted AWS load balancers and return NXDOMAIN; OTX remains available through its separate adapter.
 
 ### Fixed
+- Fixed THC rate-limit exhaustion so terminal failures are reported without sleeping after the final attempt, with offline recovery, non-success, and malformed-response contracts.
 - Made RapidDNS, Robtex, and Subdomain Center HTTP failures report the source and response status before parsing.
 - Fixed GitHub code-search fragment limits, boundary separation, and malformed-page termination with offline provider tests.
 - Fixed GitLab public discovery scope normalization, request bounds, and default-branch README requests.

--- a/tests/discovery/test_thc.py
+++ b/tests/discovery/test_thc.py
@@ -22,11 +22,10 @@ from theHarvester.lib.core import Core
 
 
 class FakeResponse:
-    status = 200
-    headers: dict[str, str] = {}
-
-    def __init__(self, text: str) -> None:
+    def __init__(self, text: str, status: int = 200, headers: dict[str, str] | None = None) -> None:
         self._text = text
+        self.status = status
+        self.headers = headers or {}
 
     async def __aenter__(self) -> Self:
         return self
@@ -63,9 +62,33 @@ class FakeSession:
         return FakeResponse(f'WWW.{domain}\napi.{domain}\napi.{domain}\n')
 
 
+def session_for(*outcomes: FakeResponse | Exception) -> type[FakeSession]:
+    remaining = iter(outcomes)
+
+    class SequencedSession(FakeSession):
+        def get(self, _url: str) -> FakeResponse:
+            outcome = next(remaining)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+    return SequencedSession
+
+
 @pytest.fixture(autouse=True)
 def fake_thc_session(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(thc.aiohttp, 'ClientSession', FakeSession)
+
+
+@pytest.fixture
+def recorded_sleeps(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    sleeps: list[int] = []
+
+    async def record_sleep(seconds: int) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(thc.asyncio, 'sleep', record_sleep)
+    return sleeps
 
 
 # =============================================================================
@@ -153,6 +176,90 @@ class TestThcSubdomainSearch:
         result = await search.get_hostnames()
         result_list = list(result)
         assert len(result_list) == len(set(result_list))
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ('outcomes', 'message'),
+        [
+            (
+                tuple(FakeResponse('', status=429) for _ in range(3)),
+                'THC returned status 429 after 3 attempts',
+            ),
+            (
+                tuple(RuntimeError('429 too many requests') for _ in range(3)),
+                'THC rate limit failure after 3 attempts',
+            ),
+        ],
+    )
+    async def test_final_rate_limit_is_attributed_without_an_extra_sleep(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        recorded_sleeps: list[int],
+        caplog: pytest.LogCaptureFixture,
+        outcomes: tuple[FakeResponse | Exception, ...],
+        message: str,
+    ) -> None:
+        monkeypatch.setattr(
+            thc.aiohttp,
+            'ClientSession',
+            session_for(FakeResponse('kept.example.com\n'), *outcomes),
+        )
+        search = thc.SearchThc(self.domain())
+        await search.process()
+
+        with caplog.at_level('INFO', logger=thc.__name__):
+            await search.process()
+
+        assert await search.get_hostnames() == {'kept.example.com'}
+        assert recorded_sleeps == [2, 4]
+        assert message in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_retry_recovers(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        recorded_sleeps: list[int],
+    ) -> None:
+        monkeypatch.setattr(
+            thc.aiohttp,
+            'ClientSession',
+            session_for(FakeResponse('', status=429), FakeResponse('WWW.example.com\napi.example.com\n')),
+        )
+        search = thc.SearchThc(self.domain())
+
+        await search.process()
+
+        assert recorded_sleeps == [2]
+        assert await search.get_hostnames() == {'www.example.com', 'api.example.com'}
+
+    @pytest.mark.asyncio
+    async def test_non_success_status_is_attributed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setattr(thc.aiohttp, 'ClientSession', session_for(FakeResponse('', status=503)))
+        search = thc.SearchThc(self.domain())
+
+        with caplog.at_level('INFO', logger=thc.__name__):
+            await search.process()
+
+        assert await search.get_hostnames() == set()
+        assert 'THC returned status 503' in caplog.text
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('payload', ['', '\n\t\n', 'not a hostname'])
+    async def test_empty_or_malformed_payloads_fail_safely(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        payload: str,
+    ) -> None:
+        monkeypatch.setattr(thc.aiohttp, 'ClientSession', session_for(FakeResponse(payload)))
+        search = thc.SearchThc(self.domain())
+
+        await search.process()
+
+        assert await search.get_hostnames() == set()
 
 
 # =============================================================================

--- a/theHarvester/discovery/thc.py
+++ b/theHarvester/discovery/thc.py
@@ -29,6 +29,9 @@ class SearchThc:
                     async with session.get(url) as response:
                         if response.status == 429:
                             rate_remaining = response.headers.get('x-ratelimit-remaining', '0')
+                            if attempt == self.max_retries - 1:
+                                logger.info(f'THC returned status 429 after {self.max_retries} attempts')
+                                return
                             wait_time = self.base_delay * (attempt + 1)
                             logger.info(f'THC rate limit hit (remaining: {rate_remaining}). Waiting {wait_time}s before retry...')
                             await asyncio.sleep(wait_time)
@@ -49,6 +52,9 @@ class SearchThc:
             except Exception as e:
                 error_msg = str(e).lower()
                 if '429' in error_msg or 'rate' in error_msg:
+                    if attempt == self.max_retries - 1:
+                        logger.info(f'THC rate limit failure after {self.max_retries} attempts')
+                        return
                     wait_time = self.base_delay * (attempt + 1)
                     logger.info(f'THC rate limit detected. Waiting {wait_time}s before retry...')
                     await asyncio.sleep(wait_time)


### PR DESCRIPTION
## Summary

- stop THC retry exhaustion before the useless final sleep
- report terminal HTTP 429 and exception-based rate-limit failures with source attribution and attempt count
- preserve results already collected on the adapter and keep the existing three-attempt, 2-second then 4-second retry policy
- add deterministic offline contracts for recovery, exhaustion, 503 attribution, empty and malformed payloads, and partial-result preservation

## Why this policy

THC makes one provider request per search, so there is no normal pagination or request stream where an inter-request delay could prevent rate limiting. The existing bounded retry policy remains unchanged: up to three attempts, waiting 2 seconds and then 4 seconds only when a retry will actually occur. Sleeping 6 seconds after the third and final failure delayed completion without making another request.

The terminal exception log intentionally omits raw exception text because an HTTP exception can contain the request URL and operator target.

Tracks NotoriousRebel/theHarvester#98.

## Verification

- red-green: final HTTP 429 initially slept `[2, 4, 6]`; now sleeps `[2, 4]` and reports exhaustion
- red-green: exception-based rate limiting had the same extra final sleep; now stops and reports exhaustion without logging the raw exception
- focused offline pytest: 29 passed, 4 live tests skipped
- full pytest: 347 passed, 6 skipped
- Ruff check and format check
- mypy
- `git diff --check`
- zero em dashes
- final parallel Standards and Spec reviews against `c8d4cbebaaf9e060852d817add959b1c5994fee3`: pass
- opt-in live THC tests against `mozilla.org`: 4 passed
- real THC adapter run against `mozilla.org`: 880 hostnames, no payload retained

All committed tests are offline. No CLI, REST, JSON, JSONL, XML, SQLite, source-selection, or public getter contract changed.
