### PR TITLE
Persist terminal evidence for REST queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the nonfunctional ThreatCrowd source because its service hostnames terminate at deleted AWS load balancers and return NXDOMAIN; OTX remains available through its separate adapter.
 
 ### Fixed
+- Made no-filename REST `/query` executions reach completed-result construction and SQLite persistence without changing the legacy response fields.
 - Made Hudson Rock HTTP failures status-aware, bounded rate-limit retries, removed trailing request delays, isolated malformed provider items, and retained infostealer details in completed JSONL and SQLite results.
 - Made the public Have I Been Pwned breach catalogue keyless, added offline response contracts, and retained stable breach names in completed JSONL and SQLite results.
 - Fixed THC rate-limit exhaustion so terminal failures are reported without sleeping after the final attempt, with offline recovery, non-success, and malformed-response contracts.

--- a/docs/wiki/Rest-API.md
+++ b/docs/wiki/Rest-API.md
@@ -65,6 +65,10 @@ curl -sG http://127.0.0.1:5000/query \
   | jq
 ```
 
+A completed `/query` also retains its normalized terminal record in the local
+SQLite database. The response fields remain unchanged, and no JSON, XML, or
+JSONL report file is written unless `filename` is supplied.
+
 ## Additional API routes
 
 The following `POST /additional/*` routes provide optional breach, leak, security-score, and technology-stack lookups:

--- a/docs/wiki/Results-and-Local-Data.md
+++ b/docs/wiki/Results-and-Local-Data.md
@@ -34,13 +34,17 @@ Host, email, IP, and related records are stored at:
 
 The database persists across runs. Account for it in engagement cleanup and retention procedures.
 
+Completed CLI and REST `/query` executions also store one normalized terminal
+record keyed by run UUID. REST keeps its existing response shape and does not
+write report files unless a filename is requested.
+
 ## Screenshots
 
 `--screenshot DIR` writes browser captures to the selected directory. Screenshots may contain authentication pages, internal names, or other sensitive visual data even when no credentials were used.
 
 ## REST JSON
 
-The REST `/query` response returns arrays for ASNs, interesting URLs, Twitter/LinkedIn data, Trello URLs, IPs, emails, and hosts. Treat runtime `/docs`, `/redoc`, and OpenAPI as the exact request/response reference.
+The REST `/query` response returns arrays for ASNs, interesting URLs, Twitter/LinkedIn data, Trello URLs, IPs, emails, and hosts. The corresponding normalized terminal record is retained in SQLite. Treat runtime `/docs`, `/redoc`, and OpenAPI as the exact request/response reference.
 
 ## Handling and sharing
 

--- a/tests/discovery/test_rapiddns.py
+++ b/tests/discovery/test_rapiddns.py
@@ -266,8 +266,7 @@ async def test_rapiddns_evidence_reaches_existing_outputs(
     console = capsys.readouterr().out
     assert {'alias.example.com', 'api.example.com', 'broken.example.com', '192.0.2.1'} <= set(console.splitlines())
 
-    stored_before_rest = len(stored)
-    rest_results = await theharvester_main.start(
+    legacy_rest_results = await theharvester_main.start(
         Namespace(
             source='dehashed,rapiddns',
             dns_brute=False,
@@ -284,6 +283,29 @@ async def test_rapiddns_evidence_reaches_existing_outputs(
             proxies=False,
         )
     )
+    stored_before_rest = len(stored)
+    rest_results = await theharvester_main.start(
+        Namespace(
+            source='dehashed,rapiddns',
+            dns_brute=False,
+            filename='',
+            quiet=True,
+            dns_lookup=False,
+            dns_server=None,
+            dns_resolve='',
+            limit=500,
+            shodan=False,
+            start=0,
+            domain='example.com',
+            take_over=False,
+            proxies=False,
+            screenshot='',
+            wordlist='',
+            api_scan=False,
+        ),
+        persist_completed_result=True,
+    )
+    assert rest_results == legacy_rest_results
     assert set(rest_results[6]) == {'192.0.2.1', '198.51.100.2'}
     assert rest_results[8] == ['alias.example.com', 'api.example.com', 'broken.example.com']
     assert stored[stored_before_rest:] == [
@@ -291,18 +313,21 @@ async def test_rapiddns_evidence_reaches_existing_outputs(
         ('host', ('alias.example.com', 'api.example.com', 'broken.example.com'), 'rapiddns'),
         ('ip', ('192.0.2.1',), 'rapiddns'),
     ]
-    assert len(completed_results) == 1
+    assert len(completed_results) == 2
+    assert FakeSecurityScorecard.created == 2
+    assert completed_results[1].target == 'example.com'
+    assert {'192.0.2.1', '198.51.100.2'} <= {value for kind, value in completed_results[1].results if kind == 'ip-address'}
 
     monkeypatch.setattr(sys, 'argv', ['theHarvester', '-d', 'example.com', '-b', 'rapiddns'])
     with pytest.raises(SystemExit) as no_file_exit:
         await theharvester_main.start()
     assert no_file_exit.value.code == 0
-    assert len(completed_results) == 2
-    assert completed_results[1].target == 'example.com'
+    assert len(completed_results) == 3
+    assert completed_results[2].target == 'example.com'
 
     FakeStash.fail_completed_write = True
     with pytest.raises(SystemExit) as failed_write_exit:
         await theharvester_main.start()
     assert failed_write_exit.value.code == 0
-    assert len(completed_results) == 2
+    assert len(completed_results) == 3
     assert 'forced completed-result failure' in capsys.readouterr().out

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -7,10 +7,10 @@ from theHarvester.lib.core import Core
 
 
 def test_query_expands_source_capability(monkeypatch) -> None:
-    captured: list[Namespace] = []
+    captured: list[tuple[Namespace, bool]] = []
 
-    async def fake_start(args: Namespace):
-        captured.append(args)
+    async def fake_start(args: Namespace, *, persist_completed_result: bool = False):
+        captured.append((args, persist_completed_result))
         return ([], [], [], [], [], [], [], [], [])
 
     monkeypatch.setattr(api.__main__, 'start', fake_start)
@@ -18,14 +18,15 @@ def test_query_expands_source_capability(monkeypatch) -> None:
     response = TestClient(api.app).get('/query?domain=example.test&source=subdomains')
 
     assert response.status_code == 200
-    assert captured[0].source == ','.join(Core.expand_source_selection('subdomains'))
+    assert captured[0][0].source == ','.join(Core.expand_source_selection('subdomains'))
+    assert captured[0][1] is True
 
 
 def test_query_unions_capabilities_and_explicit_sources(monkeypatch) -> None:
-    captured: list[Namespace] = []
+    captured: list[tuple[Namespace, bool]] = []
 
-    async def fake_start(args: Namespace):
-        captured.append(args)
+    async def fake_start(args: Namespace, *, persist_completed_result: bool = False):
+        captured.append((args, persist_completed_result))
         return ([], [], [], [], [], [], [], [], [])
 
     monkeypatch.setattr(api.__main__, 'start', fake_start)
@@ -33,7 +34,8 @@ def test_query_unions_capabilities_and_explicit_sources(monkeypatch) -> None:
     response = TestClient(api.app).get('/query?domain=example.test&source=emails&source=certspotter')
 
     assert response.status_code == 200
-    assert captured[0].source == ','.join(Core.expand_source_selection('emails,certspotter'))
+    assert captured[0][0].source == ','.join(Core.expand_source_selection('emails,certspotter'))
+    assert captured[0][1] is True
 
 
 def test_query_rejects_unknown_source_or_capability(monkeypatch) -> None:

--- a/tests/test_rest_terminal_evidence.py
+++ b/tests/test_rest_terminal_evidence.py
@@ -1,0 +1,20 @@
+from argparse import Namespace
+
+from fastapi.testclient import TestClient
+
+from theHarvester.lib.api import api
+
+
+def test_query_requests_completed_result_persistence(monkeypatch) -> None:
+    persistence_flags: list[bool] = []
+
+    async def fake_start(args: Namespace, *, persist_completed_result: bool = False):
+        persistence_flags.append(persist_completed_result)
+        return ([], [], [], [], [], [], [], [], [])
+
+    monkeypatch.setattr(api.__main__, 'start', fake_start)
+
+    response = TestClient(api.app).get('/query?domain=example.test&source=crtsh')
+
+    assert response.status_code == 200
+    assert persistence_flags == [True]

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -138,7 +138,7 @@ def sanitize_filename(filename: str) -> str:
     return filename
 
 
-async def start(rest_args: argparse.Namespace | None = None):
+async def start(rest_args: argparse.Namespace | None = None, *, persist_completed_result: bool = False):
     """Main program function"""
     parser = argparse.ArgumentParser(
         description='theHarvester is used to gather open source intelligence (OSINT) on a company or domain.'
@@ -1299,6 +1299,47 @@ async def start(rest_args: argparse.Namespace | None = None):
         await asyncio.gather(*tasks, return_exceptions=True)
 
     await handler(lst=stor_lst)
+
+    def finish_completed_result(
+        *, extra_hostnames: Iterable[str] = (), virtual_hosts: Iterable[str] = ()
+    ) -> CompletedResult | None:
+        groups: dict[ResultKind, Iterable[str]] = {
+            'asn': map(str, total_asns),
+            'breach': map(str, all_breaches),
+            'email': map(str, all_emails),
+            'hostname': _normalize_hosts_for_storage((*all_hosts, *extra_hostnames), word),
+            'infostealer': (
+                json.dumps(stealer, ensure_ascii=False, separators=(',', ':'), sort_keys=True) for stealer in all_infostealers
+            ),
+            'interesting-url': map(str, interesting_urls),
+            'ip-address': _normalize_ip_addresses(all_ip),
+            'linkedin-link': map(str, linkedin_links_tracker),
+            'linkedin-person': map(str, linkedin_people_list_tracker),
+            'person': (json.dumps(person, ensure_ascii=False, separators=(',', ':'), sort_keys=True) for person in all_people),
+            'twitter-person': map(str, twitter_people_list_tracker),
+            'url': map(str, all_urls),
+            'vhost': map(str, virtual_hosts),
+        }
+        try:
+            return CompletedResult.finish(
+                target=word,
+                started_at=run_started_at,
+                completed_at=datetime.now(UTC),
+                groups=groups,
+            )
+        except (ValueError, TypeError) as error:
+            output_logger.info(f'[!] An error occurred while completing the result: {error}')
+            return None
+
+    async def persist_result(completed_result: CompletedResult | None) -> None:
+        if completed_result is None:
+            return
+        try:
+            completed_db = stash.StashManager()
+            await completed_db.store_completed_result(completed_result)
+        except Exception as error:
+            output_logger.info(f'[!] An error occurred while storing the completed result: {error}')
+
     return_ips: list = []
     if rest_args is not None and len(rest_filename) == 0 and rest_args.dns_brute is False:
         # Indicates user is using REST api but not wanting output to be saved to a file
@@ -1306,6 +1347,8 @@ async def start(rest_args: argparse.Namespace | None = None):
         return_ips.extend([str(ip) for ip in sorted([netaddr.IPAddress(ip.strip()) for ip in set(all_ip)])])
         # return list(set(all_emails)), return_ips, full, '', ''
         all_hosts = sorted_unique(all_hosts)
+        if persist_completed_result:
+            await persist_result(finish_completed_result())
         return (
             total_asns,
             interesting_urls,
@@ -1845,33 +1888,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 else:
                     output_logger.info(f'An exception has occurred in BuiltWith scanning: {e}')
 
-    groups: dict[ResultKind, Iterable[str]] = {
-        'asn': map(str, total_asns),
-        'breach': map(str, all_breaches),
-        'email': map(str, all_emails),
-        'hostname': _normalize_hosts_for_storage((*all_hosts, *dnsrev), word),
-        'infostealer': (
-            json.dumps(stealer, ensure_ascii=False, separators=(',', ':'), sort_keys=True) for stealer in all_infostealers
-        ),
-        'interesting-url': map(str, interesting_urls),
-        'ip-address': _normalize_ip_addresses(all_ip),
-        'linkedin-link': map(str, linkedin_links_tracker),
-        'linkedin-person': map(str, linkedin_people_list_tracker),
-        'person': (json.dumps(person, ensure_ascii=False, separators=(',', ':'), sort_keys=True) for person in all_people),
-        'twitter-person': map(str, twitter_people_list_tracker),
-        'url': map(str, all_urls),
-        'vhost': map(str, vhost),
-    }
-    try:
-        completed_result = CompletedResult.finish(
-            target=word,
-            started_at=run_started_at,
-            completed_at=datetime.now(UTC),
-            groups=groups,
-        )
-    except (ValueError, TypeError) as error:
-        completed_result = None
-        output_logger.info(f'[!] An error occurred while completing the result: {error}')
+    completed_result = finish_completed_result(extra_hostnames=dnsrev, virtual_hosts=vhost)
 
     if filename and completed_result is not None:
         try:
@@ -1882,12 +1899,7 @@ async def start(rest_args: argparse.Namespace | None = None):
         except (OSError, ValueError, TypeError, UnicodeEncodeError) as error:
             output_logger.info(f'[!] An error occurred while saving the JSONL file: {error}')
 
-    if completed_result is not None:
-        try:
-            completed_db = stash.StashManager()
-            await completed_db.store_completed_result(completed_result)
-        except Exception as error:
-            output_logger.info(f'[!] An error occurred while storing the completed result: {error}')
+    await persist_result(completed_result)
 
     if rest_args is not None:
         all_hosts = sorted_unique(all_hosts)

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -362,7 +362,8 @@ async def query(
                 dns_resolve=dns_resolve,
                 quiet=False,
                 screenshot='',
-            )
+            ),
+            persist_completed_result=True,
         )
 
         # Return the results using the Pydantic model


### PR DESCRIPTION
## Summary

- persist no-filename REST `/query` runs as normalized completed results in SQLite
- preserve the existing nine-field response and legacy early-return boundary
- keep JSON, XML, and JSONL report creation gated on an explicit filename
- share completion and persistence logic with the existing CLI path

## Verification

- focused pytest: 7 passed
- full pytest: 364 passed, 6 skipped
- Ruff check and format check
- mypy: 85 source files
- git diff --check
- parallel Standards and Spec reviews: PASS

Related fork issue: NotoriousRebel/theHarvester#151