### PR TITLE
feat: add bounded Arquivo.pt passive source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added authenticated REST routes for listing completed enumeration runs and retrieving their normalized evidence.
 - Added an authenticated HIBP verified-domain source for CLI and conditionally authenticated REST queries that retains normalized account emails and stable breach names without retaining the raw account mapping.
 - Added keyless Shodan Certificate Transparency hostname discovery with bounded requests and offline response contracts.
+- Added bounded, keyless subdomain discovery through Arquivo.pt's public CDX API with offline response contracts.
 - Added transactional SQLite storage and loading for completed full-pipeline runs without changing legacy result rows.
 - Added deterministic JSONL report companions finalized after selected one-shot actions complete.
 - Added normalized BuiltWith framework, language, server, CMS, and analytics findings to JSONL and completed-result SQLite output.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Read the **API key** column as follows:
 
 | Source | Subdomains | Emails | IPs | ASNs | URLs / links | People | Breaches | Separate REST/action output (not consolidated report) | API key |
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- | :---: |
+| `arquivo` | ✓ | No | No | No | No | No | No | No | No |
 | `baidu` | ✓ | ✓ | No | No | No | No | No | No | No |
 | `bevigil` | ✓ | No | No | No | ✓ | No | No | No | ✓ |
 | `bufferoverun` | ✓ | No | ✓ | No | No | No | No | No | ✓ |

--- a/tests/discovery/test_arquivo.py
+++ b/tests/discovery/test_arquivo.py
@@ -1,0 +1,93 @@
+import logging
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from theHarvester.discovery import arquivo
+from theHarvester.lib.core import FetcherResponse
+
+
+@pytest.mark.asyncio
+async def test_process_collects_scoped_hosts_from_one_cdx_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    requested_urls: list[str] = []
+
+    async def fake_fetch_all(urls: list[str], **kwargs: Any) -> list[FetcherResponse]:
+        requested_urls.extend(urls)
+        assert kwargs['include_metadata'] is True
+        assert kwargs['headers']['User-agent']
+        return [
+            FetcherResponse(
+                body='\n'.join(
+                    (
+                        '{"url": "https://API.Example.COM/path"}',
+                        '{"url": "http://www.example.com/"}',
+                        '{"url": "https://api.example.com/repeated"}',
+                        '{"url": "https://example.com/"}',
+                        '{"url": "https://outside.test/"}',
+                        '{"url": 42}',
+                        'not-json',
+                    )
+                ),
+                status=200,
+                headers={},
+            )
+        ]
+
+    monkeypatch.setattr(arquivo.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = arquivo.SearchArquivo('Example.COM.', 750)
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com', 'www.example.com'}
+    assert len(requested_urls) == 1
+    assert parse_qs(urlparse(requested_urls[0]).query) == {
+        'url': ['example.com'],
+        'matchType': ['domain'],
+        'output': ['json'],
+        'fields': ['url'],
+        'limit': ['750'],
+    }
+
+
+@pytest.mark.asyncio
+async def test_process_bounds_the_provider_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    requested_urls: list[str] = []
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: Any) -> list[FetcherResponse]:
+        requested_urls.extend(urls)
+        return [FetcherResponse(body='', status=200, headers={})]
+
+    monkeypatch.setattr(arquivo.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = arquivo.SearchArquivo('example.com', 100_001)
+    await search.process()
+
+    assert parse_qs(urlparse(requested_urls[0]).query)['limit'] == ['10000']
+
+
+@pytest.mark.asyncio
+async def test_process_reports_http_and_malformed_responses(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    responses = [
+        FetcherResponse(body='rate limited', status=429, headers={}),
+        FetcherResponse(body={'unexpected': 'shape'}, status=200, headers={}),
+    ]
+
+    async def fake_fetch_all(_urls: list[str], **_kwargs: Any) -> list[FetcherResponse]:
+        return [responses.pop(0)]
+
+    monkeypatch.setattr(arquivo.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    with caplog.at_level(logging.INFO, logger=arquivo.__name__):
+        first = arquivo.SearchArquivo('example.com', 500)
+        await first.process()
+        second = arquivo.SearchArquivo('example.com', 500)
+        await second.process()
+
+    assert await first.get_hostnames() == set()
+    assert await second.get_hostnames() == set()
+    assert 'Arquivo.pt request failed with HTTP 429' in caplog.text
+    assert 'Arquivo.pt returned malformed CDX data' in caplog.text

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -80,8 +80,8 @@ def test_readme_matches_declared_source_contracts() -> None:
     declared = _declared_source_contracts()
 
     assert '| Source | Subdomains | Emails | IPs | ASNs | URLs / links | People | Breaches |' in readme
-    assert len(declared) == 56
-    assert len(documented) == 56
+    assert len(declared) == 57
+    assert len(documented) == 57
     assert documented == declared
     assert {'securitytrails', 'shodaninternetdb'}.isdisjoint(documented)
 

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -21,6 +21,7 @@ from aiomultiprocess import Pool
 
 from theHarvester.discovery import (
     api_endpoints,
+    arquivo,
     baidusearch,
     bevigil,
     bravesearch,
@@ -496,7 +497,14 @@ async def start(
             output_logger.info(f'\n[*] Target: {word} \n')
 
             for engineitem in engines:
-                if engineitem == 'baidu':
+                if engineitem == 'arquivo':
+                    try:
+                        arquivo_search = arquivo.SearchArquivo(word, limit)
+                        stor_lst.append(store(arquivo_search, engineitem))
+                    except Exception as e:
+                        show_default_error_message(engineitem, word, e)
+
+                elif engineitem == 'baidu':
                     try:
                         baidu_search = baidusearch.SearchBaidu(word, limit)
                         stor_lst.append(

--- a/theHarvester/discovery/arquivo.py
+++ b/theHarvester/discovery/arquivo.py
@@ -1,0 +1,68 @@
+import json
+import logging
+from urllib.parse import urlencode, urlsplit
+
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
+from theHarvester.lib.hostnames import normalize_scoped_hostname
+
+logger = logging.getLogger(__name__)
+
+
+class SearchArquivo:
+    MAX_RESULTS = 10_000
+
+    def __init__(self, word: str, limit: int) -> None:
+        self.word = word.strip().lower().rstrip('.')
+        self.limit = min(max(limit, 1), self.MAX_RESULTS)
+        self.totalhosts: set[str] = set()
+        self.proxy = False
+
+    async def process(self, proxy: bool = False) -> None:
+        self.proxy = proxy
+        query = urlencode(
+            {
+                'url': self.word,
+                'matchType': 'domain',
+                'output': 'json',
+                'fields': 'url',
+                'limit': self.limit,
+            }
+        )
+        try:
+            responses: list[FetcherResponse | None] = await AsyncFetcher.fetch_all(
+                [f'https://arquivo.pt/wayback/cdx?{query}'],
+                headers={'User-agent': Core.get_user_agent()},
+                proxy=self.proxy,
+                include_metadata=True,
+            )
+        except Exception as error:
+            logger.info(f'Arquivo.pt request failed: {error}')
+            return
+
+        response = responses[0] if responses else None
+        if response is None:
+            logger.info('Arquivo.pt request failed')
+            return
+        if not 200 <= response.status < 300:
+            logger.info(f'Arquivo.pt request failed with HTTP {response.status}')
+            return
+        if not isinstance(response.body, str):
+            logger.info('Arquivo.pt returned malformed CDX data')
+            return
+
+        for line in response.body.splitlines():
+            try:
+                item = json.loads(line)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if not isinstance(item, dict) or not isinstance(url := item.get('url'), str):
+                continue
+            try:
+                hostname = urlsplit(url).hostname
+            except ValueError:
+                continue
+            if (normalized := normalize_scoped_hostname(hostname, self.word)) and normalized != self.word:
+                self.totalhosts.add(normalized)
+
+    async def get_hostnames(self) -> set[str]:
+        return self.totalhosts

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -290,6 +290,7 @@ class Core:
     def get_supportedengines() -> list[str]:
         """Returns a list of supported search engines."""
         return [
+            'arquivo',
             'baidu',
             'bevigil',
             'bufferoverun',

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -62,6 +62,7 @@ def _spec(
 
 
 _SPECS = (
+    _spec('arquivo', ResultRoute.SUBDOMAINS),
     _spec('baidu', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS),
     _spec('bevigil', ResultRoute.SUBDOMAINS, ResultRoute.INTERESTING_URLS),
     _spec('brave', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS),


### PR DESCRIPTION
## Summary

- add a keyless `arquivo` passive source backed by Arquivo.pt's CDX endpoint
- bound each run to one request and at most 10,000 records
- parse JSONL defensively and retain only normalized in-scope descendant hostnames
- preserve CLI, REST, JSON, XML, JSONL, SQLite, and public getter behavior

## Verification

- offline success, malformed-line, and HTTP-failure coverage
- live authorized CLI smoke against `mozilla.org` returned `www.mozilla.org`
- the live result was confirmed in JSON, JSONL, and SQLite completed results
- final aggregate suite: 430 passed, 6 skipped
- Ruff, formatting, mypy, and `git diff --check`

Stack: 3 of 3. Depends on #2489.
