### PR TITLE
Expose completed run history over REST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added authenticated REST routes for listing completed enumeration runs and retrieving their normalized evidence.
 - Added keyless Shodan Certificate Transparency hostname discovery with bounded requests and offline response contracts.
 - Added transactional SQLite storage and loading for completed full-pipeline runs without changing legacy result rows.
 - Added deterministic JSONL report companions finalized after selected one-shot actions complete.

--- a/docs/wiki/Rest-API.md
+++ b/docs/wiki/Rest-API.md
@@ -35,6 +35,8 @@ Treat the runtime OpenAPI document as the exact request and response reference.
 | `GET /sources` | List current discovery sources. |
 | `GET /query` | Run selected discovery sources and return consolidated JSON. |
 | `GET /dnsbrute` | Run active DNS brute force for an authorized domain. |
+| `GET /runs` | List recent completed enumeration runs. |
+| `GET /runs/{run_id}` | Retrieve one completed run and its normalized evidence. |
 
 List sources:
 
@@ -69,6 +71,15 @@ A completed `/query` also retains its normalized terminal record in the local
 SQLite database. The response fields remain unchanged, and no JSON, XML, or
 JSONL report file is written unless `filename` is supplied.
 
+Completed-run routes require the operator API key because retained evidence can
+contain sensitive results:
+
+```bash
+curl -s http://127.0.0.1:5000/runs \
+  -H "X-API-Key: $THEHARVESTER_API_KEY" \
+  | jq
+```
+
 ## Additional API routes
 
 The following `POST /additional/*` routes provide optional breach, leak, security-score, and technology-stack lookups:
@@ -101,7 +112,7 @@ These routes may also require provider credentials in the request body or local 
 
 ## Security boundary
 
-`THEHARVESTER_API_KEY` protects only `/additional/*`. It does not authenticate `/query`, `/sources`, or `/dnsbrute`.
+`THEHARVESTER_API_KEY` protects `/additional/*` and `/runs*`. It does not authenticate `/query`, `/sources`, or `/dnsbrute`.
 
 Keep the default localhost binding. If you require remote access, add authentication, network allowlists, TLS, request logging, and an appropriate rate limit.
 

--- a/tests/test_rest_completed_runs.py
+++ b/tests/test_rest_completed_runs.py
@@ -1,0 +1,94 @@
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+
+from theHarvester.lib.api import api
+from theHarvester.lib.completed_result import CompletedResult
+from theHarvester.lib.stash import StashManager
+
+
+def completed_result(run_id: str, completed_at: datetime) -> CompletedResult:
+    return CompletedResult.finish(
+        run_id=UUID(run_id),
+        target='example.com',
+        started_at=completed_at - timedelta(minutes=1),
+        completed_at=completed_at,
+        groups={'hostname': ['www.example.com']},
+    )
+
+
+@pytest.mark.asyncio
+async def test_authenticated_operator_lists_recent_completed_runs(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr('theHarvester.lib.stash.db_path', str(tmp_path))
+    monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-secret')
+    manager = StashManager()
+    await manager.do_init()
+    older = completed_result('11111111-1111-4111-8111-111111111111', datetime(2026, 8, 6, 12, 0, tzinfo=UTC))
+    newer = completed_result('22222222-2222-4222-8222-222222222222', datetime(2026, 8, 6, 13, 0, tzinfo=UTC))
+    offset_older = completed_result(
+        '55555555-5555-4555-8555-555555555555', datetime.fromisoformat('2026-08-06T14:30:00+05:00')
+    )
+    await manager.store_completed_result(older)
+    await manager.store_completed_result(newer)
+    await manager.store_completed_result(offset_older)
+
+    response = TestClient(api.app).get('/runs?limit=1', headers={'X-API-Key': 'test-secret'})
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            'run_id': str(newer.run_id),
+            'target': 'example.com',
+            'started_at': '2026-08-06T12:59:00Z',
+            'completed_at': '2026-08-06T13:00:00Z',
+            'result_count': 1,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_authenticated_operator_gets_one_completed_run(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr('theHarvester.lib.stash.db_path', str(tmp_path))
+    monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-secret')
+    manager = StashManager()
+    await manager.do_init()
+    result = CompletedResult.finish(
+        run_id=UUID('33333333-3333-4333-8333-333333333333'),
+        target='example.com',
+        started_at=datetime(2026, 8, 6, 14, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 8, 6, 14, 1, tzinfo=UTC),
+        groups={'email': ['security@example.com'], 'hostname': ['www.example.com']},
+    )
+    await manager.store_completed_result(result)
+    client = TestClient(api.app)
+
+    response = client.get(f'/runs/{result.run_id}', headers={'X-API-Key': 'test-secret'})
+    missing = client.get('/runs/44444444-4444-4444-8444-444444444444', headers={'X-API-Key': 'test-secret'})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        'run_id': str(result.run_id),
+        'target': 'example.com',
+        'started_at': '2026-08-06T14:00:00Z',
+        'completed_at': '2026-08-06T14:01:00Z',
+        'result_count': 2,
+        'results': [
+            {'type': 'email', 'value': 'security@example.com'},
+            {'type': 'hostname', 'value': 'www.example.com'},
+        ],
+    }
+    assert missing.status_code == 404
+    assert missing.json() == {'detail': 'Completed run not found'}
+
+
+def test_completed_run_routes_fail_closed_without_operator_key(monkeypatch) -> None:
+    monkeypatch.delenv('THEHARVESTER_API_KEY', raising=False)
+    client = TestClient(api.app)
+
+    list_response = client.get('/runs')
+    detail_response = client.get('/runs/33333333-3333-4333-8333-333333333333')
+
+    assert list_response.status_code == 503
+    assert detail_response.status_code == 503

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -4,9 +4,11 @@ import ipaddress
 import logging
 import os
 import socket
+from datetime import datetime
 from typing import Annotated, Any, cast
+from uuid import UUID
 
-from fastapi import FastAPI, Header, HTTPException, Query, Request, status
+from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from pydantic import BaseModel, Field
@@ -16,7 +18,10 @@ from slowapi.util import get_remote_address
 from starlette.staticfiles import StaticFiles
 
 from theHarvester import __main__
+from theHarvester.lib import stash
 from theHarvester.lib.api.additional_endpoints import router as additional_router
+from theHarvester.lib.api.auth import get_api_key
+from theHarvester.lib.completed_result import ResultKind
 
 logger = logging.getLogger(__name__)
 
@@ -166,6 +171,23 @@ class SourcesResponse(BaseModel):
     sources: list[str] = Field(..., description='List of supported data sources')
 
 
+class CompletedRunSummary(BaseModel):
+    run_id: UUID
+    target: str
+    started_at: datetime
+    completed_at: datetime
+    result_count: int
+
+
+class CompletedResultItem(BaseModel):
+    type: ResultKind
+    value: str
+
+
+class CompletedRunDetail(CompletedRunSummary):
+    results: list[CompletedResultItem]
+
+
 @app.get(
     '/sources',
     response_model=SourcesResponse,
@@ -194,6 +216,54 @@ async def getsources(request: Request) -> Response:
             },
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
+
+
+@app.get(
+    '/runs',
+    response_model=list[CompletedRunSummary],
+    responses={status.HTTP_429_TOO_MANY_REQUESTS: {'model': ErrorResponse}},
+)
+@limiter.limit(API_RATE_LIMIT)
+async def list_runs(
+    request: Request,
+    _api_key: Annotated[str, Depends(get_api_key)],
+    limit: Annotated[int, Query(ge=1, le=500)] = 50,
+) -> list[dict[str, object]]:
+    """List recently completed enumeration runs."""
+    manager = stash.StashManager()
+    await manager.do_init()
+    return await manager.list_completed_results(limit=limit)
+
+
+@app.get(
+    '/runs/{run_id}',
+    response_model=CompletedRunDetail,
+    responses={
+        status.HTTP_404_NOT_FOUND: {'model': ErrorResponse},
+        status.HTTP_429_TOO_MANY_REQUESTS: {'model': ErrorResponse},
+    },
+)
+@limiter.limit(API_RATE_LIMIT)
+async def get_run(
+    request: Request,
+    run_id: UUID,
+    _api_key: Annotated[str, Depends(get_api_key)],
+) -> dict[str, object]:
+    """Retrieve one completed enumeration run with its normalized evidence."""
+    manager = stash.StashManager()
+    await manager.do_init()
+    try:
+        result = await manager.load_completed_result(run_id)
+    except LookupError as error:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Completed run not found') from error
+    return {
+        'run_id': str(result.run_id),
+        'target': result.target,
+        'started_at': result.started_at.isoformat(),
+        'completed_at': result.completed_at.isoformat(),
+        'result_count': len(result.results),
+        'results': [{'type': kind, 'value': value} for kind, value in result.results],
+    }
 
 
 # Define Pydantic model for DNS brute force response

--- a/theHarvester/lib/stash.py
+++ b/theHarvester/lib/stash.py
@@ -117,6 +117,30 @@ class StashManager:
             results=tuple((cast('ResultKind', kind), value) for kind, value in rows),
         )
 
+    async def list_completed_results(self, *, limit: int = 50) -> list[dict[str, object]]:
+        async with aiosqlite.connect(self.db, timeout=30) as db:
+            rows = await db.execute_fetchall(
+                """
+                SELECT runs.run_id, runs.target, runs.started_at, runs.completed_at, COUNT(items.position)
+                FROM completed_results AS runs
+                LEFT JOIN completed_result_items AS items ON items.run_id = runs.run_id
+                GROUP BY runs.run_id
+                ORDER BY julianday(runs.completed_at) DESC, runs.run_id DESC
+                LIMIT ?
+                """,
+                (limit,),
+            )
+        return [
+            {
+                'run_id': row[0],
+                'target': row[1],
+                'started_at': row[2],
+                'completed_at': row[3],
+                'result_count': row[4],
+            }
+            for row in rows
+        ]
+
     async def store(self, domain, resource, res_type, source) -> None:
         self.domain = domain
         self.resource = resource


### PR DESCRIPTION
## Summary

- add API-key-protected `GET /runs` for bounded completed enumeration history
- add API-key-protected `GET /runs/{run_id}` for normalized evidence detail
- reuse the completed-result SQLite records already written by REST `/query`
- order results chronologically across timezone offsets and expose typed UUID and date-time OpenAPI fields

## Why

REST `/query` now persists terminal evidence, but operators have no REST path for reading it back. These routes expose that existing evidence without rerunning providers or introducing Wayfinder scheduling, workers, cancellation, imports, exports, or UI code.

Completed evidence can contain sensitive breach, infostealer, contact, and infrastructure data, so both routes fail closed through the existing `THEHARVESTER_API_KEY` dependency.

## Compatibility

- existing `/query`, `/sources`, `/dnsbrute`, CLI, JSON, XML, JSONL, SQLite, and public getter contracts are unchanged
- no dependency or database schema change
- invalid run IDs use FastAPI validation; unknown valid IDs return `404`

## Verification

- focused REST and persistence tests: 9 passed
- full pytest: 375 passed, 6 skipped
- Ruff check passed
- Ruff format check passed
- mypy passed
- `git diff --check` passed
- zero em dashes
- parallel Standards and Spec reviews passed after fixing mixed-timezone ordering and OpenAPI typing findings

A bounded live `mozilla.org` Shodan CT check was exercised through the actual FastAPI `/query` ASGI route with isolated temporary SQLite storage. It returned HTTP 200 and 207 normalized hostnames, including `www.mozilla.org`. The new authenticated history routes then listed and retrieved that same 207-result record. Temporary live evidence was deleted afterward.

Related fork decisions remain open because retention, comparison, export, asynchronous lifecycle, cancellation, and UI work are deliberately excluded:

- https://github.com/NotoriousRebel/theHarvester/issues/149
- https://github.com/NotoriousRebel/theHarvester/issues/151
