### PR TITLE
Add catalog-driven passive collection and sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Allowed REST `/query` requests to select discovery sources by result capability, matching the CLI's union semantics while preserving explicit source selection.
+- Changed `-b all` to select every cataloged P0 passive source once while leaving P1 DNS and P2 direct sources available through explicit selection.
 - Expanded Common Crawl discovery to use every unique crawl ending within one year of the newest catalog entry, validate catalog endpoints, batch requests, cap each query at 100 pages, and enforce the CLI result limit across page requests ([249ce64b](https://github.com/laramies/theHarvester/commit/249ce64b), [70470cd8](https://github.com/laramies/theHarvester/commit/70470cd8)).
 - Completed bounded pagination for Wayback Archive and Cert Spotter, including continuation handling, truncation diagnostics, and preservation of partial results on provider failures ([df6ff2c9](https://github.com/laramies/theHarvester/commit/df6ff2c9), [f85a08ff](https://github.com/laramies/theHarvester/commit/f85a08ff)).
 - Routed operator messages and diagnostics through logging, preserved host logging policy and existing handlers, and configured logging for the standalone API example ([8a7b8b71](https://github.com/laramies/theHarvester/commit/8a7b8b71)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added authenticated REST routes for listing completed enumeration runs and retrieving their normalized evidence.
+- Added an explicit authenticated HIBP verified-domain source that retains normalized account emails and stable breach names without retaining the raw account mapping.
 - Added keyless Shodan Certificate Transparency hostname discovery with bounded requests and offline response contracts.
 - Added transactional SQLite storage and loading for completed full-pipeline runs without changing legacy result rows.
 - Added deterministic JSONL report companions finalized after selected one-shot actions complete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added authenticated REST routes for listing completed enumeration runs and retrieving their normalized evidence.
 - Added an explicit authenticated HIBP verified-domain source that retains normalized account emails and stable breach names without retaining the raw account mapping.
 - Added keyless Shodan Certificate Transparency hostname discovery with bounded requests and offline response contracts.
+- Added bounded, keyless subdomain discovery through Arquivo.pt's public CDX API with offline response contracts.
 - Added transactional SQLite storage and loading for completed full-pipeline runs without changing legacy result rows.
 - Added deterministic JSONL report companions finalized after selected one-shot actions complete.
 - Added DNSDB passive DNS discovery with API key configuration, shared transport handling, result parsing, and offline tests ([9b41b78e](https://github.com/laramies/theHarvester/commit/9b41b78e), [aba9fec6](https://github.com/laramies/theHarvester/commit/aba9fec6)).

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Read the **API key** column as follows:
 
 | Source | Subdomains | Emails | IPs | ASNs | URLs / links | People | Breaches | Separate REST/action output (not consolidated report) | API key |
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- | :---: |
+| `arquivo` | ✓ | No | No | No | No | No | No | No | No |
 | `baidu` | ✓ | ✓ | No | No | No | No | No | No | No |
 | `bevigil` | ✓ | No | No | No | ✓ | No | No | No | ✓ |
 | `bufferoverun` | ✓ | No | ✓ | No | No | No | No | No | ✓ |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Combine capability selectors, or mix them with explicit source names:
 uv run theHarvester -d example.com -b emails,urls,certspotter
 ```
 
-Capability selectors form a union and choose which sources run. They do not discard other result types returned by those sources. Available selectors are `subdomains`, `emails`, `ips`, `asns`, `urls`, `people`, and `breaches`. `-b all` continues to run every registered source.
+Capability selectors form a union and choose which sources run. They do not discard other result types returned by those sources. Available selectors are `subdomains`, `emails`, `ips`, `asns`, `urls`, `people`, and `breaches`. `-b all` runs every cataloged P0 passive source. P1 DNS and P2 direct sources require explicit selection.
 
 Save JSON, XML, and JSONL reports:
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Read the **API key** column as follows:
 | `gitlab` | ✓ | ✓ | No | No | No | No | No | No | No |
 | `hackertarget` | ✓ | No | No | No | No | No | No | No | Optional |
 | `haveibeenpwned` | No | No | No | No | No | No | ✓ | `POST /additional/breaches` response | No |
+| `hibpverified` | No | ✓ | No | No | No | No | ✓ | No | ✓ |
 | `hudsonrock` | ✓ | ✓ | ✓ | No | No | No | No | No | No |
 | `hunter` | ✓ | ✓ | No | No | No | No | No | No | ✓ |
 | `hunterhow` | ✓ | No | No | No | No | No | No | No | ✓ |
@@ -190,6 +191,8 @@ Read the **API key** column as follows:
 </details>
 
 Provider pricing is intentionally omitted because plans and quotas change frequently. See [Configuration and API Keys](docs/wiki/Configuration-and-API-Keys.md) and each provider's current documentation.
+
+`haveibeenpwned` remains the keyless public breach catalogue. `hibpverified` is a separate, CLI-only source for HIBP's authenticated `breachedDomain` endpoint. It runs only when explicitly named, either alone or in a combination such as `breaches,hibpverified`; capability selectors and `all` exclude it. A live run requires a user-owned paid HIBP API key and a user-owned domain verified in that account; routine tests use offline responses.
 
 The runtime registry also reports the legacy identifiers `linkedin`, `linkedin_links`, `netcraft`, `omnisint`, `sublist3r`, and `zoomeyeapi`. These identifiers have no active CLI handlers. The table does not present them as usable sources.
 

--- a/docs/wiki/Configuration-and-API-Keys.md
+++ b/docs/wiki/Configuration-and-API-Keys.md
@@ -28,6 +28,9 @@ apikeys:
   github:
     key: your-github-token
 
+  hibpverified:
+    key: your-hibp-api-key
+
   tomba:
     key: your-tomba-key
     secret: your-tomba-secret
@@ -38,6 +41,8 @@ Do not commit populated configuration files. Prefer provider credentials scoped 
 The [README source matrix](https://github.com/laramies/theHarvester/blob/dev/README.md#discovery-sources) is the canonical source list. It shows whether each source requires a key, accepts an optional key, or has no key setting.
 
 Provider pricing, quotas, and terms change frequently. Check the provider's current documentation for these details.
+
+`hibpverified` queries [HIBP's authenticated verified-domain endpoint](https://haveibeenpwned.com/API/v3#BreachedDomain) only when explicitly named, either alone or in a combination such as `breaches,hibpverified`. Capability selectors and `all` exclude it. Live use requires a user-owned paid HIBP API key and a user-owned domain verified in that account. The unauthenticated REST `/query` route excludes it, and the keyless `haveibeenpwned` source continues to query only the public breach catalogue.
 
 ## Proxies
 

--- a/tests/discovery/test_arquivo.py
+++ b/tests/discovery/test_arquivo.py
@@ -1,0 +1,93 @@
+import logging
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from theHarvester.discovery import arquivo
+from theHarvester.lib.core import FetcherResponse
+
+
+@pytest.mark.asyncio
+async def test_process_collects_scoped_hosts_from_one_cdx_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    requested_urls: list[str] = []
+
+    async def fake_fetch_all(urls: list[str], **kwargs: Any) -> list[FetcherResponse]:
+        requested_urls.extend(urls)
+        assert kwargs['include_metadata'] is True
+        assert kwargs['headers']['User-agent']
+        return [
+            FetcherResponse(
+                body='\n'.join(
+                    (
+                        '{"url": "https://API.Example.COM/path"}',
+                        '{"url": "http://www.example.com/"}',
+                        '{"url": "https://api.example.com/repeated"}',
+                        '{"url": "https://example.com/"}',
+                        '{"url": "https://outside.test/"}',
+                        '{"url": 42}',
+                        'not-json',
+                    )
+                ),
+                status=200,
+                headers={},
+            )
+        ]
+
+    monkeypatch.setattr(arquivo.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = arquivo.SearchArquivo('Example.COM.', 750)
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com', 'www.example.com'}
+    assert len(requested_urls) == 1
+    assert parse_qs(urlparse(requested_urls[0]).query) == {
+        'url': ['example.com'],
+        'matchType': ['domain'],
+        'output': ['json'],
+        'fields': ['url'],
+        'limit': ['750'],
+    }
+
+
+@pytest.mark.asyncio
+async def test_process_bounds_the_provider_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    requested_urls: list[str] = []
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: Any) -> list[FetcherResponse]:
+        requested_urls.extend(urls)
+        return [FetcherResponse(body='', status=200, headers={})]
+
+    monkeypatch.setattr(arquivo.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = arquivo.SearchArquivo('example.com', 100_001)
+    await search.process()
+
+    assert parse_qs(urlparse(requested_urls[0]).query)['limit'] == ['10000']
+
+
+@pytest.mark.asyncio
+async def test_process_reports_http_and_malformed_responses(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    responses = [
+        FetcherResponse(body='rate limited', status=429, headers={}),
+        FetcherResponse(body={'unexpected': 'shape'}, status=200, headers={}),
+    ]
+
+    async def fake_fetch_all(_urls: list[str], **_kwargs: Any) -> list[FetcherResponse]:
+        return [responses.pop(0)]
+
+    monkeypatch.setattr(arquivo.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    with caplog.at_level(logging.INFO, logger=arquivo.__name__):
+        first = arquivo.SearchArquivo('example.com', 500)
+        await first.process()
+        second = arquivo.SearchArquivo('example.com', 500)
+        await second.process()
+
+    assert await first.get_hostnames() == set()
+    assert await second.get_hostnames() == set()
+    assert 'Arquivo.pt request failed with HTTP 429' in caplog.text
+    assert 'Arquivo.pt returned malformed CDX data' in caplog.text

--- a/tests/discovery/test_builtwith.py
+++ b/tests/discovery/test_builtwith.py
@@ -80,6 +80,7 @@ async def test_process_accepts_text_json_content_type(monkeypatch) -> None:
 
     assert await search.get_hostnames() == {'sub.example.com'}
     assert await search.get_interesting_urls() == {'https://example.com/login'}
+    assert await search.get_interestingurls() == {'https://example.com/login'}
     assert await search.get_frameworks() == {'Django'}
     assert await search.get_languages() == {'Python'}
     assert await search.get_servers() == {'nginx'}

--- a/tests/discovery/test_hibpverified.py
+++ b/tests/discovery/test_hibpverified.py
@@ -1,0 +1,192 @@
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from theHarvester import __main__ as theharvester_main
+from theHarvester.discovery import hibpverified
+from theHarvester.discovery.constants import MissingKey
+from theHarvester.lib.completed_result import CompletedResult
+from theHarvester.lib.core import FetcherResponse
+
+
+@pytest.mark.parametrize('api_key', [None, '', '   '])
+def test_verified_domain_source_requires_its_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+    api_key: str | None,
+) -> None:
+    monkeypatch.setattr(hibpverified.Core, 'hibpverified_key', lambda: api_key)
+
+    with pytest.raises(MissingKey, match='HIBP verified domain'):
+        hibpverified.SearchHibpVerified('example.com')
+
+
+def test_verified_domain_source_handles_existing_config_without_new_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(hibpverified.Core, 'api_keys', lambda: {})
+
+    with pytest.raises(MissingKey, match='HIBP verified domain'):
+        hibpverified.SearchHibpVerified('example.com')
+
+
+@pytest.mark.asyncio
+async def test_verified_domain_source_returns_emails_and_stable_breach_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch_all(urls: list[str], **kwargs: Any) -> list[FetcherResponse]:
+        assert urls == ['https://haveibeenpwned.com/api/v3/breachedDomain/example.com']
+        assert kwargs['headers']['hibp-api-key'] == 'secret'
+        assert kwargs['json'] is True
+        assert kwargs['include_metadata'] is True
+        return [
+            FetcherResponse(
+                body={
+                    'alice': ['ExampleBreachA', 'ExampleBreachB'],
+                    'bob': ['ExampleBreach'],
+                },
+                status=200,
+                headers={},
+            )
+        ]
+
+    monkeypatch.setattr(hibpverified.Core, 'hibpverified_key', lambda: 'secret')
+    monkeypatch.setattr(hibpverified.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = hibpverified.SearchHibpVerified('example.com')
+
+    await search.process()
+
+    assert await search.get_emails() == {'alice@example.com', 'bob@example.com'}
+    assert await search.get_breach_names() == {'ExampleBreach', 'ExampleBreachA', 'ExampleBreachB'}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('payload', [None, [], {'alice': 'ExampleBreach'}, {'': ['ExampleBreach']}, {'alice': [None]}])
+async def test_verified_domain_source_rejects_malformed_responses(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: Any,
+) -> None:
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        return [FetcherResponse(body=payload, status=200, headers={})]
+
+    monkeypatch.setattr(hibpverified.Core, 'hibpverified_key', lambda: 'secret')
+    monkeypatch.setattr(hibpverified.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = hibpverified.SearchHibpVerified('example.com')
+
+    await search.process()
+
+    assert await search.get_emails() == set()
+    assert await search.get_breach_names() == set()
+
+
+@pytest.mark.asyncio
+async def test_verified_domain_source_attributes_unverified_domain(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        return [FetcherResponse(body={'statusCode': 403}, status=403, headers={})]
+
+    monkeypatch.setattr(hibpverified.Core, 'hibpverified_key', lambda: 'secret')
+    monkeypatch.setattr(hibpverified.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = hibpverified.SearchHibpVerified('example.com')
+
+    with caplog.at_level('INFO', logger=hibpverified.__name__):
+        await search.process()
+
+    assert 'HIBP verified-domain target is not verified for this API key (HTTP 403)' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_verified_domain_source_treats_not_found_as_valid_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        return [FetcherResponse(body={'statusCode': 404}, status=404, headers={})]
+
+    monkeypatch.setattr(hibpverified.Core, 'hibpverified_key', lambda: 'secret')
+    monkeypatch.setattr(hibpverified.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = hibpverified.SearchHibpVerified('example.com')
+
+    with caplog.at_level('INFO', logger=hibpverified.__name__):
+        await search.process()
+
+    assert await search.get_emails() == set()
+    assert await search.get_breach_names() == set()
+    assert 'failed' not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_verified_domain_source_attributes_rate_limit_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    calls = 0
+
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        nonlocal calls
+        calls += 1
+        return [FetcherResponse(body={'statusCode': 429}, status=429, headers={})]
+
+    monkeypatch.setattr(hibpverified.Core, 'hibpverified_key', lambda: 'secret')
+    monkeypatch.setattr(hibpverified.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = hibpverified.SearchHibpVerified('example.com')
+
+    with caplog.at_level('INFO', logger=hibpverified.__name__):
+        await search.process()
+
+    assert calls == 1
+    assert 'HIBP verified-domain request was rate limited (HTTP 429)' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_verified_domain_results_reach_completed_jsonl_and_sqlite_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    completed_results: list[CompletedResult] = []
+
+    class FakeStash:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args: object) -> None:
+            return None
+
+        async def store_completed_result(self, result: CompletedResult) -> None:
+            completed_results.append(result)
+
+    class FakeHibpVerified:
+        def __init__(self, domain: str) -> None:
+            assert domain == 'example.com'
+
+        async def process(self, _proxy: bool) -> None:
+            return None
+
+        async def get_emails(self) -> set[str]:
+            return {'alice@example.com'}
+
+        async def get_breach_names(self) -> set[str]:
+            return {'ExampleBreach'}
+
+    report = tmp_path / 'hibp-verified-report'
+    monkeypatch.setattr(theharvester_main.stash, 'StashManager', FakeStash)
+    monkeypatch.setattr(theharvester_main.hibpverified, 'SearchHibpVerified', FakeHibpVerified)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['theHarvester', '-d', 'example.com', '-b', 'hibpverified', '-f', str(report)],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    assert completed_results[0].results == (
+        ('breach', 'ExampleBreach'),
+        ('email', 'alice@example.com'),
+    )
+    records = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
+    assert {'type': 'breach', 'value': 'ExampleBreach'} in records
+    assert {'type': 'email', 'value': 'alice@example.com'} in records

--- a/tests/discovery/test_rapiddns.py
+++ b/tests/discovery/test_rapiddns.py
@@ -179,7 +179,6 @@ async def test_rapiddns_evidence_reaches_existing_outputs(
         created = 0
 
         def __init__(self, _domain: str) -> None:
-            self.is_late_action = self.created > 0
             type(self).created += 1
 
         async def process(self, _proxy: bool) -> None:
@@ -189,16 +188,14 @@ async def test_rapiddns_evidence_reaches_existing_outputs(
             return set()
 
         async def get_ips(self) -> set[str]:
-            if self.is_late_action:
-                return {'2001:0DB8::1', '198.51.100.9', 'not-an-ip'}
-            return set()
+            return {'2001:0DB8::1', '198.51.100.9', 'not-an-ip'}
 
     async def fake_reverse_all_ips_in_range(
         iprange: str,
         callback: Any,
         nameservers: list[str] | None = None,
     ) -> None:
-        assert iprange in {'192.0.2.0/24', '198.51.100.0/24'}
+        assert iprange in {'192.0.2.0/24', '198.51.100.0/24', '2001:d00::/24'}
         assert nameservers is None
         callback('reverse.example.com')
 
@@ -237,7 +234,7 @@ async def test_rapiddns_evidence_reaches_existing_outputs(
 
     report_json = json.loads(report.with_suffix('.json').read_text())
     assert report_json['hosts'] == ['alias.example.com', 'api.example.com', 'broken.example.com']
-    assert report_json['ips'] == ['192.0.2.1']
+    assert report_json['ips'] == ['192.0.2.1', '198.51.100.9', '2001:db8::1']
     assert 'interesting_urls' not in report_json
 
     jsonl_records = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
@@ -314,7 +311,7 @@ async def test_rapiddns_evidence_reaches_existing_outputs(
         ('ip', ('192.0.2.1',), 'rapiddns'),
     ]
     assert len(completed_results) == 2
-    assert FakeSecurityScorecard.created == 2
+    assert FakeSecurityScorecard.created == 1
     assert completed_results[1].target == 'example.com'
     assert {'192.0.2.1', '198.51.100.2'} <= {value for kind, value in completed_results[1].results if kind == 'ip-address'}
 

--- a/tests/lib/test_core.py
+++ b/tests/lib/test_core.py
@@ -11,6 +11,7 @@ import yaml
 import theHarvester.lib.core as core_module
 from theHarvester.lib.core import CONFIG_DIRS, DATA_DIR, AsyncFetcher, Core, FetcherResponse
 from theHarvester.lib.output import configure_logging
+from theHarvester.lib.source_catalog import SOURCE_SPECS, ActivityClass
 
 
 @pytest.fixture(autouse=True)
@@ -73,10 +74,22 @@ def test_explicit_only_source_can_be_combined_with_a_capability() -> None:
     assert Core.expand_source_selection('breaches,hibpverified') == ['haveibeenpwned', 'hibpverified']
 
 
-def test_all_preserves_every_supported_source() -> None:
-    assert Core.expand_source_selection("ALL") == [
-        source for source in Core.get_supportedengines() if source != 'hibpverified'
-    ]
+def test_all_selects_only_passive_catalog_sources() -> None:
+    assert Core.expand_source_selection("ALL") == sorted(
+        spec.name
+        for spec in SOURCE_SPECS.values()
+        if spec.activity is ActivityClass.PASSIVE and not spec.requires_explicit_selection
+    )
+    assert {
+        name: spec.activity for name, spec in SOURCE_SPECS.items() if spec.activity is not ActivityClass.PASSIVE
+    } == {
+        "criminalip": ActivityClass.DIRECT,
+        "pentesttools": ActivityClass.DNS,
+        "shodan": ActivityClass.DNS,
+        "shodanInternetDB": ActivityClass.DNS,
+        "subdomainfinderc99": ActivityClass.DNS,
+        "windvane": ActivityClass.DNS,
+    }
 
 
 def mock_read_text(mocked: dict[Path, str | Exception]):

--- a/tests/lib/test_core.py
+++ b/tests/lib/test_core.py
@@ -65,12 +65,18 @@ def test_multiple_capabilities_form_a_union() -> None:
     ]
 
 
-def test_breach_capability_selects_haveibeenpwned() -> None:
+def test_capability_selectors_exclude_explicit_only_sources() -> None:
     assert Core.expand_source_selection('breaches') == ['haveibeenpwned']
 
 
+def test_explicit_only_source_can_be_combined_with_a_capability() -> None:
+    assert Core.expand_source_selection('breaches,hibpverified') == ['haveibeenpwned', 'hibpverified']
+
+
 def test_all_preserves_every_supported_source() -> None:
-    assert Core.expand_source_selection("ALL") == Core.get_supportedengines()
+    assert Core.expand_source_selection("ALL") == [
+        source for source in Core.get_supportedengines() if source != 'hibpverified'
+    ]
 
 
 def mock_read_text(mocked: dict[Path, str | Exception]):

--- a/tests/lib/test_source_catalog.py
+++ b/tests/lib/test_source_catalog.py
@@ -57,6 +57,8 @@ def test_subdomain_route_drives_subdomain_capability() -> None:
 def test_source_specs_describe_consolidated_routes_not_getter_presence() -> None:
     assert SOURCE_SPECS['gitlab'].routes == frozenset({ResultRoute.SUBDOMAINS, ResultRoute.EMAILS})
     assert SOURCE_SPECS['haveibeenpwned'].routes == frozenset({ResultRoute.BREACHES})
+    assert SOURCE_SPECS['hibpverified'].routes == frozenset({ResultRoute.EMAILS, ResultRoute.BREACHES})
+    assert SOURCE_SPECS['hibpverified'].requires_explicit_selection
     assert SOURCE_SPECS['urlscan'].routes == frozenset(
         {
             ResultRoute.SUBDOMAINS,

--- a/tests/test_all_source_orchestration.py
+++ b/tests/test_all_source_orchestration.py
@@ -1,0 +1,243 @@
+import json
+import sys
+import xml.etree.ElementTree as ElementTree
+from collections import Counter
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from theHarvester import __main__ as theharvester_main
+from theHarvester.lib.source_catalog import SOURCE_SPECS, ActivityClass
+
+
+@pytest.mark.asyncio
+async def test_source_help_uses_the_runtime_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(theharvester_main, 'SOURCE_SPECS', {'catalog-only-source': object()})
+    monkeypatch.setattr(sys, 'argv', ['theHarvester', '--help'])
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    help_output = capsys.readouterr().out
+    assert 'catalog-only-source' in help_output
+    assert 'linkedin_links' not in help_output
+
+
+@pytest.mark.asyncio
+async def test_activity_summary_includes_source_and_option_classes(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class FakeStash:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args: object) -> None:
+            return None
+
+        async def store_completed_result(self, _result: object) -> None:
+            return None
+
+    class FakeCriminalIP:
+        def __init__(self, _domain: str) -> None:
+            pass
+
+        async def process(self, _proxy: bool) -> None:
+            return None
+
+        async def get_hostnames(self) -> set[str]:
+            return set()
+
+        async def get_ips(self) -> set[str]:
+            return set()
+
+        async def get_asns(self) -> set[str]:
+            return set()
+
+    monkeypatch.setattr(theharvester_main.criminalip, 'SearchCriminalIP', FakeCriminalIP)
+    monkeypatch.setattr(theharvester_main.stash, 'StashManager', FakeStash)
+    monkeypatch.setattr(sys, 'argv', ['theHarvester', '-d', 'example.test', '-b', 'criminalip', '-n', '-s'])
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    assert '[*] Activity: P0 passive collection, P1 DNS interaction, P2 direct interaction' in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_activity_summary_covers_api_scan_without_sources(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class FakeStash:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args: object) -> None:
+            return None
+
+        async def store_completed_result(self, _result: object) -> None:
+            return None
+
+    def stop_api_scan(**_kwargs: object) -> None:
+        raise RuntimeError('offline test stop')
+
+    monkeypatch.setattr(theharvester_main.api_endpoints, 'SearchApiEndpoints', stop_api_scan)
+    monkeypatch.setattr(theharvester_main.stash, 'StashManager', FakeStash)
+    monkeypatch.setattr(sys, 'argv', ['theHarvester', '-d', 'example.test', '-a'])
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    assert '[*] Activity: P2 direct interaction' in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_legacy_handlerless_source_does_not_break_activity_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeStash:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_completed_result(self, _result: object) -> None:
+            return None
+
+    monkeypatch.setattr(theharvester_main.stash, 'StashManager', FakeStash)
+    monkeypatch.setattr(sys, 'argv', ['theHarvester', '-d', 'example.test', '-b', 'linkedin'])
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+
+
+@pytest.mark.asyncio
+async def test_all_schedules_each_passive_catalog_source_once_and_reports_results(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    executions: Counter[str] = Counter()
+    passive_sources = sorted(
+        source
+        for source, spec in SOURCE_SPECS.items()
+        if spec.activity is ActivityClass.PASSIVE and not spec.requires_explicit_selection
+    )
+
+    class TestStash(theharvester_main.stash.StashManager):
+        def __init__(self) -> None:
+            super().__init__()
+            self.db = str(tmp_path / 'stash.sqlite')
+
+        async def store_all(self, *_args: Any, **_kwargs: Any) -> None:
+            return None
+
+        async def store(self, *_args: Any, **_kwargs: Any) -> None:
+            return None
+
+    class FakeAdapter:
+        def __init__(self, adapter: str) -> None:
+            self.adapter = adapter
+
+        async def process(self, *_args: object, **_kwargs: object) -> None:
+            executions[self.adapter] += 1
+
+        async def get_hostnames(self) -> set[str]:
+            return {'sub.example.test'}
+
+        async def get_emails(self) -> set[str]:
+            return {'user@example.test'}
+
+        async def get_ips(self) -> set[str]:
+            return {'192.0.2.1'}
+
+        async def get_asns(self) -> set[str]:
+            return {'AS64500'}
+
+        async def get_people(self) -> list[dict[str, str]]:
+            return [{'name': 'Example Person'}]
+
+        async def get_links(self) -> set[str]:
+            return {'https://sub.example.test/profile'}
+
+        async def get_interestingurls(self) -> set[str]:
+            return {'https://sub.example.test/evidence'}
+
+        async def get_interesting_urls(self) -> set[str]:
+            return await self.get_interestingurls()
+
+        async def get_host_ip_pairs(self) -> set[tuple[str, str]]:
+            return set()
+
+        async def get_breach_names(self) -> set[str]:
+            return {'ExampleBreach'}
+
+        async def get_infostealers(self) -> list[dict[str, object]]:
+            return []
+
+    def fake_constructor(adapter: str):
+        def constructor(*_args: object, **_kwargs: object) -> FakeAdapter:
+            return FakeAdapter(adapter)
+
+        return constructor
+
+    discovery_modules = sorted(
+        {
+            value
+            for value in vars(theharvester_main).values()
+            if isinstance(value, ModuleType) and value.__name__.startswith('theHarvester.discovery.')
+        },
+        key=lambda module: module.__name__,
+    )
+    patched_classes = 0
+    for module in discovery_modules:
+        for name, value in list(vars(module).items()):
+            if isinstance(value, type) and value.__module__ == module.__name__:
+                monkeypatch.setattr(module, name, fake_constructor(f'{module.__name__}.{name}'))
+                patched_classes += 1
+    assert patched_classes
+
+    report = tmp_path / 'all-sources'
+    monkeypatch.setattr(theharvester_main.stash, 'StashManager', TestStash)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['theHarvester', '-d', 'example.test', '-b', 'all', '-f', str(report)],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    assert len(executions) == len(passive_sources)
+    assert sum(executions.values()) == len(passive_sources)
+    assert set(executions.values()) == {1}
+
+    json_report = json.loads(report.with_suffix('.json').read_text())
+    assert 'sub.example.test' in json_report['hosts']
+    assert 'user@example.test' in json_report['emails']
+
+    jsonl_records = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
+    assert {'type': 'hostname', 'value': 'sub.example.test'} in jsonl_records
+    assert {'type': 'email', 'value': 'user@example.test'} in jsonl_records
+
+    completed = await TestStash().load_completed_result(UUID(jsonl_records[0]['run_id']))
+    assert completed.target == 'example.test'
+    assert ('hostname', 'sub.example.test') in completed.results
+    assert ('email', 'user@example.test') in completed.results
+    assert ('ip-address', '192.0.2.1') in completed.results
+
+    xml_hosts = {
+        (element.findtext('hostname') or (element.text or '').strip())
+        for element in ElementTree.parse(report.with_suffix('.xml')).getroot().findall('host')
+    }
+    assert 'sub.example.test' in xml_hosts

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -80,8 +80,8 @@ def test_readme_matches_declared_source_contracts() -> None:
     declared = _declared_source_contracts()
 
     assert '| Source | Subdomains | Emails | IPs | ASNs | URLs / links | People | Breaches |' in readme
-    assert len(declared) == 56
-    assert len(documented) == 56
+    assert len(declared) == 57
+    assert len(documented) == 57
     assert documented == declared
     assert {'securitytrails', 'shodaninternetdb'}.isdisjoint(documented)
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -80,8 +80,8 @@ def test_readme_matches_declared_source_contracts() -> None:
     declared = _declared_source_contracts()
 
     assert '| Source | Subdomains | Emails | IPs | ASNs | URLs / links | People | Breaches |' in readme
-    assert len(declared) == 55
-    assert len(documented) == 55
+    assert len(declared) == 56
+    assert len(documented) == 56
     assert documented == declared
     assert {'securitytrails', 'shodaninternetdb'}.isdisjoint(documented)
 

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -1,9 +1,17 @@
 from argparse import Namespace
 
+import pytest
 from fastapi.testclient import TestClient
 
 from theHarvester.lib.api import api
 from theHarvester.lib.core import Core
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limiter() -> None:
+    api.limiter.reset()
+    yield
+    api.limiter.reset()
 
 
 def test_query_expands_source_capability(monkeypatch) -> None:
@@ -34,7 +42,8 @@ def test_query_unions_capabilities_and_explicit_sources(monkeypatch) -> None:
     response = TestClient(api.app).get('/query?domain=example.test&source=emails&source=certspotter')
 
     assert response.status_code == 200
-    assert captured[0][0].source == ','.join(Core.expand_source_selection('emails,certspotter'))
+    expected_sources = [source for source in Core.expand_source_selection('emails,certspotter') if source != 'hibpverified']
+    assert captured[0][0].source == ','.join(expected_sources)
     assert captured[0][1] is True
 
 
@@ -48,3 +57,39 @@ def test_query_rejects_unknown_source_or_capability(monkeypatch) -> None:
 
     assert response.status_code == 400
     assert response.json()['detail'].startswith("Source 'unknown' is not supported")
+
+
+def test_query_rejects_explicit_verified_hibp_source(monkeypatch) -> None:
+    async def unexpected_start(_args: Namespace, *, persist_completed_result: bool = False):
+        raise AssertionError('enumeration must not start')
+
+    monkeypatch.setattr(api.__main__, 'start', unexpected_start)
+
+    response = TestClient(api.app).get('/query?domain=example.test&source=hibpverified')
+
+    assert response.status_code == 400
+    assert response.json()['detail'] == "Source 'hibpverified' is available only through the CLI"
+
+
+def test_query_omits_verified_hibp_from_capability_selection(monkeypatch) -> None:
+    captured: list[Namespace] = []
+
+    async def fake_start(args: Namespace, *, persist_completed_result: bool = False):
+        captured.append(args)
+        return ([], [], [], [], [], [], [], [], [])
+
+    monkeypatch.setattr(api.__main__, 'start', fake_start)
+
+    response = TestClient(api.app).get('/query?domain=example.test&source=breaches')
+
+    assert response.status_code == 200
+    assert captured[0].source == 'haveibeenpwned'
+
+
+def test_sources_omits_cli_only_verified_hibp(monkeypatch) -> None:
+    monkeypatch.setattr(api.__main__.Core, 'get_supportedengines', lambda: ['crtsh', 'hibpverified'])
+
+    response = TestClient(api.app).get('/sources')
+
+    assert response.status_code == 200
+    assert response.json() == {'sources': ['crtsh']}

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -86,7 +86,7 @@ from theHarvester.lib.completed_result import CompletedResult, ResultKind
 from theHarvester.lib.core import DATA_DIR, Core, show_default_error_message
 from theHarvester.lib.hostnames import normalize_scoped_hostname
 from theHarvester.lib.output import configure_logging, output_logger, print_linkedin_sections, print_section, sorted_unique
-from theHarvester.lib.source_catalog import ResultRoute, get_source_spec
+from theHarvester.lib.source_catalog import SOURCE_SPECS, ActivityClass, ResultRoute, get_source_spec
 from theHarvester.screenshot.screenshot import ScreenShotter
 
 if TYPE_CHECKING:
@@ -231,12 +231,10 @@ async def start(rest_args: argparse.Namespace | None = None, *, persist_complete
     parser.add_argument(
         '-b',
         '--source',
-        help="""Comma-separated sources or capability selectors: subdomains, emails, ips, asns, urls, people, breaches, or all.
-                            Sources: baidu, bevigil, brave, bufferoverun,
-                            builtwith, censys, certspotter, chaos, commoncrawl, criminalip, crtsh, dehashed, dnsdumpster, duckduckgo, dymo, fofa, fullhunt, github-code,
-                            gitlab, hackertarget, haveibeenpwned, hibpverified, hudsonrock, hunter, hunterhow, intelx, leakix, leaklookup, mojeek, netlas, onyphe, otx, pentesttools,
-                            projectdiscovery, rapiddns, robtex, rocketreach, securityscorecard, securityTrails, sherlockeye, shodan, shodanct, shodanInternetDB, subdomaincenter,
-                            subdomainfinderc99, thc, tomba, urlscan, venacus, virustotal, waybackarchive, whoisxml, windvane, yahoo, zoomeye""",
+        help=(
+            'Comma-separated sources or capability selectors: subdomains, emails, ips, asns, urls, people, '
+            f'breaches, or all. Sources: {", ".join(sorted(SOURCE_SPECS, key=str.casefold))}'
+        ),
     )
 
     # determines if the filename is coming from rest api or user
@@ -454,6 +452,22 @@ async def start(rest_args: argparse.Namespace | None = None, *, persist_complete
     stor_lst = []
     if args.source is not None:
         engines = Core.expand_source_selection(args.source)
+    activities = {get_source_spec(engine).activity for engine in engines if engine in SOURCE_SPECS}
+    if shodan:
+        activities.add(ActivityClass.PASSIVE)
+    if dnslookup or dnsbrute[0] or dnsresolve != '':
+        activities.add(ActivityClass.DNS)
+    if takeover_status or getattr(args, 'screenshot', '') or getattr(args, 'api_scan', False):
+        activities.add(ActivityClass.DIRECT)
+    if activities:
+        activity_labels = {
+            ActivityClass.PASSIVE: 'P0 passive collection',
+            ActivityClass.DNS: 'P1 DNS interaction',
+            ActivityClass.DIRECT: 'P2 direct interaction',
+        }
+        output_logger.info(f'[*] Activity: {", ".join(activity_labels[item] for item in ActivityClass if item in activities)}')
+
+    if args.source is not None:
         # Iterate through search engines in order
         if set(engines).issubset(Core.get_supportedengines()):
             output_logger.info(f'\n[*] Target: {word} \n')
@@ -1852,60 +1866,6 @@ async def start(rest_args: argparse.Namespace | None = None, *, persist_complete
             output_logger.info(f'\n[!] An exception has occurred in API Endpoints scanning: {e}')
             output_logger.info('    Continuing with the rest of the scan...')
             traceback.print_exc()  # More detailed error information for developers
-
-    if 'securityscorecard' in engines:
-        try:
-            output_logger.info('\n[*] Performing SecurityScorecard scan...')
-            securityscorecard_scanner = securityscorecard.SearchSecurityScorecard(word)
-            await securityscorecard_scanner.process(use_proxy)
-
-            # Use the existing API to get results
-            hosts = await securityscorecard_scanner.get_hostnames()
-            if hosts:
-                output_logger.info(f'\n[*] SecurityScorecard results: {len(hosts)} hosts found')
-                for host in hosts:
-                    output_logger.info(f'    - {host}')
-
-                all_hosts.extend(hosts)
-
-            ips = await securityscorecard_scanner.get_ips()
-            if ips:
-                output_logger.info(f'\n[*] SecurityScorecard IPs found: {len(ips)}')
-                for ip in ips:
-                    output_logger.info(f'    - {ip}')
-                all_ip.extend(ips)
-
-        except Exception as e:
-            output_logger.info(f'An exception has occurred in SecurityScorecard scanning: {e}')
-
-    if 'builtwith' in engines:
-        try:
-            output_logger.info('\n[*] Performing BuiltWith scan...')
-            builtwith_scanner = builtwith.SearchBuiltWith(word)
-            await builtwith_scanner.process(use_proxy)
-
-            hosts = await builtwith_scanner.get_hostnames()
-            if hosts:
-                output_logger.info(f'\n[*] BuiltWith results: {len(hosts)} hosts found')
-                for host in hosts:
-                    output_logger.info(f'    - {host}')
-
-                # Add results to the main host list
-                all_hosts.extend(hosts)
-
-            urls = list(await builtwith_scanner.get_interesting_urls())
-            if urls:
-                output_logger.info(f'\n[*] BuiltWith interesting URLs found: {len(urls)}')
-                for url in urls:
-                    output_logger.info(f'    - {url}')
-                interesting_urls.extend(urls)
-
-        except Exception as e:
-            if isinstance(e, MissingKey):
-                if not args.quiet:
-                    output_logger.info(MissingKey('BuiltWith'))
-                else:
-                    output_logger.info(f'An exception has occurred in BuiltWith scanning: {e}')
 
     completed_result = finish_completed_result(extra_hostnames=dnsrev, virtual_hosts=vhost)
 

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -21,6 +21,7 @@ from aiomultiprocess import Pool
 
 from theHarvester.discovery import (
     api_endpoints,
+    arquivo,
     baidusearch,
     bevigil,
     bravesearch,
@@ -473,7 +474,14 @@ async def start(rest_args: argparse.Namespace | None = None, *, persist_complete
             output_logger.info(f'\n[*] Target: {word} \n')
 
             for engineitem in engines:
-                if engineitem == 'baidu':
+                if engineitem == 'arquivo':
+                    try:
+                        arquivo_search = arquivo.SearchArquivo(word, limit)
+                        stor_lst.append(store(arquivo_search, engineitem))
+                    except Exception as e:
+                        show_default_error_message(engineitem, word, e)
+
+                elif engineitem == 'baidu':
                     try:
                         baidu_search = baidusearch.SearchBaidu(word, limit)
                         stor_lst.append(

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -42,6 +42,7 @@ from theHarvester.discovery import (
     gitlabsearch,
     hackertarget,
     haveibeenpwned,
+    hibpverified,
     hudsonrocksearch,
     huntersearch,
     intelxsearch,
@@ -233,7 +234,7 @@ async def start(rest_args: argparse.Namespace | None = None, *, persist_complete
         help="""Comma-separated sources or capability selectors: subdomains, emails, ips, asns, urls, people, breaches, or all.
                             Sources: baidu, bevigil, brave, bufferoverun,
                             builtwith, censys, certspotter, chaos, commoncrawl, criminalip, crtsh, dehashed, dnsdumpster, duckduckgo, dymo, fofa, fullhunt, github-code,
-                            gitlab, hackertarget, haveibeenpwned, hudsonrock, hunter, hunterhow, intelx, leakix, leaklookup, mojeek, netlas, onyphe, otx, pentesttools,
+                            gitlab, hackertarget, haveibeenpwned, hibpverified, hudsonrock, hunter, hunterhow, intelx, leakix, leaklookup, mojeek, netlas, onyphe, otx, pentesttools,
                             projectdiscovery, rapiddns, robtex, rocketreach, securityscorecard, securityTrails, sherlockeye, shodan, shodanct, shodanInternetDB, subdomaincenter,
                             subdomainfinderc99, thc, tomba, urlscan, venacus, virustotal, waybackarchive, whoisxml, windvane, yahoo, zoomeye""",
     )
@@ -742,6 +743,16 @@ async def start(rest_args: argparse.Namespace | None = None, *, persist_complete
                         )
                     except Exception as e:
                         show_default_error_message(engineitem, word, e)
+
+                elif engineitem == 'hibpverified':
+                    try:
+                        hibp_search = hibpverified.SearchHibpVerified(word)
+                        stor_lst.append(store(hibp_search, engineitem))
+                    except MissingKey as error:
+                        if not args.quiet:
+                            output_logger.info(f'A Missing Key error occurred in hibpverified: {error}')
+                    except Exception as error:
+                        show_default_error_message(engineitem, word, error)
 
                 elif engineitem == 'hudsonrock':
                     try:

--- a/theHarvester/data/api-keys.yaml
+++ b/theHarvester/data/api-keys.yaml
@@ -44,6 +44,9 @@ apikeys:
   hackertarget:
     key:
 
+  hibpverified:
+    key:
+
   hunter:
     key:
 

--- a/theHarvester/discovery/arquivo.py
+++ b/theHarvester/discovery/arquivo.py
@@ -1,0 +1,68 @@
+import json
+import logging
+from urllib.parse import urlencode, urlsplit
+
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
+from theHarvester.lib.hostnames import normalize_scoped_hostname
+
+logger = logging.getLogger(__name__)
+
+
+class SearchArquivo:
+    MAX_RESULTS = 10_000
+
+    def __init__(self, word: str, limit: int) -> None:
+        self.word = word.strip().lower().rstrip('.')
+        self.limit = min(max(limit, 1), self.MAX_RESULTS)
+        self.totalhosts: set[str] = set()
+        self.proxy = False
+
+    async def process(self, proxy: bool = False) -> None:
+        self.proxy = proxy
+        query = urlencode(
+            {
+                'url': self.word,
+                'matchType': 'domain',
+                'output': 'json',
+                'fields': 'url',
+                'limit': self.limit,
+            }
+        )
+        try:
+            responses: list[FetcherResponse | None] = await AsyncFetcher.fetch_all(
+                [f'https://arquivo.pt/wayback/cdx?{query}'],
+                headers={'User-agent': Core.get_user_agent()},
+                proxy=self.proxy,
+                include_metadata=True,
+            )
+        except Exception as error:
+            logger.info(f'Arquivo.pt request failed: {error}')
+            return
+
+        response = responses[0] if responses else None
+        if response is None:
+            logger.info('Arquivo.pt request failed')
+            return
+        if not 200 <= response.status < 300:
+            logger.info(f'Arquivo.pt request failed with HTTP {response.status}')
+            return
+        if not isinstance(response.body, str):
+            logger.info('Arquivo.pt returned malformed CDX data')
+            return
+
+        for line in response.body.splitlines():
+            try:
+                item = json.loads(line)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if not isinstance(item, dict) or not isinstance(url := item.get('url'), str):
+                continue
+            try:
+                hostname = urlsplit(url).hostname
+            except ValueError:
+                continue
+            if (normalized := normalize_scoped_hostname(hostname, self.word)) and normalized != self.word:
+                self.totalhosts.add(normalized)
+
+    async def get_hostnames(self) -> set[str]:
+        return self.totalhosts

--- a/theHarvester/discovery/builtwith.py
+++ b/theHarvester/discovery/builtwith.py
@@ -77,6 +77,9 @@ class SearchBuiltWith:
     async def get_interesting_urls(self) -> set[str]:
         return self.interesting_urls
 
+    async def get_interestingurls(self) -> set[str]:
+        return await self.get_interesting_urls()
+
     async def get_frameworks(self) -> set[str]:
         return self.frameworks
 

--- a/theHarvester/discovery/hibpverified.py
+++ b/theHarvester/discovery/hibpverified.py
@@ -1,0 +1,70 @@
+import logging
+
+from theHarvester.discovery.constants import MissingKey
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
+
+logger = logging.getLogger(__name__)
+
+
+class SearchHibpVerified:
+    def __init__(self, word: str) -> None:
+        self.word = word.strip().lower().rstrip('.')
+        self.api_key = (Core.hibpverified_key() or '').strip()
+        if not self.api_key:
+            raise MissingKey('HIBP verified domain')
+        self.base_url = 'https://haveibeenpwned.com/api/v3'
+        self.headers = {'hibp-api-key': self.api_key, 'user-agent': 'theHarvester'}
+        self.emails: set[str] = set()
+        self.breach_names: set[str] = set()
+
+    async def process(self, proxy: bool = False) -> None:
+        try:
+            responses = await AsyncFetcher.fetch_all(
+                [f'{self.base_url}/breachedDomain/{self.word}'],
+                headers=self.headers,
+                json=True,
+                proxy=proxy,
+                include_metadata=True,
+            )
+        except (OSError, RuntimeError, ValueError):
+            logger.info('HIBP verified-domain request failed')
+            return
+
+        response = responses[0] if responses and isinstance(responses[0], FetcherResponse) else None
+        if response is None:
+            logger.info('HIBP verified-domain request failed')
+            return
+        if response.status == 403:
+            logger.info('HIBP verified-domain target is not verified for this API key (HTTP 403)')
+            return
+        if response.status == 404:
+            return
+        if response.status == 429:
+            logger.info('HIBP verified-domain request was rate limited (HTTP 429)')
+            return
+        if response.status != 200:
+            logger.info(f'HIBP verified-domain request failed with HTTP {response.status}')
+            return
+        if not isinstance(response.body, dict):
+            logger.info('HIBP verified-domain returned malformed account data')
+            return
+        if not all(
+            isinstance(alias, str)
+            and alias.strip()
+            and '@' not in alias
+            and not any(character.isspace() for character in alias)
+            and isinstance(breaches, list)
+            and all(isinstance(breach, str) and breach.strip() for breach in breaches)
+            for alias, breaches in response.body.items()
+        ):
+            logger.info('HIBP verified-domain returned malformed account data')
+            return
+        for alias, breaches in response.body.items():
+            self.emails.add(f'{alias.strip()}@{self.word}')
+            self.breach_names.update(breach.strip() for breach in breaches)
+
+    async def get_emails(self) -> set[str]:
+        return self.emails
+
+    async def get_breach_names(self) -> set[str]:
+        return self.breach_names

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -204,7 +204,7 @@ async def getsources(request: Request) -> Response:
     Rate limit is configurable via CLI argument (default: 5 requests per minute).
     """
     try:
-        sources = __main__.Core.get_supportedengines()
+        sources = [source for source in __main__.Core.get_supportedengines() if source != 'hibpverified']
         return JSONResponse({'sources': sources})
     except Exception as e:
         logger.exception('Error in getsources endpoint')
@@ -388,7 +388,14 @@ async def query(
 
     try:
         # Validate sources
+        requested_sources = {token.casefold() for value in source for token in map(str.strip, value.split(',')) if token}
+        if 'hibpverified' in requested_sources:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Source 'hibpverified' is available only through the CLI",
+            )
         selected_sources = __main__.Core.expand_source_selection(','.join(source))
+        selected_sources = [selected_source for selected_source in selected_sources if selected_source != 'hibpverified']
         supported_engines = __main__.Core.get_supportedengines()
         for s in selected_sources:
             if s not in supported_engines:

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -290,6 +290,7 @@ class Core:
     def get_supportedengines() -> list[str]:
         """Returns a list of supported search engines."""
         return [
+            'arquivo',
             'baidu',
             'bevigil',
             'bufferoverun',

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -19,7 +19,7 @@ from aiohttp_socks import ProxyConnector
 
 from theHarvester import __version__
 from theHarvester.lib.output import output_logger
-from theHarvester.lib.source_catalog import SOURCE_SPECS
+from theHarvester.lib.source_catalog import SOURCE_SPECS, ActivityClass
 
 if TYPE_CHECKING:
     from collections.abc import Sized
@@ -358,8 +358,11 @@ class Core:
     def expand_source_selection(cls, selection: str) -> list[str]:
         """Expand result capability selectors into source names."""
         if selection.lower() == 'all':
-            explicit_only = {spec.name for spec in SOURCE_SPECS.values() if spec.requires_explicit_selection}
-            return [source for source in cls.get_supportedengines() if source not in explicit_only]
+            return sorted(
+                spec.name
+                for spec in SOURCE_SPECS.values()
+                if spec.activity is ActivityClass.PASSIVE and not spec.requires_explicit_selection
+            )
         capabilities = {capability for spec in SOURCE_SPECS.values() for capability in spec.capabilities}
         selected: set[str] = set()
         for token in map(str.strip, selection.split(',')):

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -58,6 +58,7 @@ class Core:
         'fullhunt': ('key',),
         'github': ('key',),
         'hackertarget': ('key',),
+        'hibpverified': ('key',),
         'hunter': ('key',),
         'hunterhow': ('key',),
         'intelx': ('key',),
@@ -167,6 +168,10 @@ class Core:
     @staticmethod
     def hackertarget_key() -> str:
         return Core._api_key_value('hackertarget')
+
+    @staticmethod
+    def hibpverified_key() -> str | None:
+        return Core.api_keys().get('hibpverified', {}).get('key')
 
     @staticmethod
     def hunter_key() -> str:
@@ -307,6 +312,7 @@ class Core:
             'gitlab',
             'hackertarget',
             'haveibeenpwned',
+            'hibpverified',
             'hudsonrock',
             'hunter',
             'hunterhow',
@@ -352,12 +358,17 @@ class Core:
     def expand_source_selection(cls, selection: str) -> list[str]:
         """Expand result capability selectors into source names."""
         if selection.lower() == 'all':
-            return cls.get_supportedengines()
+            explicit_only = {spec.name for spec in SOURCE_SPECS.values() if spec.requires_explicit_selection}
+            return [source for source in cls.get_supportedengines() if source not in explicit_only]
         capabilities = {capability for spec in SOURCE_SPECS.values() for capability in spec.capabilities}
         selected: set[str] = set()
         for token in map(str.strip, selection.split(',')):
             if token in capabilities:
-                selected.update(spec.name for spec in SOURCE_SPECS.values() if token in spec.capabilities)
+                selected.update(
+                    spec.name
+                    for spec in SOURCE_SPECS.values()
+                    if token in spec.capabilities and not spec.requires_explicit_selection
+                )
             else:
                 selected.add(token)
         return sorted(selected)

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -1,5 +1,11 @@
 from dataclasses import dataclass
-from enum import Enum, auto
+from enum import Enum, StrEnum, auto
+
+
+class ActivityClass(StrEnum):
+    PASSIVE = 'P0'
+    DNS = 'P1'
+    DIRECT = 'P2'
 
 
 class ResultRoute(Enum):
@@ -37,17 +43,24 @@ class SourceSpec:
     name: str
     routes: frozenset[ResultRoute]
     requires_explicit_selection: bool = False
+    activity: ActivityClass = ActivityClass.PASSIVE
 
     @property
     def capabilities(self) -> frozenset[str]:
         return frozenset(_ROUTE_CAPABILITIES[route] for route in self.routes)
 
 
-def _spec(name: str, *routes: ResultRoute, requires_explicit_selection: bool = False) -> SourceSpec:
+def _spec(
+    name: str,
+    *routes: ResultRoute,
+    requires_explicit_selection: bool = False,
+    activity: ActivityClass = ActivityClass.PASSIVE,
+) -> SourceSpec:
     return SourceSpec(
         name=name,
         routes=frozenset(routes),
         requires_explicit_selection=requires_explicit_selection,
+        activity=activity,
     )
 
 
@@ -61,7 +74,13 @@ _SPECS = (
     _spec('certspotter', ResultRoute.SUBDOMAINS),
     _spec('chaos', ResultRoute.SUBDOMAINS),
     _spec('commoncrawl', ResultRoute.SUBDOMAINS),
-    _spec('criminalip', ResultRoute.SUBDOMAINS, ResultRoute.IPS, ResultRoute.ASNS),
+    _spec(
+        'criminalip',
+        ResultRoute.SUBDOMAINS,
+        ResultRoute.IPS,
+        ResultRoute.ASNS,
+        activity=ActivityClass.DIRECT,
+    ),
     _spec('crtsh', ResultRoute.SUBDOMAINS),
     _spec('dehashed', ResultRoute.IPS),
     _spec('dnsdb', ResultRoute.SUBDOMAINS),
@@ -90,7 +109,7 @@ _SPECS = (
     _spec('netlas', ResultRoute.SUBDOMAINS),
     _spec('onyphe', ResultRoute.SUBDOMAINS, ResultRoute.IPS, ResultRoute.ASNS),
     _spec('otx', ResultRoute.SUBDOMAINS, ResultRoute.IPS),
-    _spec('pentesttools', ResultRoute.SUBDOMAINS),
+    _spec('pentesttools', ResultRoute.SUBDOMAINS, activity=ActivityClass.DNS),
     _spec('projectdiscovery', ResultRoute.SUBDOMAINS),
     _spec('rapiddns', ResultRoute.SUBDOMAINS, ResultRoute.IPS),
     _spec('robtex', ResultRoute.SUBDOMAINS, ResultRoute.IPS),
@@ -98,11 +117,16 @@ _SPECS = (
     _spec('securityTrails', ResultRoute.SUBDOMAINS, ResultRoute.IPS),
     _spec('securityscorecard', ResultRoute.SUBDOMAINS, ResultRoute.IPS),
     _spec('sherlockeye', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS, ResultRoute.IPS),
-    _spec('shodan', ResultRoute.SUBDOMAINS),
-    _spec('shodanInternetDB', ResultRoute.SUBDOMAINS, ResultRoute.IPS),
+    _spec('shodan', ResultRoute.SUBDOMAINS, activity=ActivityClass.DNS),
+    _spec(
+        'shodanInternetDB',
+        ResultRoute.SUBDOMAINS,
+        ResultRoute.IPS,
+        activity=ActivityClass.DNS,
+    ),
     _spec('shodanct', ResultRoute.SUBDOMAINS),
     _spec('subdomaincenter', ResultRoute.SUBDOMAINS),
-    _spec('subdomainfinderc99', ResultRoute.SUBDOMAINS),
+    _spec('subdomainfinderc99', ResultRoute.SUBDOMAINS, activity=ActivityClass.DNS),
     _spec('thc', ResultRoute.SUBDOMAINS),
     _spec('tomba', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS),
     _spec('urlscan', ResultRoute.SUBDOMAINS, ResultRoute.IPS, ResultRoute.ASNS, ResultRoute.INTERESTING_URLS),
@@ -110,7 +134,13 @@ _SPECS = (
     _spec('virustotal', ResultRoute.SUBDOMAINS),
     _spec('waybackarchive', ResultRoute.SUBDOMAINS),
     _spec('whoisxml', ResultRoute.SUBDOMAINS),
-    _spec('windvane', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS, ResultRoute.IPS),
+    _spec(
+        'windvane',
+        ResultRoute.SUBDOMAINS,
+        ResultRoute.EMAILS,
+        ResultRoute.IPS,
+        activity=ActivityClass.DNS,
+    ),
     _spec('yahoo', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS),
     _spec(
         'zoomeye',

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -65,6 +65,7 @@ def _spec(
 
 
 _SPECS = (
+    _spec('arquivo', ResultRoute.SUBDOMAINS),
     _spec('baidu', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS),
     _spec('bevigil', ResultRoute.SUBDOMAINS, ResultRoute.INTERESTING_URLS),
     _spec('brave', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS),

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -36,14 +36,19 @@ _ROUTE_CAPABILITIES = {
 class SourceSpec:
     name: str
     routes: frozenset[ResultRoute]
+    requires_explicit_selection: bool = False
 
     @property
     def capabilities(self) -> frozenset[str]:
         return frozenset(_ROUTE_CAPABILITIES[route] for route in self.routes)
 
 
-def _spec(name: str, *routes: ResultRoute) -> SourceSpec:
-    return SourceSpec(name=name, routes=frozenset(routes))
+def _spec(name: str, *routes: ResultRoute, requires_explicit_selection: bool = False) -> SourceSpec:
+    return SourceSpec(
+        name=name,
+        routes=frozenset(routes),
+        requires_explicit_selection=requires_explicit_selection,
+    )
 
 
 _SPECS = (
@@ -69,6 +74,12 @@ _SPECS = (
     _spec('gitlab', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS),
     _spec('hackertarget', ResultRoute.SUBDOMAINS),
     _spec('haveibeenpwned', ResultRoute.BREACHES),
+    _spec(
+        'hibpverified',
+        ResultRoute.EMAILS,
+        ResultRoute.BREACHES,
+        requires_explicit_selection=True,
+    ),
     _spec('hudsonrock', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS, ResultRoute.IPS),
     _spec('hunter', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS),
     _spec('hunterhow', ResultRoute.SUBDOMAINS),


### PR DESCRIPTION
## Summary

This is one review batch containing three focused commits:

1. Add an explicit authenticated HIBP verified-domain CLI source while preserving the keyless public HIBP source. Broad selectors cannot invoke the authenticated endpoint.
2. Make the source catalog drive CLI help, P0-only `all` selection, and the P0/P1/P2 activity summary. Remove duplicate late provider execution.
3. Add a bounded keyless Arquivo.pt passive source with defensive JSONL parsing and scoped hostname normalization.

The commits are also available as a dependent fork stack for layer-by-layer inspection:

- NotoriousRebel/theHarvester#249
- NotoriousRebel/theHarvester#250
- NotoriousRebel/theHarvester#251

## Verification

- 424 passed, 6 skipped
- `ruff check .`
- `ruff format --check .`
- `mypy theHarvester`
- `git diff --check`
- zero em dashes in the aggregate diff
- parallel Standards and Spec reviews passed against `ffd03b13`

An authorized live Arquivo.pt CLI smoke against `mozilla.org` returned `www.mozilla.org`; the result was confirmed in JSON, JSONL, and SQLite completed results. HIBP verified-domain testing remained offline because live use requires a paid user-owned key and a domain verified in that HIBP account.
