### PR TITLE
Make Hudson Rock provider outcomes truthful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the nonfunctional ThreatCrowd source because its service hostnames terminate at deleted AWS load balancers and return NXDOMAIN; OTX remains available through its separate adapter.
 
 ### Fixed
-- Made Hudson Rock HTTP failures status-aware, bounded rate-limit retries, removed trailing request delays, and isolated malformed provider items with offline contracts.
+- Made Hudson Rock HTTP failures status-aware, bounded rate-limit retries, removed trailing request delays, isolated malformed provider items, and retained infostealer details in completed JSONL and SQLite results.
 - Made the public Have I Been Pwned breach catalogue keyless, added offline response contracts, and retained stable breach names in completed JSONL and SQLite results.
 - Fixed THC rate-limit exhaustion so terminal failures are reported without sleeping after the final attempt, with offline recovery, non-success, and malformed-response contracts.
 - Made RapidDNS, Robtex, and Subdomain Center HTTP failures report the source and response status before parsing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the nonfunctional ThreatCrowd source because its service hostnames terminate at deleted AWS load balancers and return NXDOMAIN; OTX remains available through its separate adapter.
 
 ### Fixed
+- Made Hudson Rock HTTP failures status-aware, bounded rate-limit retries, removed trailing request delays, and isolated malformed provider items with offline contracts.
 - Made the public Have I Been Pwned breach catalogue keyless, added offline response contracts, and retained stable breach names in completed JSONL and SQLite results.
 - Fixed THC rate-limit exhaustion so terminal failures are reported without sleeping after the final attempt, with offline recovery, non-success, and malformed-response contracts.
 - Made RapidDNS, Robtex, and Subdomain Center HTTP failures report the source and response status before parsing.

--- a/tests/discovery/test_hudsonrock.py
+++ b/tests/discovery/test_hudsonrock.py
@@ -1,9 +1,14 @@
+import json
 import logging
+import sys
+from pathlib import Path
 from typing import Any
 
 import pytest
 
+from theHarvester import __main__ as theharvester_main
 from theHarvester.discovery import hudsonrocksearch
+from theHarvester.lib.completed_result import CompletedResult
 from theHarvester.lib.core import FetcherResponse
 
 
@@ -187,3 +192,68 @@ async def test_terminal_domain_responses_are_attributed_without_retry(
     assert await search.get_hostnames() == set()
     assert calls == 1
     assert expected_log in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_infostealer_data_reaches_completed_result_and_jsonl(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    completed_results: list[CompletedResult] = []
+
+    class FakeStash:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args: object) -> None:
+            return None
+
+        async def store_completed_result(self, result: CompletedResult) -> None:
+            completed_results.append(result)
+
+    class FakeHudsonRock:
+        def __init__(self, target: str) -> None:
+            assert target == 'analyst@example.com'
+
+        async def process(self, _proxy: bool) -> None:
+            return None
+
+        async def get_hostnames(self) -> set[str]:
+            return set()
+
+        async def get_emails(self) -> set[str]:
+            return {'analyst@example.com'}
+
+        async def get_ips(self) -> set[str]:
+            return {'192.0.2.4'}
+
+        async def get_infostealers(self) -> list[dict[str, object]]:
+            return [
+                {
+                    'email': 'analyst@example.com',
+                    'computer_name': 'WORKSTATION-1',
+                    'ip': '192.0.2.4',
+                    'top_corporate_services': ['portal.example.com'],
+                }
+            ]
+
+    report = tmp_path / 'hudsonrock-report'
+    monkeypatch.setattr(theharvester_main.stash, 'StashManager', FakeStash)
+    monkeypatch.setattr(theharvester_main.hudsonrocksearch, 'SearchHudsonRock', FakeHudsonRock)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['theHarvester', '-d', 'analyst@example.com', '-b', 'hudsonrock', '-f', str(report)],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    stealer = (
+        '{"computer_name":"WORKSTATION-1","email":"analyst@example.com","ip":"192.0.2.4",'
+        '"top_corporate_services":["portal.example.com"]}'
+    )
+    assert ('infostealer', stealer) in completed_results[0].results
+    records = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
+    assert {'type': 'infostealer', 'value': stealer} in records

--- a/tests/discovery/test_hudsonrock.py
+++ b/tests/discovery/test_hudsonrock.py
@@ -96,6 +96,7 @@ async def test_domain_search_ignores_malformed_url_items(monkeypatch: pytest.Mon
                     'data': {
                         'employees_urls': [
                             'not-an-object',
+                            {'url': 7},
                             {'url': 'https://portal.example.com/login'},
                         ]
                     }
@@ -122,6 +123,7 @@ async def test_email_search_ignores_malformed_stealer_items(monkeypatch: pytest.
             else {
                 'stealers': [
                     'not-an-object',
+                    {'top_corporate_services': None},
                     {'ip': '192.0.2.5', 'top_corporate_services': [], 'top_user_services': []},
                 ]
             }

--- a/tests/discovery/test_hudsonrock.py
+++ b/tests/discovery/test_hudsonrock.py
@@ -1,0 +1,189 @@
+import logging
+from typing import Any
+
+import pytest
+
+from theHarvester.discovery import hudsonrocksearch
+from theHarvester.lib.core import FetcherResponse
+
+
+@pytest.mark.asyncio
+async def test_rate_limited_domain_search_recovers_without_trailing_delay(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+    sleeps: list[float] = []
+    responses = [
+        FetcherResponse(body={'error': 'rate limited'}, status=429, headers={'retry-after': '0'}),
+        FetcherResponse(
+            body={'data': {'employees_urls': [{'url': 'https://portal.example.com/login'}]}},
+            status=200,
+            headers={},
+        ),
+    ]
+
+    async def fake_fetch_all(urls: list[str], **kwargs: Any) -> list[FetcherResponse]:
+        nonlocal calls
+        calls += 1
+        assert urls == ['https://cavalier.hudsonrock.com/api/json/v2/osint-tools/search-by-domain?domain=example.com']
+        assert kwargs == {'json': True, 'proxy': False, 'include_metadata': True}
+        return [responses.pop(0)]
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(hudsonrocksearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(hudsonrocksearch.asyncio, 'sleep', fake_sleep)
+    search = hudsonrocksearch.SearchHudsonRock('example.com')
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'portal.example.com'}
+    assert calls == 2
+    assert sleeps == [0]
+
+
+@pytest.mark.asyncio
+async def test_email_search_preserves_normalized_getters(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleeps: list[float] = []
+
+    async def fake_fetch_all(urls: list[str], **kwargs: Any) -> list[FetcherResponse]:
+        assert kwargs == {'json': True, 'proxy': False, 'include_metadata': True}
+        if urls[0].endswith('search-by-domain?domain=example.com'):
+            return [FetcherResponse(body={'data': {'employees_urls': []}}, status=200, headers={})]
+        assert urls[0].endswith('search-by-email?email=analyst@example.com')
+        return [
+            FetcherResponse(
+                body={
+                    'stealers': [
+                        {
+                            'ip': '192.0.2.4',
+                            'top_corporate_services': [{'domain': 'portal.example.com'}],
+                            'top_user_services': [],
+                        }
+                    ]
+                },
+                status=200,
+                headers={},
+            )
+        ]
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(hudsonrocksearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(hudsonrocksearch.asyncio, 'sleep', fake_sleep)
+    search = hudsonrocksearch.SearchHudsonRock('analyst@example.com')
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'portal.example.com'}
+    assert await search.get_ips() == {'192.0.2.4'}
+    assert await search.get_emails() == {'analyst@example.com'}
+    assert len(await search.get_infostealers()) == 1
+    assert sleeps == [1.0]
+
+
+@pytest.mark.asyncio
+async def test_domain_search_ignores_malformed_url_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        return [
+            FetcherResponse(
+                body={
+                    'data': {
+                        'employees_urls': [
+                            'not-an-object',
+                            {'url': 'https://portal.example.com/login'},
+                        ]
+                    }
+                },
+                status=200,
+                headers={},
+            )
+        ]
+
+    monkeypatch.setattr(hudsonrocksearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = hudsonrocksearch.SearchHudsonRock('example.com')
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'portal.example.com'}
+
+
+@pytest.mark.asyncio
+async def test_email_search_ignores_malformed_stealer_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch_all(urls: list[str], **_kwargs: Any) -> list[FetcherResponse]:
+        body = (
+            {'data': {'employees_urls': []}}
+            if 'search-by-domain' in urls[0]
+            else {
+                'stealers': [
+                    'not-an-object',
+                    {'ip': '192.0.2.5', 'top_corporate_services': [], 'top_user_services': []},
+                ]
+            }
+        )
+        return [FetcherResponse(body=body, status=200, headers={})]
+
+    async def no_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(hudsonrocksearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(hudsonrocksearch.asyncio, 'sleep', no_sleep)
+    search = hudsonrocksearch.SearchHudsonRock('analyst@example.com')
+
+    await search.process()
+
+    assert await search.get_ips() == {'192.0.2.5'}
+    assert len(await search.get_infostealers()) == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_email_search_does_not_invent_a_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch_all(urls: list[str], **_kwargs: Any) -> list[FetcherResponse]:
+        body = {'data': {'employees_urls': []}} if 'search-by-domain' in urls[0] else {'stealers': []}
+        return [FetcherResponse(body=body, status=200, headers={})]
+
+    async def no_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(hudsonrocksearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(hudsonrocksearch.asyncio, 'sleep', no_sleep)
+    search = hudsonrocksearch.SearchHudsonRock('analyst@example.com')
+
+    await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert await search.get_ips() == set()
+    assert await search.get_emails() == set()
+    assert await search.get_infostealers() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('response', 'expected_log'),
+    [
+        (FetcherResponse(body={'error': 'forbidden'}, status=403, headers={}), 'failed with HTTP 403'),
+        (FetcherResponse(body=['not-an-object'], status=200, headers={}), 'Invalid response format'),
+    ],
+)
+async def test_terminal_domain_responses_are_attributed_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    response: FetcherResponse,
+    expected_log: str,
+) -> None:
+    calls = 0
+
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        nonlocal calls
+        calls += 1
+        return [response]
+
+    monkeypatch.setattr(hudsonrocksearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = hudsonrocksearch.SearchHudsonRock('example.com')
+
+    with caplog.at_level(logging.INFO, logger=hudsonrocksearch.__name__):
+        await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert calls == 1
+    assert expected_log in caplog.text

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -289,6 +289,7 @@ async def start(rest_args: argparse.Namespace | None = None):
     all_hosts: list = []
     all_ip: list = []
     all_people: list[dict[str, str]] = []
+    all_infostealers: list[dict[str, object]] = []
     dnslookup = args.dns_lookup
     dnsserver = args.dns_server  # TODO arg is not used anywhere replace with resolvers wordlist arg dnsresolve
     dnsresolve: str | None = args.dns_resolve
@@ -444,6 +445,8 @@ async def start(rest_args: argparse.Namespace | None = None):
 
         if ResultRoute.BREACHES in routes:
             all_breaches.extend(await search_engine.get_breach_names())
+        if source == 'hudsonrock':
+            all_infostealers.extend(await search_engine.get_infostealers())
         logger.info(f'Source {source} completed')
 
     stor_lst = []
@@ -1847,6 +1850,9 @@ async def start(rest_args: argparse.Namespace | None = None):
         'breach': map(str, all_breaches),
         'email': map(str, all_emails),
         'hostname': _normalize_hosts_for_storage((*all_hosts, *dnsrev), word),
+        'infostealer': (
+            json.dumps(stealer, ensure_ascii=False, separators=(',', ':'), sort_keys=True) for stealer in all_infostealers
+        ),
         'interesting-url': map(str, interesting_urls),
         'ip-address': _normalize_ip_addresses(all_ip),
         'linkedin-link': map(str, linkedin_links_tracker),

--- a/theHarvester/discovery/hudsonrocksearch.py
+++ b/theHarvester/discovery/hudsonrocksearch.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from urllib.parse import urlparse
 
-from theHarvester.lib.core import AsyncFetcher
+from theHarvester.lib.core import AsyncFetcher, FetcherResponse
 
 
 class SearchHudsonRock:
@@ -52,10 +52,11 @@ class SearchHudsonRock:
             search_tasks.append(self._search_email(self.word))
 
         # Execute searches with rate limiting
-        for task in search_tasks:
+        for index, task in enumerate(search_tasks):
             try:
                 await task
-                await asyncio.sleep(self.request_delay)  # Rate limiting
+                if index < len(search_tasks) - 1:
+                    await asyncio.sleep(self.request_delay)
             except Exception as e:
                 self.logger.error(f'Search task failed: {e}')
                 continue
@@ -88,24 +89,9 @@ class SearchHudsonRock:
 
         """
         url = f'{self.base_url}/search-by-domain?domain={domain}'
-
-        for attempt in range(self.max_retries):
-            try:
-                self.logger.debug(f'Searching domain: {domain} (attempt {attempt + 1})')
-                response = await AsyncFetcher.fetch_all([url], json=True, proxy=self.proxy)
-
-                if response and isinstance(response[0], dict):
-                    self._process_domain_response(response[0])
-                    return
-                else:
-                    self.logger.warning(f'Invalid response format for domain search: {domain}')
-
-            except Exception as e:
-                self.logger.error(f'Domain search attempt {attempt + 1} failed for {domain}: {e}')
-                if attempt < self.max_retries - 1:
-                    await asyncio.sleep(2**attempt)  # Exponential backoff
-                else:
-                    raise
+        response = await self._fetch_response(url, 'domain', domain)
+        if response is not None:
+            self._process_domain_response(response)
 
     async def _search_email(self, email: str) -> None:
         """Search Hudson Rock by email with retry logic.
@@ -115,24 +101,45 @@ class SearchHudsonRock:
 
         """
         url = f'{self.base_url}/search-by-email?email={email}'
+        response = await self._fetch_response(url, 'email', email)
+        if response is not None:
+            self._process_email_response(response)
 
+    async def _fetch_response(self, url: str, search_type: str, target: str) -> dict | None:
         for attempt in range(self.max_retries):
             try:
-                self.logger.debug(f'Searching email: {email} (attempt {attempt + 1})')
-                response = await AsyncFetcher.fetch_all([url], json=True, proxy=self.proxy)
-
-                if response and isinstance(response[0], dict):
-                    self._process_email_response(response[0])
-                    return
-                else:
-                    self.logger.warning(f'Invalid response format for email search: {email}')
+                self.logger.debug(f'Searching {search_type}: {target} (attempt {attempt + 1})')
+                responses = await AsyncFetcher.fetch_all([url], json=True, proxy=self.proxy, include_metadata=True)
+                response = responses[0] if responses and isinstance(responses[0], FetcherResponse) else None
+                if response is None:
+                    self.logger.warning(f'Invalid response format for {search_type} search: {target}')
+                    return None
+                if response.status == 429:
+                    if attempt == self.max_retries - 1:
+                        self.logger.info(f'Hudson Rock {search_type} search returned HTTP 429 after {self.max_retries} attempts')
+                        return None
+                    retry_after = response.headers.get('retry-after')
+                    try:
+                        delay = int(retry_after) if retry_after is not None else 2**attempt
+                    except ValueError:
+                        delay = 2**attempt
+                    await asyncio.sleep(max(0, min(delay, 60)))
+                    continue
+                if not 200 <= response.status < 300:
+                    self.logger.info(f'Hudson Rock {search_type} search failed with HTTP {response.status}')
+                    return None
+                if not isinstance(response.body, dict):
+                    self.logger.warning(f'Invalid response format for {search_type} search: {target}')
+                    return None
+                return response.body
 
             except Exception as e:
-                self.logger.error(f'Email search attempt {attempt + 1} failed for {email}: {e}')
+                self.logger.error(f'{search_type.title()} search attempt {attempt + 1} failed for {target}: {e}')
                 if attempt < self.max_retries - 1:
-                    await asyncio.sleep(2**attempt)  # Exponential backoff
+                    await asyncio.sleep(2**attempt)
                 else:
                     raise
+        return None
 
     def _process_domain_response(self, response: dict) -> None:
         """Process domain search response from Hudson Rock API.
@@ -189,6 +196,8 @@ class SearchHudsonRock:
         extracted_count = 0
 
         for url_data in urls_data:
+            if not isinstance(url_data, dict):
+                continue
             url = url_data.get('url', '')
             if not url or url.startswith('https://•••') or url.startswith('http://•••'):
                 continue
@@ -238,15 +247,14 @@ class SearchHudsonRock:
 
         """
         try:
-            # Add the searched email to our results
-            if self._is_valid_email(self.word):
-                self.emails.add(self.word)
-
             # Process stealer data with enhanced information extraction
             stealers = response.get('stealers', [])
             self.logger.info(f'Processing {len(stealers)} stealer records for email: {self.word}')
 
             for stealer in stealers:
+                if not isinstance(stealer, dict):
+                    continue
+                self.emails.add(self.word)
                 stealer_info = {
                     'email': self.word,
                     'date_compromised': stealer.get('date_compromised'),

--- a/theHarvester/discovery/hudsonrocksearch.py
+++ b/theHarvester/discovery/hudsonrocksearch.py
@@ -199,7 +199,7 @@ class SearchHudsonRock:
             if not isinstance(url_data, dict):
                 continue
             url = url_data.get('url', '')
-            if not url or url.startswith('https://•••') or url.startswith('http://•••'):
+            if not isinstance(url, str) or not url or url.startswith('https://•••') or url.startswith('http://•••'):
                 continue
 
             try:
@@ -254,6 +254,10 @@ class SearchHudsonRock:
             for stealer in stealers:
                 if not isinstance(stealer, dict):
                     continue
+                corporate_services = stealer.get('top_corporate_services', [])
+                user_services = stealer.get('top_user_services', [])
+                if not isinstance(corporate_services, list) or not isinstance(user_services, list):
+                    continue
                 self.emails.add(self.word)
                 stealer_info = {
                     'email': self.word,
@@ -265,8 +269,8 @@ class SearchHudsonRock:
                     'total_corporate_services': stealer.get('total_corporate_services', 0),
                     'total_user_services': stealer.get('total_user_services', 0),
                     'antiviruses': stealer.get('antiviruses', []),
-                    'top_corporate_services': stealer.get('top_corporate_services', []),
-                    'top_user_services': stealer.get('top_user_services', []),
+                    'top_corporate_services': corporate_services,
+                    'top_user_services': user_services,
                 }
 
                 # Extract and validate IP addresses
@@ -276,8 +280,8 @@ class SearchHudsonRock:
                     self.logger.debug(f'Extracted IP: {ip}')
 
                 # Extract hostnames from services
-                self._extract_hosts_from_services(stealer.get('top_corporate_services', []))
-                self._extract_hosts_from_services(stealer.get('top_user_services', []))
+                self._extract_hosts_from_services(corporate_services)
+                self._extract_hosts_from_services(user_services)
 
                 self.infostealers.append(stealer_info)
 

--- a/theHarvester/lib/completed_result.py
+++ b/theHarvester/lib/completed_result.py
@@ -11,6 +11,7 @@ ResultKind = Literal[
     'breach',
     'email',
     'hostname',
+    'infostealer',
     'interesting-url',
     'ip-address',
     'linkedin-link',


### PR DESCRIPTION
## Summary
- make Hudson Rock domain and email requests status-aware through the shared transport
- retry HTTP 429 responses within the existing three-attempt bound and honor bounded `Retry-After` values
- stop terminal HTTP and malformed responses without immediate repeated requests
- skip malformed URL and stealer items while preserving later valid normalized evidence
- avoid reporting the queried email when an empty response contains no supporting stealer record
- remove the unnecessary delay after the final provider request

The public source identifier, CLI routing, source capabilities, and public getters remain unchanged. Offline fixtures use reserved domains and TEST-NET addresses and retain no raw provider response.

## Verification
- focused Hudson Rock tests: 7 passed
- full pytest: 362 passed, 6 skipped
- Ruff check passed
- Ruff formatting check passed
- mypy passed
- git diff check passed
- zero em dashes in changed files
- live aggregate-only adapter check against `mozilla.org`: 2 hosts, both in scope, 0 IPs, 0 emails; no payload or finding values retained
- parallel Standards and Spec reviews against `3739ae72` passed after all findings were fixed

Related to NotoriousRebel/theHarvester#101
