### PR TITLE
Make Chaos provider outcomes explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Made no-filename REST `/query` executions reach completed-result construction and SQLite persistence without changing the legacy response fields.
+- Made Chaos reject empty credentials, report HTTP and malformed-response failures, and preserve supported subdomain response shapes.
 - Made Hudson Rock HTTP failures status-aware, bounded rate-limit retries, removed trailing request delays, isolated malformed provider items, and retained infostealer details in completed JSONL and SQLite results.
 - Made the public Have I Been Pwned breach catalogue keyless, added offline response contracts, and retained stable breach names in completed JSONL and SQLite results.
 - Fixed THC rate-limit exhaustion so terminal failures are reported without sleeping after the final attempt, with offline recovery, non-success, and malformed-response contracts.

--- a/tests/discovery/test_chaos.py
+++ b/tests/discovery/test_chaos.py
@@ -1,0 +1,110 @@
+import logging
+from typing import Any
+
+import pytest
+
+from theHarvester.discovery import chaos
+from theHarvester.discovery.constants import MissingKey
+from theHarvester.lib.core import FetcherResponse
+
+
+@pytest.mark.asyncio
+async def test_http_failure_is_reported_without_results(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(chaos.Core, 'projectdiscovery_key', lambda: 'test-key')
+
+    async def fake_fetch_all(urls: list[str], **kwargs: Any) -> list[FetcherResponse]:
+        assert urls == ['https://dns.projectdiscovery.io/dns/example.com/subdomains']
+        assert kwargs['headers']['Authorization'] == 'Bearer test-key'
+        assert isinstance(kwargs['headers']['User-agent'], str)
+        assert {key: value for key, value in kwargs.items() if key != 'headers'} == {
+            'proxy': False,
+            'json': True,
+            'include_metadata': True,
+        }
+        return [FetcherResponse(body={'error': 'forbidden'}, status=403, headers={})]
+
+    monkeypatch.setattr(chaos.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = chaos.SearchChaos('example.com')
+
+    with caplog.at_level(logging.INFO, logger=chaos.__name__):
+        await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert 'Chaos request failed with HTTP 403' in caplog.text
+
+
+@pytest.mark.parametrize('key', ['', '   '])
+def test_empty_api_key_is_rejected(monkeypatch: pytest.MonkeyPatch, key: str) -> None:
+    monkeypatch.setattr(chaos.Core, 'projectdiscovery_key', lambda: key)
+
+    with pytest.raises(MissingKey):
+        chaos.SearchChaos('example.com')
+
+
+@pytest.mark.asyncio
+async def test_malformed_response_is_reported(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(chaos.Core, 'projectdiscovery_key', lambda: 'test-key')
+
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        return [FetcherResponse(body=7, status=200, headers={})]
+
+    monkeypatch.setattr(chaos.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = chaos.SearchChaos('example.com')
+
+    with caplog.at_level(logging.INFO, logger=chaos.__name__):
+        await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert 'Chaos returned malformed data' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_success_preserves_supported_subdomain_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(chaos.Core, 'projectdiscovery_key', lambda: 'test-key')
+
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        return [
+            FetcherResponse(
+                body={'subdomains': ['api', {'name': 'WWW'}, {'name': 7}, {'unexpected': 'value'}]},
+                status=200,
+                headers={},
+            )
+        ]
+
+    monkeypatch.setattr(chaos.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = chaos.SearchChaos('example.com')
+
+    with caplog.at_level(logging.INFO, logger=chaos.__name__):
+        await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com', 'www.example.com'}
+    assert caplog.text.count('Chaos ignored a malformed subdomain item') == 2
+
+
+@pytest.mark.asyncio
+async def test_malformed_subdomain_collection_is_reported(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(chaos.Core, 'projectdiscovery_key', lambda: 'test-key')
+
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        return [FetcherResponse(body={'subdomains': 7}, status=200, headers={})]
+
+    monkeypatch.setattr(chaos.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = chaos.SearchChaos('example.com')
+
+    with caplog.at_level(logging.INFO, logger=chaos.__name__):
+        await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert 'Chaos returned malformed subdomain data' in caplog.text

--- a/theHarvester/discovery/chaos.py
+++ b/theHarvester/discovery/chaos.py
@@ -1,21 +1,9 @@
-import json as _stdlib_json
 import logging
-from types import ModuleType
 
 from theHarvester.discovery.constants import MissingKey
-from theHarvester.lib.core import AsyncFetcher, Core
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
 
 logger = logging.getLogger(__name__)
-
-json: ModuleType = _stdlib_json
-try:
-    import ujson as _ujson
-
-    json = _ujson
-except ImportError:
-    pass
-except Exception:
-    pass
 
 
 class SearchChaos:
@@ -31,21 +19,12 @@ class SearchChaos:
     def _get_api_key(self) -> str:
         """Get Chaos API key"""
         try:
-            return Core.projectdiscovery_key()
-        except Exception:
+            key = Core.projectdiscovery_key()
+        except Exception as error:
+            raise MissingKey('Chaos (ProjectDiscovery)') from error
+        if not isinstance(key, str) or not key.strip():
             raise MissingKey('Chaos (ProjectDiscovery)')
-
-    @staticmethod
-    def _safe_parse_json(payload: object) -> dict:
-        # If already a dict, return it; if string, try parse; else return {}
-        if isinstance(payload, dict):
-            return payload
-        if isinstance(payload, str):
-            try:
-                return json.loads(payload)
-            except Exception:
-                return {}
-        return {}
+        return key
 
     async def do_search(self) -> None:
         try:
@@ -54,21 +33,34 @@ class SearchChaos:
             # Chaos API endpoint for subdomain enumeration
             url = f'{self.hostname}/dns/{self.word}/subdomains'
 
-            response = await AsyncFetcher.fetch_all([url], headers=headers, proxy=self.proxy)
+            response = await AsyncFetcher.fetch_all(
+                [url],
+                headers=headers,
+                proxy=self.proxy,
+                json=True,
+                include_metadata=True,
+            )
 
-            if not response or not isinstance(response, list) or not response[0]:
+            metadata = response[0] if response and isinstance(response[0], FetcherResponse) else None
+            if metadata is None:
                 logger.info(f'No response from Chaos API for: {url}')
+                return
+            if not 200 <= metadata.status < 300:
+                logger.info(f'Chaos request failed with HTTP {metadata.status}')
                 return
 
             try:
-                data = self._safe_parse_json(response[0])
+                data = metadata.body
+                if not isinstance(data, (dict, list)):
+                    logger.info('Chaos returned malformed data')
+                    return
 
                 if isinstance(data, dict):
                     # Check for error messages
                     if 'error' in data:
                         error_msg = data.get('message', data.get('error', 'Unknown error'))
                         logger.info('Chaos API returned an error')
-                        if 'unauthorized' in error_msg.lower():
+                        if 'unauthorized' in str(error_msg).lower():
                             raise MissingKey('Chaos (ProjectDiscovery)')
                         return
 
@@ -79,26 +71,25 @@ class SearchChaos:
                     if not subdomains:
                         subdomains = data.get('results', [])
 
-                    if isinstance(subdomains, list):
-                        for subdomain in subdomains:
-                            if isinstance(subdomain, str):
-                                # Chaos returns subdomain names without the root domain
-                                # So we need to append the root domain
-                                full_domain = f'{subdomain}.{self.word}' if subdomain else self.word
-                                self.totalhosts.add(full_domain.lower())
-                            elif isinstance(subdomain, dict):
-                                # Handle different response formats
-                                sub = subdomain.get('subdomain', '') or subdomain.get('name', '')
-                                if sub:
-                                    full_domain = f'{sub}.{self.word}'
-                                    self.totalhosts.add(full_domain.lower())
+                else:
+                    subdomains = data
 
-                elif isinstance(data, list):
-                    # Sometimes the response is directly a list
-                    for subdomain in data:
-                        if isinstance(subdomain, str):
-                            full_domain = f'{subdomain}.{self.word}' if subdomain else self.word
-                            self.totalhosts.add(full_domain.lower())
+                if not isinstance(subdomains, list):
+                    logger.info('Chaos returned malformed subdomain data')
+                    return
+                for subdomain in subdomains:
+                    if isinstance(subdomain, str):
+                        label = subdomain
+                    elif isinstance(subdomain, dict):
+                        label = subdomain.get('subdomain', '') or subdomain.get('name', '')
+                        if not isinstance(label, str) or not label:
+                            logger.info('Chaos ignored a malformed subdomain item')
+                            continue
+                    else:
+                        logger.info('Chaos ignored a malformed subdomain item')
+                        continue
+                    full_domain = f'{label}.{self.word}' if label else self.word
+                    self.totalhosts.add(full_domain.lower())
 
             except Exception as e:
                 logger.info(f'Failed to parse Chaos response: {e}')


### PR DESCRIPTION
## Summary

- fail before network access when the Chaos API key is missing or blank
- report HTTP, malformed-response, and empty-success outcomes explicitly
- accept documented string and object subdomain shapes while isolating malformed siblings
- reuse the shared request metadata transport

## Verification

- focused tests: 6 passed
- full pytest: 381 passed, 6 skipped
- Ruff check and format check passed
- mypy passed
- git diff check and zero em dash check passed
- parallel Standards and Spec reviews passed

No live provider requests were used. This is a focused subset of the broader authenticated-source work tracked in the fork.
