### PR TITLE
Fix public Have I Been Pwned breach catalogue contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the nonfunctional ThreatCrowd source because its service hostnames terminate at deleted AWS load balancers and return NXDOMAIN; OTX remains available through its separate adapter.
 
 ### Fixed
+- Made the public Have I Been Pwned breach catalogue keyless and added offline response contracts.
 - Fixed THC rate-limit exhaustion so terminal failures are reported without sleeping after the final attempt, with offline recovery, non-success, and malformed-response contracts.
 - Made RapidDNS, Robtex, and Subdomain Center HTTP failures report the source and response status before parsing.
 - Fixed GitHub code-search fragment limits, boundary separation, and malformed-page termination with offline provider tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the nonfunctional ThreatCrowd source because its service hostnames terminate at deleted AWS load balancers and return NXDOMAIN; OTX remains available through its separate adapter.
 
 ### Fixed
-- Made the public Have I Been Pwned breach catalogue keyless and added offline response contracts.
+- Made the public Have I Been Pwned breach catalogue keyless, added offline response contracts, and retained stable breach names in completed JSONL and SQLite results.
 - Fixed THC rate-limit exhaustion so terminal failures are reported without sleeping after the final attempt, with offline recovery, non-success, and malformed-response contracts.
 - Made RapidDNS, Robtex, and Subdomain Center HTTP failures report the source and response status before parsing.
 - Fixed GitHub code-search fragment limits, boundary separation, and malformed-page termination with offline provider tests.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Read the **API key** column as follows:
 | `github-code` | ✓ | ✓ | No | No | No | No | No | ✓ |
 | `gitlab` | ✓ | ✓ | No | No | No | No | No | No |
 | `hackertarget` | ✓ | No | No | No | No | No | No | Optional |
-| `haveibeenpwned` | No | No | No | No | No | No | `POST /additional/breaches` response | ✓ |
+| `haveibeenpwned` | No | No | No | No | No | No | `POST /additional/breaches` response | No |
 | `hudsonrock` | ✓ | ✓ | ✓ | No | No | No | No | No |
 | `hunter` | ✓ | ✓ | No | No | No | No | No | ✓ |
 | `hunterhow` | ✓ | No | No | No | No | No | No | ✓ |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Combine capability selectors, or mix them with explicit source names:
 uv run theHarvester -d example.com -b emails,urls,certspotter
 ```
 
-Capability selectors form a union and choose which sources run. They do not discard other result types returned by those sources. Available selectors are `subdomains`, `emails`, `ips`, `asns`, `urls`, and `people`. `-b all` continues to run every registered source.
+Capability selectors form a union and choose which sources run. They do not discard other result types returned by those sources. Available selectors are `subdomains`, `emails`, `ips`, `asns`, `urls`, `people`, and `breaches`. `-b all` continues to run every registered source.
 
 Save JSON, XML, and JSONL reports:
 
@@ -114,7 +114,7 @@ docker compose up --build
 
 ## Discovery sources
 
-The table shows which result types each source can add to the JSON report. It covers the consolidated CLI report only. Some adapters parse fields that the report does not store.
+The table shows which result types each source can add to consolidated CLI results. Legacy JSON and XML keep their existing schemas; breach names are retained in JSONL and SQLite. Some adapters parse fields that the reports do not store.
 
 The report groups findings by result type. It does not record which source found each item. Empty optional fields may be omitted.
 
@@ -129,62 +129,62 @@ Read the **API key** column as follows:
 <details>
 <summary><strong>View the source and result matrix</strong></summary>
 
-| Source | Subdomains | Emails | IPs | ASNs | URLs / links | People | Separate REST/action output (not consolidated report) | API key |
-| --- | :---: | :---: | :---: | :---: | :---: | :---: | --- | :---: |
-| `baidu` | ✓ | ✓ | No | No | No | No | No | No |
-| `bevigil` | ✓ | No | No | No | ✓ | No | No | ✓ |
-| `bufferoverun` | ✓ | No | ✓ | No | No | No | No | ✓ |
-| `builtwith` | ✓ | No | No | No | ✓ | No | `POST /additional/tech-stack` response | ✓ |
-| `brave` | ✓ | ✓ | No | No | No | No | No | ✓ |
-| `censys` | ✓ | ✓ | No | No | No | No | No | ✓ |
-| `certspotter` | ✓ | No | No | No | No | No | No | No |
-| `chaos` | ✓ | No | No | No | No | No | No | ✓ |
-| `commoncrawl` | ✓ | No | No | No | No | No | No | No |
-| `criminalip` | ✓ | No | ✓ | ✓ | No | No | No | ✓ |
-| `crtsh` | ✓ | No | No | No | No | No | No | No |
-| `dehashed` | No | No | ✓ | No | No | No | No | ✓ |
-| `dnsdb` | ✓ | No | No | No | No | No | No | ✓ |
-| `dnsdumpster` | ✓ | No | ✓ | No | No | No | No | ✓ |
-| `duckduckgo` | ✓ | ✓ | No | No | No | No | No | No |
-| `dymo` | ✓ | No | No | No | No | No | No | ✓ |
-| `fofa` | ✓ | No | ✓ | No | No | No | No | ✓ |
-| `fullhunt` | ✓ | No | No | No | No | No | No | ✓ |
-| `github-code` | ✓ | ✓ | No | No | No | No | No | ✓ |
-| `gitlab` | ✓ | ✓ | No | No | No | No | No | No |
-| `hackertarget` | ✓ | No | No | No | No | No | No | Optional |
-| `haveibeenpwned` | No | No | No | No | No | No | `POST /additional/breaches` response | No |
-| `hudsonrock` | ✓ | ✓ | ✓ | No | No | No | No | No |
-| `hunter` | ✓ | ✓ | No | No | No | No | No | ✓ |
-| `hunterhow` | ✓ | No | No | No | No | No | No | ✓ |
-| `intelx` | ✓ | ✓ | No | No | ✓ | No | No | ✓ |
-| `leakix` | ✓ | ✓ | No | No | No | No | No | Optional |
-| `leaklookup` | No | ✓ | No | No | No | No | `POST /additional/leaks` response | ✓ |
-| `mojeek` | ✓ | ✓ | No | No | No | No | No | Optional |
-| `netlas` | ✓ | No | No | No | No | No | No | ✓ |
-| `onyphe` | ✓ | No | ✓ | ✓ | No | No | No | ✓ |
-| `otx` | ✓ | No | ✓ | No | No | No | No | No |
-| `pentesttools` | ✓ | No | No | No | No | No | No | ✓ |
-| `projectdiscovery` | ✓ | No | No | No | No | No | No | ✓ |
-| `rapiddns` | ✓ | No | ✓ | No | No | No | No | No |
-| `robtex` | ✓ | No | ✓ | No | No | No | No | No |
-| `rocketreach` | No | ✓ | No | No | ✓ | No | No | ✓ |
-| `securityscorecard` | ✓ | No | ✓ | No | No | No | `POST /additional/security-score` response | ✓ |
-| `securityTrails` | ✓ | No | ✓ | No | No | No | No | ✓ |
-| `sherlockeye` | ✓ | ✓ | ✓ | No | No | No | No | ✓ |
-| `shodan` | ✓ | No | No | No | No | No | `-s` / `--shodan` host-enrichment output | ✓ |
-| `shodanInternetDB` | ✓ | No | ✓ | No | No | No | No | No |
-| `subdomaincenter` | ✓ | No | No | No | No | No | No | No |
-| `subdomainfinderc99` | ✓ | No | No | No | No | No | No | No |
-| `thc` | ✓ | No | No | No | No | No | No | No |
-| `tomba` | ✓ | ✓ | No | No | No | No | No | ✓ |
-| `urlscan` | ✓ | No | ✓ | ✓ | ✓ | No | No | No |
-| `venacus` | No | ✓ | ✓ | No | ✓ | ✓ | No | ✓ |
-| `virustotal` | ✓ | No | No | No | No | No | No | ✓ |
-| `waybackarchive` | ✓ | No | No | No | No | No | No | No |
-| `whoisxml` | ✓ | No | No | No | No | No | No | ✓ |
-| `windvane` | ✓ | ✓ | ✓ | No | No | No | No | Optional |
-| `yahoo` | ✓ | ✓ | No | No | No | No | No | No |
-| `zoomeye` | ✓ | ✓ | ✓ | ✓ | ✓ | No | No | ✓ |
+| Source | Subdomains | Emails | IPs | ASNs | URLs / links | People | Breaches | Separate REST/action output (not consolidated report) | API key |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- | :---: |
+| `baidu` | ✓ | ✓ | No | No | No | No | No | No | No |
+| `bevigil` | ✓ | No | No | No | ✓ | No | No | No | ✓ |
+| `bufferoverun` | ✓ | No | ✓ | No | No | No | No | No | ✓ |
+| `builtwith` | ✓ | No | No | No | ✓ | No | No | `POST /additional/tech-stack` response | ✓ |
+| `brave` | ✓ | ✓ | No | No | No | No | No | No | ✓ |
+| `censys` | ✓ | ✓ | No | No | No | No | No | No | ✓ |
+| `certspotter` | ✓ | No | No | No | No | No | No | No | No |
+| `chaos` | ✓ | No | No | No | No | No | No | No | ✓ |
+| `commoncrawl` | ✓ | No | No | No | No | No | No | No | No |
+| `criminalip` | ✓ | No | ✓ | ✓ | No | No | No | No | ✓ |
+| `crtsh` | ✓ | No | No | No | No | No | No | No | No |
+| `dehashed` | No | No | ✓ | No | No | No | No | No | ✓ |
+| `dnsdb` | ✓ | No | No | No | No | No | No | No | ✓ |
+| `dnsdumpster` | ✓ | No | ✓ | No | No | No | No | No | ✓ |
+| `duckduckgo` | ✓ | ✓ | No | No | No | No | No | No | No |
+| `dymo` | ✓ | No | No | No | No | No | No | No | ✓ |
+| `fofa` | ✓ | No | ✓ | No | No | No | No | No | ✓ |
+| `fullhunt` | ✓ | No | No | No | No | No | No | No | ✓ |
+| `github-code` | ✓ | ✓ | No | No | No | No | No | No | ✓ |
+| `gitlab` | ✓ | ✓ | No | No | No | No | No | No | No |
+| `hackertarget` | ✓ | No | No | No | No | No | No | No | Optional |
+| `haveibeenpwned` | No | No | No | No | No | No | ✓ | `POST /additional/breaches` response | No |
+| `hudsonrock` | ✓ | ✓ | ✓ | No | No | No | No | No | No |
+| `hunter` | ✓ | ✓ | No | No | No | No | No | No | ✓ |
+| `hunterhow` | ✓ | No | No | No | No | No | No | No | ✓ |
+| `intelx` | ✓ | ✓ | No | No | ✓ | No | No | No | ✓ |
+| `leakix` | ✓ | ✓ | No | No | No | No | No | No | Optional |
+| `leaklookup` | No | ✓ | No | No | No | No | No | `POST /additional/leaks` response | ✓ |
+| `mojeek` | ✓ | ✓ | No | No | No | No | No | No | Optional |
+| `netlas` | ✓ | No | No | No | No | No | No | No | ✓ |
+| `onyphe` | ✓ | No | ✓ | ✓ | No | No | No | No | ✓ |
+| `otx` | ✓ | No | ✓ | No | No | No | No | No | No |
+| `pentesttools` | ✓ | No | No | No | No | No | No | No | ✓ |
+| `projectdiscovery` | ✓ | No | No | No | No | No | No | No | ✓ |
+| `rapiddns` | ✓ | No | ✓ | No | No | No | No | No | No |
+| `robtex` | ✓ | No | ✓ | No | No | No | No | No | No |
+| `rocketreach` | No | ✓ | No | No | ✓ | No | No | No | ✓ |
+| `securityscorecard` | ✓ | No | ✓ | No | No | No | No | `POST /additional/security-score` response | ✓ |
+| `securityTrails` | ✓ | No | ✓ | No | No | No | No | No | ✓ |
+| `sherlockeye` | ✓ | ✓ | ✓ | No | No | No | No | No | ✓ |
+| `shodan` | ✓ | No | No | No | No | No | No | `-s` / `--shodan` host-enrichment output | ✓ |
+| `shodanInternetDB` | ✓ | No | ✓ | No | No | No | No | No | No |
+| `subdomaincenter` | ✓ | No | No | No | No | No | No | No | No |
+| `subdomainfinderc99` | ✓ | No | No | No | No | No | No | No | No |
+| `thc` | ✓ | No | No | No | No | No | No | No | No |
+| `tomba` | ✓ | ✓ | No | No | No | No | No | No | ✓ |
+| `urlscan` | ✓ | No | ✓ | ✓ | ✓ | No | No | No | No |
+| `venacus` | No | ✓ | ✓ | No | ✓ | ✓ | No | No | ✓ |
+| `virustotal` | ✓ | No | No | No | No | No | No | No | ✓ |
+| `waybackarchive` | ✓ | No | No | No | No | No | No | No | No |
+| `whoisxml` | ✓ | No | No | No | No | No | No | No | ✓ |
+| `windvane` | ✓ | ✓ | ✓ | No | No | No | No | No | Optional |
+| `yahoo` | ✓ | ✓ | No | No | No | No | No | No | No |
+| `zoomeye` | ✓ | ✓ | ✓ | ✓ | ✓ | No | No | No | ✓ |
 
 </details>
 
@@ -230,7 +230,7 @@ The JSON report is a single object and is the more complete format for automatio
 
 The XML report contains the command, emails, hosts, and virtual hosts. Use JSON when you need the additional result types above.
 
-The JSONL report is finalized after the selected one-shot actions finish. Its first line is a summary with an independent run UUID, the target, UTC timestamps, counts, and schema version. Each remaining line is one deterministic, deduplicated string finding. The format does not claim provider success or record source attribution.
+The JSONL report is finalized after the selected one-shot actions finish. Its first line is a summary with an independent run UUID, the target, UTC timestamps, counts, and schema version. Each remaining line is one deterministic, deduplicated string finding, including stable Have I Been Pwned breach names as `breach` records. The format does not claim provider success or record source attribution.
 
 List every JSONL finding as tab-separated type and value columns:
 

--- a/tests/discovery/test_haveibeenpwned.py
+++ b/tests/discovery/test_haveibeenpwned.py
@@ -1,10 +1,15 @@
+import json
 import logging
+import sys
+from pathlib import Path
 from typing import Any
 
 import pytest
 
 from theHarvester.discovery import haveibeenpwned
+from theHarvester import __main__ as theharvester_main
 from theHarvester.lib.api import additional_endpoints
+from theHarvester.lib.completed_result import CompletedResult
 from theHarvester.lib.core import FetcherResponse
 
 
@@ -24,6 +29,7 @@ async def test_public_breach_catalog_preserves_metadata(monkeypatch: pytest.Monk
             FetcherResponse(
                 body=[
                     {
+                        'Name': 'ExampleBreach',
                         'Domain': 'example.com',
                         'BreachDate': '2024-01-02',
                         'DataClasses': ['Email addresses', 'Passwords'],
@@ -40,6 +46,7 @@ async def test_public_breach_catalog_preserves_metadata(monkeypatch: pytest.Monk
     await search.process()
 
     assert await search.get_hostnames() == {'example.com'}
+    assert await search.get_breach_names() == {'ExampleBreach'}
     assert await search.get_breach_dates() == {'2024-01-02'}
     assert await search.get_affected_data() == {'Email addresses', 'Passwords'}
     assert await search.get_emails() == set()
@@ -47,11 +54,25 @@ async def test_public_breach_catalog_preserves_metadata(monkeypatch: pytest.Monk
     assert await search.get_breach_types() == set()
     assert await search.get_breaches() == [
         {
+            'Name': 'ExampleBreach',
             'Domain': 'example.com',
             'BreachDate': '2024-01-02',
             'DataClasses': ['Email addresses', 'Passwords'],
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_public_breach_catalog_ignores_blank_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        return [FetcherResponse(body=[{'Name': '  '}, {'Name': 'ExampleBreach'}], status=200, headers={})]
+
+    monkeypatch.setattr(haveibeenpwned.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = haveibeenpwned.SearchHaveIBeenPwned('example.com')
+
+    await search.process()
+
+    assert await search.get_breach_names() == {'ExampleBreach'}
 
 
 @pytest.mark.asyncio
@@ -105,3 +126,52 @@ async def test_breach_rest_handler_does_not_initialize_unrelated_providers(monke
     )
 
     assert result == {'status': 'success', 'data': [{'Domain': 'example.com'}]}
+
+
+@pytest.mark.asyncio
+async def test_public_breach_names_reach_completed_result_and_jsonl(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    completed_results: list[CompletedResult] = []
+
+    class FakeStash:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args: object) -> None:
+            return None
+
+        async def store_completed_result(self, result: CompletedResult) -> None:
+            completed_results.append(result)
+
+    class FakeHaveIBeenPwned:
+        def __init__(self, domain: str) -> None:
+            assert domain == 'example.com'
+
+        async def process(self, _proxy: bool) -> None:
+            return None
+
+        async def get_breach_names(self) -> set[str]:
+            return {'Adobe', 'ExampleBreach'}
+
+    report = tmp_path / 'hibp-report'
+    monkeypatch.setattr(theharvester_main.stash, 'StashManager', FakeStash)
+    monkeypatch.setattr(theharvester_main.haveibeenpwned, 'SearchHaveIBeenPwned', FakeHaveIBeenPwned)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['theHarvester', '-d', 'example.com', '-b', 'haveibeenpwned', '-f', str(report)],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    assert completed_results[0].results == (
+        ('breach', 'Adobe'),
+        ('breach', 'ExampleBreach'),
+    )
+    records = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
+    assert {'type': 'breach', 'value': 'Adobe'} in records
+    assert {'type': 'breach', 'value': 'ExampleBreach'} in records

--- a/tests/discovery/test_haveibeenpwned.py
+++ b/tests/discovery/test_haveibeenpwned.py
@@ -1,0 +1,107 @@
+import logging
+from typing import Any
+
+import pytest
+
+from theHarvester.discovery import haveibeenpwned
+from theHarvester.lib.api import additional_endpoints
+from theHarvester.lib.core import FetcherResponse
+
+
+def test_public_breach_catalog_does_not_require_api_key() -> None:
+    search = haveibeenpwned.SearchHaveIBeenPwned('example.com')
+
+    assert 'hibp-api-key' not in search.headers
+
+
+@pytest.mark.asyncio
+async def test_public_breach_catalog_preserves_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch_all(urls: list[str], **kwargs: Any) -> list[FetcherResponse]:
+        assert urls == ['https://haveibeenpwned.com/api/v3/breaches?domain=example.com']
+        assert kwargs['json'] is True
+        assert kwargs['include_metadata'] is True
+        return [
+            FetcherResponse(
+                body=[
+                    {
+                        'Domain': 'example.com',
+                        'BreachDate': '2024-01-02',
+                        'DataClasses': ['Email addresses', 'Passwords'],
+                    }
+                ],
+                status=200,
+                headers={},
+            )
+        ]
+
+    monkeypatch.setattr(haveibeenpwned.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = haveibeenpwned.SearchHaveIBeenPwned('example.com')
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'example.com'}
+    assert await search.get_breach_dates() == {'2024-01-02'}
+    assert await search.get_affected_data() == {'Email addresses', 'Passwords'}
+    assert await search.get_emails() == set()
+    assert await search.get_pastes() == []
+    assert await search.get_breach_types() == set()
+    assert await search.get_breaches() == [
+        {
+            'Domain': 'example.com',
+            'BreachDate': '2024-01-02',
+            'DataClasses': ['Email addresses', 'Passwords'],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('payload', [[], None, {}, ['not-a-breach']])
+async def test_public_breach_catalog_handles_empty_and_malformed_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: Any,
+) -> None:
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        return [FetcherResponse(body=payload, status=200, headers={})]
+
+    monkeypatch.setattr(haveibeenpwned.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = haveibeenpwned.SearchHaveIBeenPwned('example.com')
+
+    await search.process()
+
+    assert await search.get_breaches() == []
+    assert await search.get_hostnames() == set()
+    assert await search.get_breach_dates() == set()
+    assert await search.get_affected_data() == set()
+
+
+@pytest.mark.asyncio
+async def test_public_breach_catalog_attributes_http_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        return [FetcherResponse(body={'error': 'rate limited'}, status=429, headers={})]
+
+    monkeypatch.setattr(haveibeenpwned.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = haveibeenpwned.SearchHaveIBeenPwned('example.com')
+
+    with caplog.at_level(logging.INFO, logger=haveibeenpwned.__name__):
+        await search.process()
+
+    assert await search.get_breaches() == []
+    assert 'HaveIBeenPwned request failed with HTTP 429' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_breach_rest_handler_does_not_initialize_unrelated_providers(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        return [FetcherResponse(body=[{'Domain': 'example.com'}], status=200, headers={})]
+
+    monkeypatch.setattr(haveibeenpwned.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    result = await additional_endpoints.get_breaches(
+        additional_endpoints.DomainRequest(domain='example.com'),
+        _api_key='local-api-key',
+    )
+
+    assert result == {'status': 'success', 'data': [{'Domain': 'example.com'}]}

--- a/tests/lib/test_completed_persistence.py
+++ b/tests/lib/test_completed_persistence.py
@@ -15,6 +15,7 @@ def completed_result(run_id: str = 'f047261c-0afb-4e18-89d5-28a7d977f51f') -> Co
         started_at=datetime(2026, 8, 5, 12, 0, tzinfo=UTC),
         completed_at=datetime(2026, 8, 5, 12, 1, tzinfo=UTC),
         groups={
+            'breach': ['ExampleBreach'],
             'hostname': ['api.example.com'],
             'ip-address': ['192.0.2.1'],
             'person': ['{"firstname":"Ada","lastname":"Lovelace"}'],
@@ -69,4 +70,4 @@ async def test_completed_result_write_is_atomic_and_rejects_duplicate_run_id(tmp
     async with aiosqlite.connect(manager.db) as db:
         parent_count = (await db.execute_fetchall('SELECT COUNT(*) FROM completed_results'))[0][0]
         item_count = (await db.execute_fetchall('SELECT COUNT(*) FROM completed_result_items'))[0][0]
-    assert (parent_count, item_count) == (1, 3)
+    assert (parent_count, item_count) == (1, 4)

--- a/tests/lib/test_core.py
+++ b/tests/lib/test_core.py
@@ -65,6 +65,10 @@ def test_multiple_capabilities_form_a_union() -> None:
     ]
 
 
+def test_breach_capability_selects_haveibeenpwned() -> None:
+    assert Core.expand_source_selection('breaches') == ['haveibeenpwned']
+
+
 def test_all_preserves_every_supported_source() -> None:
     assert Core.expand_source_selection("ALL") == Core.get_supportedengines()
 

--- a/tests/lib/test_source_catalog.py
+++ b/tests/lib/test_source_catalog.py
@@ -56,7 +56,7 @@ def test_subdomain_route_drives_subdomain_capability() -> None:
 
 def test_source_specs_describe_consolidated_routes_not_getter_presence() -> None:
     assert SOURCE_SPECS['gitlab'].routes == frozenset({ResultRoute.SUBDOMAINS, ResultRoute.EMAILS})
-    assert SOURCE_SPECS['haveibeenpwned'].routes == frozenset()
+    assert SOURCE_SPECS['haveibeenpwned'].routes == frozenset({ResultRoute.BREACHES})
     assert SOURCE_SPECS['urlscan'].routes == frozenset(
         {
             ResultRoute.SUBDOMAINS,

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -7,7 +7,7 @@ import yaml
 
 from theHarvester.lib.source_catalog import SOURCE_SPECS, ResultRoute
 
-RESULT_COLUMNS = ('Subdomains', 'Emails', 'IPs', 'ASNs', 'URLs / links', 'People')
+RESULT_COLUMNS = ('Subdomains', 'Emails', 'IPs', 'ASNs', 'URLs / links', 'People', 'Breaches')
 ROUTE_COLUMNS = {
     ResultRoute.SUBDOMAINS: 'Subdomains',
     ResultRoute.EMAILS: 'Emails',
@@ -16,6 +16,7 @@ ROUTE_COLUMNS = {
     ResultRoute.LINKS: 'URLs / links',
     ResultRoute.INTERESTING_URLS: 'URLs / links',
     ResultRoute.PEOPLE: 'People',
+    ResultRoute.BREACHES: 'Breaches',
 }
 OPTIONAL_API_KEY_SOURCES = {'hackertarget', 'leakix', 'mojeek', 'windvane'}
 API_KEY_SOURCE_ALIASES = {
@@ -58,7 +59,7 @@ def _documented_source_rows(readme: str) -> dict[str, list[str]]:
 def _documented_source_contracts(readme: str) -> dict[str, set[str]]:
     contracts: dict[str, set[str]] = {}
     for source, cells in _documented_source_rows(readme).items():
-        markers = cells[:6]
+        markers = cells[:7]
         assert set(markers) <= {'✓', 'No'}
         contracts[source] = {column for column, marker in zip(RESULT_COLUMNS, markers, strict=True) if marker == '✓'}
     return contracts
@@ -78,7 +79,7 @@ def test_readme_matches_declared_source_contracts() -> None:
     documented = _documented_source_contracts(readme)
     declared = _declared_source_contracts()
 
-    assert '| Source | Subdomains | Emails | IPs | ASNs | URLs / links | People |' in readme
+    assert '| Source | Subdomains | Emails | IPs | ASNs | URLs / links | People | Breaches |' in readme
     assert len(declared) == 54
     assert len(documented) == 54
     assert documented == declared

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -229,7 +229,7 @@ async def start(rest_args: argparse.Namespace | None = None):
     parser.add_argument(
         '-b',
         '--source',
-        help="""Comma-separated sources or capability selectors: subdomains, emails, ips, asns, urls, people, or all.
+        help="""Comma-separated sources or capability selectors: subdomains, emails, ips, asns, urls, people, breaches, or all.
                             Sources: baidu, bevigil, brave, bufferoverun,
                             builtwith, censys, certspotter, chaos, commoncrawl, criminalip, crtsh, dehashed, dnsdumpster, duckduckgo, dymo, fofa, fullhunt, github-code,
                             gitlab, hackertarget, haveibeenpwned, hudsonrock, hunter, hunterhow, intelx, leakix, leaklookup, mojeek, netlas, onyphe, otx, pentesttools,
@@ -348,6 +348,7 @@ async def start(rest_args: argparse.Namespace | None = None):
     twitter_people_list_tracker: list = []
     interesting_urls: list = []
     total_asns: list = []
+    all_breaches: list[str] = []
 
     linkedin_people_list_tracker = []
     linkedin_links_tracker = []
@@ -440,6 +441,9 @@ async def start(rest_args: argparse.Namespace | None = None):
             total_asns.extend(fasns)
             if len(fasns) > 0:
                 await db.store_all(word, fasns, 'asns', source)
+
+        if ResultRoute.BREACHES in routes:
+            all_breaches.extend(await search_engine.get_breach_names())
         logger.info(f'Source {source} completed')
 
     stor_lst = []
@@ -1840,6 +1844,7 @@ async def start(rest_args: argparse.Namespace | None = None):
 
     groups: dict[ResultKind, Iterable[str]] = {
         'asn': map(str, total_asns),
+        'breach': map(str, all_breaches),
         'email': map(str, all_emails),
         'hostname': _normalize_hosts_for_storage((*all_hosts, *dnsrev), word),
         'interesting-url': map(str, interesting_urls),

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -733,11 +733,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                             )
                         )
                     except Exception as e:
-                        if isinstance(e, MissingKey):
-                            if not args.quiet:
-                                output_logger.info(MissingKey('HaveIBeenPwned'))
-                        else:
-                            output_logger.info(f'An exception has occurred in HaveIBeenPwned search: {e}')
+                        show_default_error_message(engineitem, word, e)
 
                 elif engineitem == 'hudsonrock':
                     try:

--- a/theHarvester/data/api-keys.yaml
+++ b/theHarvester/data/api-keys.yaml
@@ -44,9 +44,6 @@ apikeys:
   hackertarget:
     key:
 
-  haveibeenpwned:
-    key:
-
   hunter:
     key:
 

--- a/theHarvester/discovery/haveibeenpwned.py
+++ b/theHarvester/discovery/haveibeenpwned.py
@@ -13,6 +13,7 @@ class SearchHaveIBeenPwned:
         self.hosts: set[str] = set()
         self.emails: set[str] = set()
         self.breaches: list[dict] = []
+        self.breach_names: set[str] = set()
         self.pastes: list[dict] = []
         self.breach_dates: set[str] = set()
         self.breach_types: set[str] = set()
@@ -49,6 +50,8 @@ class SearchHaveIBeenPwned:
     def _extract_data(self) -> None:
         """Extract and categorize breach information."""
         for breach in self.breaches:
+            if isinstance(name := breach.get('Name'), str) and name.strip():
+                self.breach_names.add(name.strip())
             if isinstance(domain := breach.get('Domain'), str):
                 self.hosts.add(domain)
             if isinstance(breach_date := breach.get('BreachDate'), str):
@@ -66,6 +69,9 @@ class SearchHaveIBeenPwned:
 
     async def get_breaches(self) -> list[dict]:
         return self.breaches
+
+    async def get_breach_names(self) -> set[str]:
+        return self.breach_names
 
     async def get_pastes(self) -> list[dict]:
         return self.pastes

--- a/theHarvester/discovery/haveibeenpwned.py
+++ b/theHarvester/discovery/haveibeenpwned.py
@@ -1,9 +1,6 @@
 import logging
 
-import aiohttp
-
-from theHarvester.discovery.constants import MissingKey
-from theHarvester.lib.core import AsyncFetcher, Core
+from theHarvester.lib.core import AsyncFetcher, FetcherResponse
 
 logger = logging.getLogger(__name__)
 
@@ -11,11 +8,8 @@ logger = logging.getLogger(__name__)
 class SearchHaveIBeenPwned:
     def __init__(self, word: str):
         self.word = word
-        self.api_key = Core.haveibeenpwned_key()
-        if self.api_key is None:
-            raise MissingKey('HaveIBeenPwned')
         self.base_url = 'https://haveibeenpwned.com/api/v3'
-        self.headers = {'hibp-api-key': self.api_key, 'user-agent': 'theHarvester', 'Content-Type': 'application/json'}
+        self.headers = {'user-agent': 'theHarvester', 'Content-Type': 'application/json'}
         self.hosts: set[str] = set()
         self.emails: set[str] = set()
         self.breaches: list[dict] = []
@@ -27,33 +21,42 @@ class SearchHaveIBeenPwned:
     async def process(self, proxy: bool = False) -> None:
         """Search for breaches associated with a domain or email."""
         try:
-            if proxy:
-                response = await AsyncFetcher.fetch(
-                    session=None, url=f'{self.base_url}/breaches?domain={self.word}', headers=self.headers, proxy=proxy
-                )
-                if response:
-                    self.breaches = response
-                    self._extract_data()
-            else:
-                async with aiohttp.ClientSession(headers=self.headers) as session:
-                    async with session.get(f'{self.base_url}/breaches?domain={self.word}') as response:
-                        if response.status == 200:
-                            self.breaches = await response.json()
-                            self._extract_data()
-        except Exception as e:
-            logger.info(f'Error in HaveIBeenPwned search: {e}')
+            responses = await AsyncFetcher.fetch_all(
+                [f'{self.base_url}/breaches?domain={self.word}'],
+                headers=self.headers,
+                json=True,
+                proxy=proxy,
+                include_metadata=True,
+            )
+        except (OSError, RuntimeError, ValueError):
+            logger.info('HaveIBeenPwned request failed')
+            return
+
+        response = responses[0] if responses and isinstance(responses[0], FetcherResponse) else None
+        if response is None:
+            logger.info('HaveIBeenPwned request failed')
+            return
+        if not 200 <= response.status < 300:
+            logger.info(f'HaveIBeenPwned request failed with HTTP {response.status}')
+            return
+        if not isinstance(response.body, list) or not all(isinstance(breach, dict) for breach in response.body):
+            logger.info('HaveIBeenPwned returned malformed breach data')
+            return
+
+        self.breaches = response.body
+        self._extract_data()
 
     def _extract_data(self) -> None:
         """Extract and categorize breach information."""
         for breach in self.breaches:
-            if 'Domain' in breach:
-                self.hosts.add(breach['Domain'])
-            if 'BreachDate' in breach:
-                self.breach_dates.add(breach['BreachDate'])
-            if 'BreachType' in breach:
-                self.breach_types.add(breach['BreachType'])
-            if 'DataClasses' in breach:
-                self.affected_data.update(breach['DataClasses'])
+            if isinstance(domain := breach.get('Domain'), str):
+                self.hosts.add(domain)
+            if isinstance(breach_date := breach.get('BreachDate'), str):
+                self.breach_dates.add(breach_date)
+            if isinstance(breach_type := breach.get('BreachType'), str):
+                self.breach_types.add(breach_type)
+            if isinstance(data_classes := breach.get('DataClasses'), list):
+                self.affected_data.update(item for item in data_classes if isinstance(item, str))
 
     async def get_hostnames(self) -> set[str]:
         return self.hosts

--- a/theHarvester/lib/api/additional_endpoints.py
+++ b/theHarvester/lib/api/additional_endpoints.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from theHarvester.discovery.additional_apis import AdditionalAPIs
+from theHarvester.discovery.haveibeenpwned import SearchHaveIBeenPwned
 from theHarvester.lib.api.auth import get_api_key
 
 router = APIRouter()
@@ -25,10 +26,9 @@ def _raise_processing_error(endpoint: str, exc: Exception) -> NoReturn:
 async def get_breaches(request: DomainRequest, _api_key: Annotated[str, Depends(get_api_key)]):
     """Get breach information for a domain using HaveIBeenPwned."""
     try:
-        apis = AdditionalAPIs(request.domain, request.api_keys or {})
-        await apis._process_haveibeenpwned()
-        results = apis.results['breaches']
-        return {'status': 'success', 'data': results}
+        search = SearchHaveIBeenPwned(request.domain)
+        await search.process()
+        return {'status': 'success', 'data': await search.get_breaches()}
     except Exception as e:
         _raise_processing_error('breaches', e)
 

--- a/theHarvester/lib/completed_result.py
+++ b/theHarvester/lib/completed_result.py
@@ -8,6 +8,7 @@ from uuid import UUID, uuid4
 
 ResultKind = Literal[
     'asn',
+    'breach',
     'email',
     'hostname',
     'interesting-url',

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -58,7 +58,6 @@ class Core:
         'fullhunt': ('key',),
         'github': ('key',),
         'hackertarget': ('key',),
-        'haveibeenpwned': ('key',),
         'hunter': ('key',),
         'hunterhow': ('key',),
         'intelx': ('key',),
@@ -168,10 +167,6 @@ class Core:
     @staticmethod
     def hackertarget_key() -> str:
         return Core._api_key_value('hackertarget')
-
-    @staticmethod
-    def haveibeenpwned_key() -> str:
-        return Core._api_key_value('haveibeenpwned')
 
     @staticmethod
     def hunter_key() -> str:

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -17,6 +17,7 @@ class ResultRoute(Enum):
     PEOPLE = auto()
     LINKS = auto()
     INTERESTING_URLS = auto()
+    BREACHES = auto()
 
 
 _ROUTE_CAPABILITIES = {
@@ -27,6 +28,7 @@ _ROUTE_CAPABILITIES = {
     ResultRoute.PEOPLE: 'people',
     ResultRoute.LINKS: 'urls',
     ResultRoute.INTERESTING_URLS: 'urls',
+    ResultRoute.BREACHES: 'breaches',
 }
 
 
@@ -66,7 +68,7 @@ _SPECS = (
     _spec('github-code', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS),
     _spec('gitlab', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS),
     _spec('hackertarget', ResultRoute.SUBDOMAINS),
-    _spec('haveibeenpwned'),
+    _spec('haveibeenpwned', ResultRoute.BREACHES),
     _spec('hudsonrock', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS, ResultRoute.IPS),
     _spec('hunter', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS),
     _spec('hunterhow', ResultRoute.SUBDOMAINS),


### PR DESCRIPTION
## Summary
- remove the API-key gate from HIBP's public breach catalogue endpoint
- use the shared fetcher for consistent proxy, status, and malformed-response handling
- keep the raw REST breach response and legacy JSON/XML schemas compatible
- retain stable HIBP breach names in completed JSONL and SQLite results
- add a `breaches` capability selector and synchronize source metadata, README, and changelog

HIBP documents `GET /api/v3/breaches?domain=...` as the public breach catalogue filter. The authenticated `/breachedDomain/{domain}` API is a different verified-domain service and is not used here: https://haveibeenpwned.com/API/v3

## Verification
- focused tests: 59 passed
- full pytest: 355 passed, 6 skipped
- Ruff check passed
- Ruff formatting check passed
- mypy passed
- git diff check passed
- zero em dashes in the patch
- live CLI test against HIBP's documented `adobe.com` example produced one JSONL `breach` record (`Adobe`) and the matching SQLite completed-result row
- parallel Standards and Spec reviews against `037fe530` passed after all findings were fixed

Related to NotoriousRebel/theHarvester#101
