### PR TITLE
Add Shodan CT passive hostname discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added keyless Shodan Certificate Transparency hostname discovery with bounded requests and offline response contracts.
 - Added transactional SQLite storage and loading for completed full-pipeline runs without changing legacy result rows.
 - Added deterministic JSONL report companions finalized after selected one-shot actions complete.
 - Added DNSDB passive DNS discovery with API key configuration, shared transport handling, result parsing, and offline tests ([9b41b78e](https://github.com/laramies/theHarvester/commit/9b41b78e), [aba9fec6](https://github.com/laramies/theHarvester/commit/aba9fec6)).

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Read the **API key** column as follows:
 | `sherlockeye` | ✓ | ✓ | ✓ | No | No | No | No | No | ✓ |
 | `shodan` | ✓ | No | No | No | No | No | No | `-s` / `--shodan` host-enrichment output | ✓ |
 | `shodanInternetDB` | ✓ | No | ✓ | No | No | No | No | No | No |
+| `shodanct` | ✓ | No | No | No | No | No | No | No | No |
 | `subdomaincenter` | ✓ | No | No | No | No | No | No | No | No |
 | `subdomainfinderc99` | ✓ | No | No | No | No | No | No | No | No |
 | `thc` | ✓ | No | No | No | No | No | No | No | No |

--- a/tests/discovery/test_shodanct.py
+++ b/tests/discovery/test_shodanct.py
@@ -1,0 +1,101 @@
+import logging
+from typing import Any
+
+import pytest
+
+from theHarvester.discovery import shodanct
+from theHarvester.lib.core import FetcherResponse
+
+
+@pytest.mark.asyncio
+async def test_process_returns_normalized_in_scope_hostnames(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    requests: list[tuple[list[str], dict[str, Any]]] = []
+
+    async def fake_fetch_all(urls: list[str], **kwargs: Any) -> list[FetcherResponse]:
+        requests.append((urls, kwargs))
+        return [
+            FetcherResponse(
+                body=[
+                    'API.Example.COM.',
+                    '*.wild.example.com',
+                    'www.example.com',
+                    'example.com',
+                    'outside.test',
+                    'not valid.example.com',
+                    '-bad.example.com',
+                    None,
+                ],
+                status=200,
+                headers={},
+            )
+        ]
+
+    monkeypatch.setattr(shodanct.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    with caplog.at_level(logging.INFO, logger=shodanct.__name__):
+        search = shodanct.SearchShodanCt(' Example.COM. ')
+        await search.process()
+
+    assert await search.get_hostnames() == {
+        'api.example.com',
+        'example.com',
+        'wild.example.com',
+        'www.example.com',
+    }
+    assert requests == [
+        (
+            ['https://ctl.shodan.io/api/v1/domain/example.com/hostnames'],
+            {'json': True, 'proxy': False, 'include_metadata': True},
+        )
+    ]
+    assert 'Shodan CT ignored malformed hostname data' in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('status', [429, 500])
+async def test_process_reports_non_success_status(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    status: int,
+) -> None:
+    async def fake_fetch_all(_urls: list[str], **_kwargs: Any) -> list[FetcherResponse]:
+        return [FetcherResponse(body={'error': 'unavailable'}, status=status, headers={})]
+
+    monkeypatch.setattr(shodanct.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    with caplog.at_level(logging.INFO, logger=shodanct.__name__):
+        search = shodanct.SearchShodanCt('example.com')
+        await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert f'Shodan CT request failed with HTTP {status}' in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('response', 'message'),
+    [
+        (None, 'Shodan CT request failed'),
+        (FetcherResponse(body='not a list', status=200, headers={}), 'Shodan CT returned malformed data'),
+    ],
+)
+async def test_process_reports_transport_and_malformed_responses(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    response: FetcherResponse | None,
+    message: str,
+) -> None:
+    async def fake_fetch_all(_urls: list[str], **_kwargs: Any) -> list[FetcherResponse | None]:
+        return [response]
+
+    monkeypatch.setattr(shodanct.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    with caplog.at_level(logging.INFO, logger=shodanct.__name__):
+        search = shodanct.SearchShodanCt('example.com')
+        await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert message in caplog.text

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -80,8 +80,8 @@ def test_readme_matches_declared_source_contracts() -> None:
     declared = _declared_source_contracts()
 
     assert '| Source | Subdomains | Emails | IPs | ASNs | URLs / links | People | Breaches |' in readme
-    assert len(declared) == 54
-    assert len(documented) == 54
+    assert len(declared) == 55
+    assert len(documented) == 55
     assert documented == declared
     assert {'securitytrails', 'shodaninternetdb'}.isdisjoint(documented)
 

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -63,6 +63,7 @@ from theHarvester.discovery import (
     securitytrailssearch,
     sherlockeye,
     shodan_internetdb,
+    shodanct,
     shodansearch,
     subdomaincenter,
     subdomainfinderc99,
@@ -233,7 +234,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                             Sources: baidu, bevigil, brave, bufferoverun,
                             builtwith, censys, certspotter, chaos, commoncrawl, criminalip, crtsh, dehashed, dnsdumpster, duckduckgo, dymo, fofa, fullhunt, github-code,
                             gitlab, hackertarget, haveibeenpwned, hudsonrock, hunter, hunterhow, intelx, leakix, leaklookup, mojeek, netlas, onyphe, otx, pentesttools,
-                            projectdiscovery, rapiddns, robtex, rocketreach, securityscorecard, securityTrails, sherlockeye, shodan, shodanInternetDB, subdomaincenter,
+                            projectdiscovery, rapiddns, robtex, rocketreach, securityscorecard, securityTrails, sherlockeye, shodan, shodanct, shodanInternetDB, subdomaincenter,
                             subdomainfinderc99, thc, tomba, urlscan, venacus, virustotal, waybackarchive, whoisxml, windvane, yahoo, zoomeye""",
     )
 
@@ -1073,6 +1074,13 @@ async def start(rest_args: argparse.Namespace | None = None):
                     except Exception as e:
                         if not args.quiet:
                             output_logger.info(f'Unexpected error occurred in Shodan InternetDB module: {e}')
+
+                elif engineitem == 'shodanct':
+                    try:
+                        shodanct_search = shodanct.SearchShodanCt(word)
+                        stor_lst.append(store(shodanct_search, engineitem))
+                    except Exception as e:
+                        show_default_error_message(engineitem, word, e)
 
                 elif engineitem == 'subdomaincenter':
                     try:

--- a/theHarvester/discovery/shodanct.py
+++ b/theHarvester/discovery/shodanct.py
@@ -1,0 +1,73 @@
+import logging
+
+from theHarvester.lib.core import AsyncFetcher, FetcherResponse
+from theHarvester.lib.hostnames import normalize_scoped_hostname
+
+logger = logging.getLogger(__name__)
+
+
+class SearchShodanCt:
+    """Collect hostname evidence from Shodan's public CT mirror.
+
+    API documentation: https://ctl.shodan.io/
+    """
+
+    def __init__(self, word: str) -> None:
+        self.word = word.strip().lower().rstrip('.')
+        self.hostnames: set[str] = set()
+        self.proxy = False
+
+    async def process(self, proxy: bool = False) -> None:
+        self.proxy = proxy
+        try:
+            responses: list[FetcherResponse | None] = await AsyncFetcher.fetch_all(
+                [f'https://ctl.shodan.io/api/v1/domain/{self.word}/hostnames'],
+                json=True,
+                proxy=self.proxy,
+                include_metadata=True,
+            )
+        except Exception as error:
+            logger.info(f'Shodan CT request failed: {error}')
+            return
+
+        response = responses[0] if responses else None
+        if response is None:
+            logger.info('Shodan CT request failed')
+            return
+        if not 200 <= response.status < 300:
+            logger.info(f'Shodan CT request failed with HTTP {response.status}')
+            return
+        if not isinstance(response.body, list):
+            logger.info('Shodan CT returned malformed data')
+            return
+
+        malformed = False
+        for candidate in response.body:
+            if not isinstance(candidate, str):
+                malformed = True
+                continue
+            normalized = normalize_scoped_hostname(candidate.strip().removeprefix('*.'), self.word)
+            if normalized is None:
+                continue
+            labels = normalized.split('.')
+            if (
+                len(normalized) > 253
+                or not normalized.isascii()
+                or any(
+                    not label
+                    or len(label) > 63
+                    or not label[0].isalnum()
+                    or not label[-1].isalnum()
+                    or not all(character.isalnum() or character == '-' for character in label)
+                    for label in labels
+                )
+            ):
+                malformed = True
+                continue
+            self.hostnames.add(normalized)
+
+        if malformed:
+            logger.info('Shodan CT ignored malformed hostname data')
+
+    async def get_hostnames(self) -> set[str]:
+        return self.hostnames

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -331,6 +331,7 @@ class Core:
             'sherlockeye',
             'shodan',
             'shodanInternetDB',
+            'shodanct',
             'subdomaincenter',
             'subdomainfinderc99',
             'sublist3r',

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -89,6 +89,7 @@ _SPECS = (
     _spec('sherlockeye', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS, ResultRoute.IPS),
     _spec('shodan', ResultRoute.SUBDOMAINS),
     _spec('shodanInternetDB', ResultRoute.SUBDOMAINS, ResultRoute.IPS),
+    _spec('shodanct', ResultRoute.SUBDOMAINS),
     _spec('subdomaincenter', ResultRoute.SUBDOMAINS),
     _spec('subdomainfinderc99', ResultRoute.SUBDOMAINS),
     _spec('thc', ResultRoute.SUBDOMAINS),


### PR DESCRIPTION
## Summary

- add Shodan CT as a keyless P0 hostname source using its documented public CT API
- make one bounded request per selected target and preserve HTTP status attribution
- normalize exact-suffix names through the shared hostname seam, preserve `www`, and reduce wildcard certificate names to their concrete suffix
- ignore malformed siblings without retaining raw provider payloads
- register only the existing subdomain route so CLI, REST, JSON, XML, JSONL, and SQLite behavior stays on the central collection path

This cleanly salvages the focused provider behavior from fork PR NotoriousRebel/theHarvester#144 without importing its stale run-evidence abstractions. Shodan is identified in code and documentation per its service terms.

## Verification

- red state: adapter import failed before implementation
- focused offline pytest: 20 passed
- full pytest: 368 passed, 6 skipped
- Ruff check and format check
- mypy: 86 source files
- git diff --check
- zero em dashes
- parallel Standards and Spec reviews: PASS
- bounded live P0 smoke against approved `mozilla.org`: 208 normalized names; apex and `www` preserved

No live provider call is part of routine tests or CI.