### PR TITLE
Preserve direct DNS source result contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the nonfunctional ThreatCrowd source because its service hostnames terminate at deleted AWS load balancers and return NXDOMAIN; OTX remains available through its separate adapter.
 
 ### Fixed
+- Added offline contracts for explicitly selected DNS and direct sources, retained normalized Pentest-Tools host and IP results, and hardened Shodan InternetDB, SubdomainFinder C99, and Windvane evidence boundaries.
 - Retained relevant GitLab project, profile, and website URLs in consolidated JSONL and SQLite results while excluding unrelated user URLs.
 - Removed BuiltWith's duplicate interesting-URL getter by allowing the shared collector to use either established getter spelling.
 - Made no-filename REST `/query` executions reach completed-result construction and SQLite persistence without changing the legacy response fields.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Read the **API key** column as follows:
 | `netlas` | ✓ | No | No | No | No | No | No | No | ✓ |
 | `onyphe` | ✓ | No | ✓ | ✓ | No | No | No | No | ✓ |
 | `otx` | ✓ | No | ✓ | No | No | No | No | No | No |
-| `pentesttools` | ✓ | No | No | No | No | No | No | No | ✓ |
+| `pentesttools` | ✓ | No | ✓ | No | No | No | No | No | ✓ |
 | `projectdiscovery` | ✓ | No | No | No | No | No | No | No | ✓ |
 | `rapiddns` | ✓ | No | ✓ | No | No | No | No | No | No |
 | `robtex` | ✓ | No | ✓ | No | No | No | No | No | No |

--- a/tests/discovery/test_pentesttools.py
+++ b/tests/discovery/test_pentesttools.py
@@ -6,6 +6,38 @@ from theHarvester.discovery import pentesttools
 
 
 @pytest.mark.asyncio
+async def test_successful_scan_returns_normalized_hostnames_and_ips(monkeypatch) -> None:
+    monkeypatch.setattr(pentesttools.Core, 'pentest_tools_key', lambda: 'test-key')
+
+    responses = iter(
+        [
+            '{"op_status":"success","scan_id":"scan-1"}',
+            '{"op_status":"success","scan_status":"finished"}',
+            (
+                '{"op_status":"success","scan_output":{"output_json":[{"output_data":'
+                '[["Api.Example.TEST.","203.0.113.10"],["Example.TEST.","203.0.113.11"],'
+                '["NoIp.Example.TEST.","not-an-ip"],["www.notexample.test","198.51.100.1"],["broken"]]}]}}'
+            ),
+        ]
+    )
+
+    async def fake_post_fetch(*_args, **_kwargs):
+        return next(responses)
+
+    async def no_sleep(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(pentesttools.AsyncFetcher, 'post_fetch', fake_post_fetch)
+    monkeypatch.setattr(pentesttools.asyncio, 'sleep', no_sleep)
+
+    search = pentesttools.SearchPentestTools(' Example.TEST. ')
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.test', 'noip.example.test'}
+    assert await search.get_ips() == {'203.0.113.10'}
+
+
+@pytest.mark.asyncio
 async def test_status_error_payload_is_not_logged(monkeypatch, caplog) -> None:
     monkeypatch.setattr(pentesttools.Core, 'pentest_tools_key', lambda: 'test-key')
 
@@ -31,3 +63,103 @@ async def test_status_error_payload_is_not_logged(monkeypatch, caplog) -> None:
     assert 'provider-secret-payload' not in caplog.text
     assert 'private target data' not in caplog.text
     assert 'get_scan_status failed' in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('response', ['not-json', '{}'])
+async def test_malformed_start_response_completes_without_evidence(monkeypatch, caplog, response) -> None:
+    monkeypatch.setattr(pentesttools.Core, 'pentest_tools_key', lambda: 'test-key')
+
+    async def fake_post_fetch(*_args, **_kwargs):
+        return response
+
+    monkeypatch.setattr(pentesttools.AsyncFetcher, 'post_fetch', fake_post_fetch)
+    caplog.set_level(logging.INFO, logger=pentesttools.__name__)
+
+    search = pentesttools.SearchPentestTools('example.test')
+    await search.process()
+
+    assert not await search.get_hostnames()
+    assert not await search.get_ips()
+    assert 'malformed response' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_waiting_scan_stops_after_ten_status_checks(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(pentesttools.Core, 'pentest_tools_key', lambda: 'test-key')
+    responses = iter(
+        ['{"op_status":"success","scan_id":"scan-1"}']
+        + ['{"op_status":"success","scan_status":"waiting"}'] * 10
+    )
+    calls = 0
+
+    async def fake_post_fetch(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return next(responses)
+
+    async def no_sleep(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(pentesttools.AsyncFetcher, 'post_fetch', fake_post_fetch)
+    monkeypatch.setattr(pentesttools.asyncio, 'sleep', no_sleep)
+    caplog.set_level(logging.INFO, logger=pentesttools.__name__)
+
+    await pentesttools.SearchPentestTools('example.test').process()
+
+    assert calls == 11
+    assert 'still waiting after 10 status checks' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_malformed_status_response_completes_without_evidence(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(pentesttools.Core, 'pentest_tools_key', lambda: 'test-key')
+    responses = iter(
+        [
+            '{"op_status":"success","scan_id":"scan-1"}',
+            '{"op_status":"success"}',
+        ]
+    )
+
+    async def fake_post_fetch(*_args, **_kwargs):
+        return next(responses)
+
+    async def no_sleep(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(pentesttools.AsyncFetcher, 'post_fetch', fake_post_fetch)
+    monkeypatch.setattr(pentesttools.asyncio, 'sleep', no_sleep)
+    caplog.set_level(logging.INFO, logger=pentesttools.__name__)
+
+    search = pentesttools.SearchPentestTools('example.test')
+    await search.process()
+
+    assert not await search.get_hostnames()
+    assert 'malformed status response' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_null_output_data_completes_without_evidence(monkeypatch) -> None:
+    monkeypatch.setattr(pentesttools.Core, 'pentest_tools_key', lambda: 'test-key')
+    responses = iter(
+        [
+            '{"op_status":"success","scan_id":"scan-1"}',
+            '{"op_status":"success","scan_status":"finished"}',
+            '{"op_status":"success","scan_output":{"output_json":[{"output_data":null}]}}',
+        ]
+    )
+
+    async def fake_post_fetch(*_args, **_kwargs):
+        return next(responses)
+
+    async def no_sleep(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(pentesttools.AsyncFetcher, 'post_fetch', fake_post_fetch)
+    monkeypatch.setattr(pentesttools.asyncio, 'sleep', no_sleep)
+
+    search = pentesttools.SearchPentestTools('example.test')
+    await search.process()
+
+    assert not await search.get_hostnames()
+    assert not await search.get_ips()

--- a/tests/discovery/test_pentesttools.py
+++ b/tests/discovery/test_pentesttools.py
@@ -34,7 +34,7 @@ async def test_successful_scan_returns_normalized_hostnames_and_ips(monkeypatch)
     await search.process()
 
     assert await search.get_hostnames() == {'api.example.test', 'noip.example.test'}
-    assert await search.get_ips() == {'203.0.113.10'}
+    assert await search.get_ips() == {'203.0.113.10', '203.0.113.11'}
 
 
 @pytest.mark.asyncio
@@ -87,10 +87,7 @@ async def test_malformed_start_response_completes_without_evidence(monkeypatch, 
 @pytest.mark.asyncio
 async def test_waiting_scan_stops_after_ten_status_checks(monkeypatch, caplog) -> None:
     monkeypatch.setattr(pentesttools.Core, 'pentest_tools_key', lambda: 'test-key')
-    responses = iter(
-        ['{"op_status":"success","scan_id":"scan-1"}']
-        + ['{"op_status":"success","scan_status":"waiting"}'] * 10
-    )
+    responses = iter(['{"op_status":"success","scan_id":"scan-1"}'] + ['{"op_status":"success","scan_status":"waiting"}'] * 10)
     calls = 0
 
     async def fake_post_fetch(*_args, **_kwargs):

--- a/tests/discovery/test_shodan_engine.py
+++ b/tests/discovery/test_shodan_engine.py
@@ -59,8 +59,8 @@ class TestShodanEngine:
 
         out = capsys.readouterr().out
         assert 'An error occurred while processing a "work item"' not in out
-        assert 'a.example.com' in out
-        assert 'b.example.com' in out
+        output_tokens = set(out.split())
+        assert {'a.example.com', 'b.example.com'} <= output_tokens
 
     @pytest.mark.asyncio
     async def test_shodan_internetdb_ignores_non_string_resolved_addresses(self, monkeypatch):

--- a/tests/discovery/test_shodan_engine.py
+++ b/tests/discovery/test_shodan_engine.py
@@ -31,27 +31,27 @@ class TestShodanEngine:
         import theHarvester.__main__ as main_module
 
         # Make DNS resolution deterministic and offline.
-        monkeypatch.setattr(socket, "gethostbyname", lambda _domain: "1.2.3.4", raising=True)
+        monkeypatch.setattr(socket, 'gethostbyname', lambda _domain: '1.2.3.4', raising=True)
 
         # Avoid filesystem/sqlite side effects.
         class DummyStashManager:
             async def do_init(self) -> None:
                 return None
 
-            async def store_all(self, domain, all, res_type, source) -> None:  # noqa: A002
+            async def store_all(self, domain, all, res_type, source) -> None:
                 return None
 
-        monkeypatch.setattr(main_module.stash, "StashManager", DummyStashManager, raising=True)
+        monkeypatch.setattr(main_module.stash, 'StashManager', DummyStashManager, raising=True)
 
         # Stub Shodan search to avoid network and API key requirements.
         class DummySearchShodan:
             async def search_ip(self, ip):
-                return OrderedDict({ip: {"hostnames": ["a.example.com", "b.example.com"]}})
+                return OrderedDict({ip: {'hostnames': ['a.example.com', 'b.example.com']}})
 
-        monkeypatch.setattr(main_module.shodansearch, "SearchShodan", DummySearchShodan, raising=True)
+        monkeypatch.setattr(main_module.shodansearch, 'SearchShodan', DummySearchShodan, raising=True)
 
         # Run the CLI path that uses the engine queue/worker (`-b shodan`).
-        monkeypatch.setattr(sys, "argv", ["theHarvester", "-d", "example.com", "-b", "shodan"], raising=True)
+        monkeypatch.setattr(sys, 'argv', ['theHarvester', '-d', 'example.com', '-b', 'shodan'], raising=True)
 
         with pytest.raises(SystemExit) as excinfo:
             await main_module.start()
@@ -59,8 +59,8 @@ class TestShodanEngine:
 
         out = capsys.readouterr().out
         assert 'An error occurred while processing a "work item"' not in out
-        assert "a.example.com" in out
-        assert "b.example.com" in out
+        assert 'a.example.com' in out
+        assert 'b.example.com' in out
 
     @pytest.mark.asyncio
     async def test_shodan_internetdb_ignores_non_string_resolved_addresses(self, monkeypatch):
@@ -116,6 +116,41 @@ class TestShodanEngine:
 
         assert await search.get_hostnames() == {'api.example.test'}
         assert await search.get_ips() == {'203.0.113.1'}
+
+    @pytest.mark.asyncio
+    async def test_shodan_internetdb_rejects_evidence_for_an_unrequested_ip(self, monkeypatch):
+        from theHarvester.discovery import shodan_internetdb
+
+        monkeypatch.setattr(
+            shodan_internetdb.socket,
+            'getaddrinfo',
+            lambda *_args: [(socket.AF_INET, socket.SOCK_STREAM, 0, '', ('203.0.113.1', 0))],
+            raising=True,
+        )
+
+        async def fake_fetch_all(_urls, json=False, proxy=False):
+            return [
+                {
+                    'ip': '198.51.100.2',
+                    'hostnames': ['injected.example.test'],
+                    'ports': [443],
+                    'vulns': ['CVE-2026-0001'],
+                    'tags': ['injected'],
+                    'cpes': ['cpe:/a:injected'],
+                }
+            ]
+
+        monkeypatch.setattr(shodan_internetdb.AsyncFetcher, 'fetch_all', fake_fetch_all, raising=True)
+
+        search = shodan_internetdb.SearchShodanInternetDB('example.test')
+        await search.process()
+
+        assert not await search.get_hostnames()
+        assert not await search.get_ips()
+        assert not await search.get_ports()
+        assert not await search.get_vulns()
+        assert not await search.get_tags()
+        assert not await search.get_cpes()
 
     @pytest.mark.asyncio
     async def test_shodan_internetdb_resolution_failure_skips_provider_request(self, monkeypatch):

--- a/tests/discovery/test_shodan_engine.py
+++ b/tests/discovery/test_shodan_engine.py
@@ -1,3 +1,4 @@
+import logging
 import socket
 import sys
 from collections import OrderedDict
@@ -6,6 +7,24 @@ import pytest
 
 
 class TestShodanEngine:
+    @pytest.mark.asyncio
+    async def test_shodan_provider_failure_returns_attributed_empty_evidence(self, monkeypatch, caplog):
+        from theHarvester.discovery import shodansearch
+
+        class FailingShodan:
+            def host(self, _ip):
+                raise shodansearch.exception.APIError('provider-secret-payload')
+
+        monkeypatch.setattr(shodansearch.Core, 'shodan_key', lambda: 'test-key')
+        monkeypatch.setattr(shodansearch, 'Shodan', lambda _key: FailingShodan())
+        caplog.set_level(logging.INFO, logger=shodansearch.__name__)
+
+        result = await shodansearch.SearchShodan().search_ip('203.0.113.1')
+
+        assert result == OrderedDict({'203.0.113.1': 'Not in Shodan'})
+        assert '203.0.113.1: Not in Shodan' in caplog.text
+        assert 'provider-secret-payload' not in caplog.text
+
     @pytest.mark.asyncio
     async def test_shodan_engine_processes_without_work_item_error_and_yields_hostnames(self, monkeypatch, capsys):
         # Import inside the test so monkeypatching affects the already-imported module namespace.
@@ -68,3 +87,76 @@ class TestShodanEngine:
 
         assert await search.get_hostnames() == {'www.example.com'}
         assert await search.get_ips() == {'203.0.113.1'}
+
+    @pytest.mark.asyncio
+    async def test_shodan_internetdb_normalizes_scoped_provider_evidence(self, monkeypatch):
+        from theHarvester.discovery import shodan_internetdb
+
+        monkeypatch.setattr(
+            shodan_internetdb.socket,
+            'getaddrinfo',
+            lambda *_args: [(socket.AF_INET, socket.SOCK_STREAM, 0, '', ('203.0.113.1', 0))],
+            raising=True,
+        )
+
+        async def fake_fetch_all(_urls, json=False, proxy=False):
+            return [
+                {
+                    'ip': '203.0.113.1',
+                    'hostnames': ['API.Example.TEST.', 'www.notexample.test', None],
+                    'ports': [443],
+                },
+                {'ip': '198.51.100.2', 'ports': [80]},
+            ]
+
+        monkeypatch.setattr(shodan_internetdb.AsyncFetcher, 'fetch_all', fake_fetch_all, raising=True)
+
+        search = shodan_internetdb.SearchShodanInternetDB(' Example.TEST. ')
+        await search.process()
+
+        assert await search.get_hostnames() == {'api.example.test'}
+        assert await search.get_ips() == {'203.0.113.1'}
+
+    @pytest.mark.asyncio
+    async def test_shodan_internetdb_resolution_failure_skips_provider_request(self, monkeypatch):
+        from theHarvester.discovery import shodan_internetdb
+
+        def fail_resolution(*_args):
+            raise socket.gaierror
+
+        async def fail_fetch(*_args, **_kwargs):
+            raise AssertionError('provider request must not run')
+
+        monkeypatch.setattr(shodan_internetdb.socket, 'getaddrinfo', fail_resolution, raising=True)
+        monkeypatch.setattr(shodan_internetdb.AsyncFetcher, 'fetch_all', fail_fetch, raising=True)
+
+        search = shodan_internetdb.SearchShodanInternetDB('example.test')
+        await search.process()
+
+        assert not await search.get_hostnames()
+        assert not await search.get_ips()
+
+    @pytest.mark.asyncio
+    async def test_shodan_internetdb_provider_failure_completes_without_evidence(self, monkeypatch, caplog):
+        from theHarvester.discovery import shodan_internetdb
+
+        monkeypatch.setattr(
+            shodan_internetdb.socket,
+            'getaddrinfo',
+            lambda *_args: [(socket.AF_INET, socket.SOCK_STREAM, 0, '', ('203.0.113.1', 0))],
+            raising=True,
+        )
+
+        async def fail_fetch(*_args, **_kwargs):
+            raise RuntimeError('provider-secret-payload')
+
+        monkeypatch.setattr(shodan_internetdb.AsyncFetcher, 'fetch_all', fail_fetch, raising=True)
+        caplog.set_level(logging.INFO, logger=shodan_internetdb.__name__)
+
+        search = shodan_internetdb.SearchShodanInternetDB('example.test')
+        await search.process()
+
+        assert not await search.get_hostnames()
+        assert not await search.get_ips()
+        assert 'Shodan InternetDB request failed' in caplog.text
+        assert 'provider-secret-payload' not in caplog.text

--- a/tests/discovery/test_shodan_engine.py
+++ b/tests/discovery/test_shodan_engine.py
@@ -153,6 +153,27 @@ class TestShodanEngine:
         assert not await search.get_cpes()
 
     @pytest.mark.asyncio
+    async def test_shodan_internetdb_retains_a_matching_ip_with_empty_details(self, monkeypatch):
+        from theHarvester.discovery import shodan_internetdb
+
+        monkeypatch.setattr(
+            shodan_internetdb.socket,
+            'getaddrinfo',
+            lambda *_args: [(socket.AF_INET, socket.SOCK_STREAM, 0, '', ('203.0.113.1', 0))],
+            raising=True,
+        )
+
+        async def fake_fetch_all(_urls, json=False, proxy=False):
+            return [{'ip': '203.0.113.1', 'hostnames': [], 'ports': [], 'vulns': [], 'tags': [], 'cpes': []}]
+
+        monkeypatch.setattr(shodan_internetdb.AsyncFetcher, 'fetch_all', fake_fetch_all, raising=True)
+
+        search = shodan_internetdb.SearchShodanInternetDB('example.test')
+        await search.process()
+
+        assert await search.get_ips() == {'203.0.113.1'}
+
+    @pytest.mark.asyncio
     async def test_shodan_internetdb_resolution_failure_skips_provider_request(self, monkeypatch):
         from theHarvester.discovery import shodan_internetdb
 

--- a/tests/discovery/test_subdomainfinderc99.py
+++ b/tests/discovery/test_subdomainfinderc99.py
@@ -1,0 +1,58 @@
+import pytest
+
+from theHarvester.discovery import subdomainfinderc99
+
+
+@pytest.mark.asyncio
+async def test_successful_response_returns_only_scoped_hostnames(monkeypatch) -> None:
+    async def fake_fetch_all(*_args, **_kwargs):
+        return ['<div class="input-group"><input name="token" value="abc"></div>']
+
+    async def fake_post_fetch(*_args, **_kwargs):
+        return 'api.example.test www.notexample.test'
+
+    async def no_sleep(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(subdomainfinderc99.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(subdomainfinderc99.AsyncFetcher, 'post_fetch', fake_post_fetch)
+    monkeypatch.setattr(subdomainfinderc99.asyncio, 'sleep', no_sleep)
+
+    search = subdomainfinderc99.SearchSubdomainfinderc99('example.test')
+    await search.process()
+
+    assert set(await search.get_hostnames()) == {'api.example.test'}
+
+
+@pytest.mark.asyncio
+async def test_empty_initial_response_completes_without_evidence(monkeypatch) -> None:
+    async def fake_fetch_all(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr(subdomainfinderc99.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = subdomainfinderc99.SearchSubdomainfinderc99('example.test')
+    await search.process()
+
+    assert not await search.get_hostnames()
+
+
+@pytest.mark.asyncio
+async def test_malformed_scan_response_completes_without_evidence(monkeypatch) -> None:
+    async def fake_fetch_all(*_args, **_kwargs):
+        return ['<div class="input-group"><input name="token" value="abc"></div>']
+
+    async def fake_post_fetch(*_args, **_kwargs):
+        return None
+
+    async def no_sleep(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(subdomainfinderc99.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(subdomainfinderc99.AsyncFetcher, 'post_fetch', fake_post_fetch)
+    monkeypatch.setattr(subdomainfinderc99.asyncio, 'sleep', no_sleep)
+
+    search = subdomainfinderc99.SearchSubdomainfinderc99('example.test')
+    await search.process()
+
+    assert not await search.get_hostnames()

--- a/tests/discovery/test_windvane.py
+++ b/tests/discovery/test_windvane.py
@@ -1,0 +1,84 @@
+import asyncio
+import json
+import socket
+
+import pytest
+
+from theHarvester.discovery import windvane
+
+
+@pytest.mark.asyncio
+async def test_authenticated_results_are_normalized_and_scoped(monkeypatch) -> None:
+    monkeypatch.setattr(windvane.Core, 'windvane_key', lambda: 'test-key')
+    responses = {
+        ('ListSubDomain', 1): {
+            'code': 0,
+            'data': {
+                'list': [
+                    {'domain': 'API.Example.TEST.'},
+                    {'domain': 'www.notexample.test'},
+                ]
+            },
+        },
+        ('ListSubDomain', 2): {'code': 0, 'data': {'list': []}},
+        ('ListDNS', 1): {
+            'code': 0,
+            'data': {
+                'list': [
+                    {'domain': 'Mail.Example.TEST.', 'answer': '203.0.113.10', 'answer_type': 'A'},
+                    {'domain': 'api.notexample.test', 'answer': '198.51.100.1', 'answer_type': 'A'},
+                ]
+            },
+        },
+        ('ListDNS', 2): {'code': 0, 'data': {'list': []}},
+        ('ListEmail', 1): {
+            'code': 0,
+            'data': {
+                'list': [
+                    {'email': 'Admin@Example.TEST'},
+                    {'email': 'attacker@notexample.test'},
+                ]
+            },
+        },
+    }
+
+    async def fake_post_fetch(url, headers=None, data=None, proxy=False):
+        endpoint = url.rsplit('/', 1)[-1]
+        page = json.loads(data)['page_request']['page']
+        assert headers['X-Api-Key'] == 'test-key'
+        return json.dumps(responses[(endpoint, page)])
+
+    monkeypatch.setattr(windvane.AsyncFetcher, 'post_fetch', fake_post_fetch)
+
+    search = windvane.SearchWindvane('example.test')
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.test', 'mail.example.test'}
+    assert await search.get_ips() == {'203.0.113.10'}
+    assert await search.get_emails() == {'admin@example.test'}
+
+
+@pytest.mark.asyncio
+async def test_keyless_fallback_uses_only_the_mocked_dns_boundary(monkeypatch) -> None:
+    monkeypatch.setattr(windvane.Core, 'windvane_key', lambda: None)
+
+    async def fake_post_fetch(*_args, **_kwargs):
+        return '{"code":1}'
+
+    async def no_sleep(*_args, **_kwargs):
+        return None
+
+    def fake_gethostbyname(hostname: str) -> str:
+        if hostname == 'api.example.test':
+            return '203.0.113.10'
+        raise socket.gaierror
+
+    monkeypatch.setattr(windvane.AsyncFetcher, 'post_fetch', fake_post_fetch)
+    monkeypatch.setattr(asyncio, 'sleep', no_sleep)
+    monkeypatch.setattr(socket, 'gethostbyname', fake_gethostbyname)
+
+    search = windvane.SearchWindvane('example.test')
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.test'}
+    assert await search.get_ips() == {'203.0.113.10'}

--- a/tests/lib/test_core.py
+++ b/tests/lib/test_core.py
@@ -94,6 +94,15 @@ def test_all_selects_only_passive_catalog_sources() -> None:
     }
 
 
+@pytest.mark.parametrize(
+    'source',
+    ['criminalip', 'pentesttools', 'shodan', 'shodanInternetDB', 'subdomainfinderc99', 'windvane'],
+)
+def test_non_passive_sources_run_only_when_explicitly_selected(source: str) -> None:
+    assert source not in Core.expand_source_selection('all')
+    assert Core.expand_source_selection(source) == [source]
+
+
 def mock_read_text(mocked: dict[Path, str | Exception]):
     read_text = Path.read_text
 

--- a/tests/lib/test_source_catalog.py
+++ b/tests/lib/test_source_catalog.py
@@ -74,6 +74,10 @@ def test_rapiddns_declares_separate_subdomain_and_ip_routes() -> None:
     assert SOURCE_SPECS['rapiddns'].routes == frozenset({ResultRoute.SUBDOMAINS, ResultRoute.IPS})
 
 
+def test_pentesttools_declares_its_normalized_subdomain_and_ip_routes() -> None:
+    assert SOURCE_SPECS['pentesttools'].routes == frozenset({ResultRoute.SUBDOMAINS, ResultRoute.IPS})
+
+
 def test_capability_selection_preserves_every_declared_route() -> None:
     assert 'venacus' in Core.expand_source_selection('emails')
     assert get_source_spec('venacus').routes == frozenset(

--- a/tests/test_all_source_orchestration.py
+++ b/tests/test_all_source_orchestration.py
@@ -1,4 +1,5 @@
 import json
+import socket
 import sys
 import xml.etree.ElementTree as ElementTree
 from collections import Counter
@@ -11,6 +12,16 @@ import pytest
 
 from theHarvester import __main__ as theharvester_main
 from theHarvester.lib.source_catalog import SOURCE_SPECS, ActivityClass
+
+
+NON_PASSIVE_SOURCES = (
+    'criminalip',
+    'pentesttools',
+    'shodan',
+    'shodanInternetDB',
+    'subdomainfinderc99',
+    'windvane',
+)
 
 
 @pytest.mark.asyncio
@@ -119,6 +130,70 @@ async def test_legacy_handlerless_source_does_not_break_activity_summary(
         await theharvester_main.start()
 
     assert exit_info.value.code == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('source', NON_PASSIVE_SOURCES)
+async def test_explicit_non_passive_source_is_scheduled_once(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+) -> None:
+    executions = 0
+
+    class FakeStash:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args: object) -> None:
+            return None
+
+        async def store_completed_result(self, *_args: object) -> None:
+            return None
+
+    class FakeAdapter:
+        async def process(self, *_args: object, **_kwargs: object) -> None:
+            nonlocal executions
+            executions += 1
+
+        async def get_hostnames(self) -> set[str]:
+            return set()
+
+        async def get_emails(self) -> set[str]:
+            return set()
+
+        async def get_ips(self) -> set[str]:
+            return set()
+
+        async def get_asns(self) -> set[str]:
+            return set()
+
+    if source == 'shodan':
+        class FakeShodan:
+            async def search_ip(self, _ip: str) -> dict:
+                nonlocal executions
+                executions += 1
+                return {}
+
+        monkeypatch.setattr(theharvester_main.shodansearch, 'SearchShodan', FakeShodan)
+        monkeypatch.setattr(socket, 'gethostbyname', lambda _domain: '203.0.113.1')
+    else:
+        module, constructor_name = {
+            'criminalip': (theharvester_main.criminalip, 'SearchCriminalIP'),
+            'pentesttools': (theharvester_main.pentesttools, 'SearchPentestTools'),
+            'shodanInternetDB': (theharvester_main.shodan_internetdb, 'SearchShodanInternetDB'),
+            'subdomainfinderc99': (theharvester_main.subdomainfinderc99, 'SearchSubdomainfinderc99'),
+            'windvane': (theharvester_main.windvane, 'SearchWindvane'),
+        }[source]
+        monkeypatch.setattr(module, constructor_name, lambda *_args, **_kwargs: FakeAdapter())
+
+    monkeypatch.setattr(theharvester_main.stash, 'StashManager', FakeStash)
+    monkeypatch.setattr(sys, 'argv', ['theHarvester', '-d', 'example.test', '-b', source])
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    assert executions == 1
 
 
 @pytest.mark.asyncio

--- a/theHarvester/discovery/pentesttools.py
+++ b/theHarvester/discovery/pentesttools.py
@@ -80,9 +80,10 @@ class SearchPentestTools:
             if not isinstance(result, list) or len(result) < 2:
                 continue
             hostname = normalize_scoped_hostname(result[0], self.word)
-            if not hostname or hostname == self.word:
+            if not hostname:
                 continue
-            self.totalhosts.add(hostname)
+            if hostname != self.word:
+                self.totalhosts.add(hostname)
             try:
                 address = str(ip_address(result[1]))
             except (TypeError, ValueError):

--- a/theHarvester/discovery/pentesttools.py
+++ b/theHarvester/discovery/pentesttools.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 
 class SearchPentestTools:
     def __init__(self, word) -> None:
-        # Script is largely based off https://pentest-tools.com/public/api_client.py.txt
         self.word = word.strip().lower().rstrip('.')
         self.key = Core.pentest_tools_key()
         if self.key is None:
@@ -97,6 +96,8 @@ class SearchPentestTools:
         return self.totalips
 
     async def do_search(self) -> None:
+        # Pentest-Tools documents Subdomain Finder as tool 20:
+        # https://pentest-tools.com/docs/api-reference/scans/start-a-scan
         subdomain_payload = {
             'op': 'start_scan',
             'tool_id': 20,

--- a/theHarvester/discovery/pentesttools.py
+++ b/theHarvester/discovery/pentesttools.py
@@ -1,10 +1,12 @@
 import asyncio
 import logging
+from ipaddress import ip_address
 
 import ujson
 
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib.core import AsyncFetcher, Core
+from theHarvester.lib.hostnames import normalize_scoped_hostname
 
 logger = logging.getLogger(__name__)
 
@@ -12,23 +14,45 @@ logger = logging.getLogger(__name__)
 class SearchPentestTools:
     def __init__(self, word) -> None:
         # Script is largely based off https://pentest-tools.com/public/api_client.py.txt
-        self.word = word
+        self.word = word.strip().lower().rstrip('.')
         self.key = Core.pentest_tools_key()
         if self.key is None:
             raise MissingKey('PentestTools')
-        self.total_results: list = []
+        self.totalhosts: set[str] = set()
+        self.totalips: set[str] = set()
         self.api = f'https://pentest-tools.com/api?key={self.key}'
         self.proxy = False
 
+    @staticmethod
+    def _decode_response(response: object) -> dict | None:
+        if not isinstance(response, str):
+            logger.info('Pentest-Tools returned a malformed response')
+            return None
+        try:
+            decoded = ujson.loads(response.strip())
+        except ValueError:
+            logger.info('Pentest-Tools returned a malformed response')
+            return None
+        if not isinstance(decoded, dict) or not isinstance(decoded.get('op_status'), str):
+            logger.info('Pentest-Tools returned a malformed response')
+            return None
+        return decoded
+
     async def poll(self, scan_id):
-        while True:
+        for _attempt in range(10):
             await asyncio.sleep(3)
             # Get the status of our scan
             scan_status_data = {'op': 'get_scan_status', 'scan_id': scan_id}
             responses = await AsyncFetcher.post_fetch(url=self.api, data=ujson.dumps(scan_status_data), proxy=self.proxy)
-            res_json = ujson.loads(responses.strip())
+            res_json = self._decode_response(responses)
+            if res_json is None:
+                return
             if res_json['op_status'] == 'success':
-                if res_json['scan_status'] != 'waiting' and res_json['scan_status'] != 'running':
+                scan_status = res_json.get('scan_status')
+                if not isinstance(scan_status, str):
+                    logger.info('Pentest-Tools returned a malformed status response')
+                    return
+                if scan_status != 'waiting' and scan_status != 'running':
                     getoutput_data = {
                         'op': 'get_output',
                         'scan_id': scan_id,
@@ -36,25 +60,40 @@ class SearchPentestTools:
                     }
                     responses = await AsyncFetcher.post_fetch(url=self.api, data=ujson.dumps(getoutput_data), proxy=self.proxy)
 
-                    res_json = ujson.loads(responses.strip('\n'))
-                    self.total_results = await self.parse_json(res_json)
-                    break
+                    output = self._decode_response(responses)
+                    if output is not None:
+                        await self.parse_json(output)
+                    return
             else:
                 logger.info('Pentest-Tools operation get_scan_status failed')
-                break
+                return
+        logger.info('Pentest-Tools scan is still waiting after 10 status checks')
 
-    @staticmethod
-    async def parse_json(json_results):
-        status = json_results['op_status']
-        if status == 'success':
-            scan_tests = json_results['scan_output']['output_json']
-            output_data = scan_tests[0]['output_data']
-            host_to_ip = [f'{subdomain[0]}:{subdomain[1]}' for subdomain in output_data if len(subdomain) > 0]
-            return host_to_ip
-        return []
+    async def parse_json(self, json_results) -> None:
+        try:
+            output_data = json_results['scan_output']['output_json'][0]['output_data']
+        except (KeyError, IndexError, TypeError):
+            return
+        if not isinstance(output_data, list):
+            return
+        for result in output_data:
+            if not isinstance(result, list) or len(result) < 2:
+                continue
+            hostname = normalize_scoped_hostname(result[0], self.word)
+            if not hostname or hostname == self.word:
+                continue
+            self.totalhosts.add(hostname)
+            try:
+                address = str(ip_address(result[1]))
+            except (TypeError, ValueError):
+                continue
+            self.totalips.add(address)
 
-    async def get_hostnames(self) -> list:
-        return self.total_results
+    async def get_hostnames(self) -> set[str]:
+        return self.totalhosts
+
+    async def get_ips(self) -> set[str]:
+        return self.totalips
 
     async def do_search(self) -> None:
         subdomain_payload = {
@@ -67,9 +106,14 @@ class SearchPentestTools:
             },
         }
         responses = await AsyncFetcher.post_fetch(url=self.api, data=ujson.dumps(subdomain_payload), proxy=self.proxy)
-        res_json = ujson.loads(responses.strip())
+        res_json = self._decode_response(responses)
+        if res_json is None:
+            return
         if res_json['op_status'] == 'success':
-            scan_id = res_json['scan_id']
+            scan_id = res_json.get('scan_id')
+            if scan_id is None:
+                logger.info('Pentest-Tools returned a malformed start response')
+                return
             await self.poll(scan_id)
 
     async def process(self, proxy: bool = False) -> None:

--- a/theHarvester/discovery/shodan_internetdb.py
+++ b/theHarvester/discovery/shodan_internetdb.py
@@ -54,20 +54,28 @@ class SearchShodanInternetDB:
             return
 
         # Query InternetDB for each resolved IP
-        urls = [f'https://internetdb.shodan.io/{ip}' for ip in resolved_ips]
+        requested_ips = sorted(resolved_ips)
+        urls = [f'https://internetdb.shodan.io/{ip}' for ip in requested_ips]
         try:
             responses = await AsyncFetcher.fetch_all(urls, json=True, proxy=self.proxy)
         except Exception:
             logger.info('Shodan InternetDB request failed')
             return
 
-        for response in responses:
+        for requested_ip, response in zip(requested_ips, responses, strict=False):
             if not isinstance(response, dict):
                 continue
 
             # InternetDB returns a 404 as an empty JSON object or with a "detail" key
             # when no data is found for an IP. Skip those.
             if 'detail' in response:
+                continue
+
+            try:
+                response_ip = str(ip_address(response.get('ip', '')))
+            except ValueError:
+                continue
+            if response_ip != requested_ip:
                 continue
 
             # Collect hostnames that match our target domain
@@ -103,12 +111,7 @@ class SearchShodanInternetDB:
                 or response.get('tags')
                 or response.get('cpes')
             ):
-                try:
-                    response_ip = str(ip_address(response.get('ip', '')))
-                except ValueError:
-                    continue
-                if response_ip in resolved_ips:
-                    self.totalips.add(response_ip)
+                self.totalips.add(response_ip)
 
     async def get_hostnames(self) -> set:
         return self.totalhosts

--- a/theHarvester/discovery/shodan_internetdb.py
+++ b/theHarvester/discovery/shodan_internetdb.py
@@ -1,8 +1,10 @@
 import asyncio
 import logging
 import socket
+from ipaddress import ip_address
 
 from theHarvester.lib.core import AsyncFetcher
+from theHarvester.lib.hostnames import normalize_scoped_hostname
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +22,7 @@ class SearchShodanInternetDB:
     """
 
     def __init__(self, word) -> None:
-        self.word = word
+        self.word = word.strip().lower().rstrip('.')
         self.totalhosts: set = set()
         self.totalips: set = set()
         self.ports: set = set()
@@ -42,7 +44,10 @@ class SearchShodanInternetDB:
         for _family, _type, _proto, _canonname, sockaddr in addr_infos:
             ip = sockaddr[0]
             if isinstance(ip, str):
-                resolved_ips.add(ip)
+                try:
+                    resolved_ips.add(str(ip_address(ip)))
+                except ValueError:
+                    continue
 
         if not resolved_ips:
             logger.info(f'Shodan InternetDB: No IPs resolved for {self.word}')
@@ -50,7 +55,11 @@ class SearchShodanInternetDB:
 
         # Query InternetDB for each resolved IP
         urls = [f'https://internetdb.shodan.io/{ip}' for ip in resolved_ips]
-        responses = await AsyncFetcher.fetch_all(urls, json=True, proxy=self.proxy)
+        try:
+            responses = await AsyncFetcher.fetch_all(urls, json=True, proxy=self.proxy)
+        except Exception:
+            logger.info('Shodan InternetDB request failed')
+            return
 
         for response in responses:
             if not isinstance(response, dict):
@@ -63,8 +72,8 @@ class SearchShodanInternetDB:
 
             # Collect hostnames that match our target domain
             for hostname in response.get('hostnames', []):
-                if isinstance(hostname, str) and (hostname == self.word or hostname.endswith('.' + self.word)):
-                    self.totalhosts.add(hostname)
+                if normalized := normalize_scoped_hostname(hostname, self.word):
+                    self.totalhosts.add(normalized)
 
             # Collect ports
             for port in response.get('ports', []):
@@ -94,9 +103,12 @@ class SearchShodanInternetDB:
                 or response.get('tags')
                 or response.get('cpes')
             ):
-                ip_str = response.get('ip', '')
-                if ip_str:
-                    self.totalips.add(str(ip_str))
+                try:
+                    response_ip = str(ip_address(response.get('ip', '')))
+                except ValueError:
+                    continue
+                if response_ip in resolved_ips:
+                    self.totalips.add(response_ip)
 
     async def get_hostnames(self) -> set:
         return self.totalhosts

--- a/theHarvester/discovery/shodan_internetdb.py
+++ b/theHarvester/discovery/shodan_internetdb.py
@@ -77,6 +77,7 @@ class SearchShodanInternetDB:
                 continue
             if response_ip != requested_ip:
                 continue
+            self.totalips.add(response_ip)
 
             # Collect hostnames that match our target domain
             for hostname in response.get('hostnames', []):
@@ -102,16 +103,6 @@ class SearchShodanInternetDB:
             for cpe in response.get('cpes', []):
                 if isinstance(cpe, str):
                     self.cpes.add(cpe)
-
-            # Add the IP if there was any data
-            if (
-                response.get('hostnames')
-                or response.get('ports')
-                or response.get('vulns')
-                or response.get('tags')
-                or response.get('cpes')
-            ):
-                self.totalips.add(response_ip)
 
     async def get_hostnames(self) -> set:
         return self.totalhosts

--- a/theHarvester/discovery/subdomainfinderc99.py
+++ b/theHarvester/discovery/subdomainfinderc99.py
@@ -22,6 +22,8 @@ class SearchSubdomainfinderc99:
         # Based on https://gist.github.com/th3gundy/bc83580cbe04031e9164362b33600962
         headers = {'User-Agent': Core.get_user_agent()}
         resp = await AsyncFetcher.fetch_all([self.server], headers=headers, proxy=self.proxy)
+        if not resp or not isinstance(resp[0], str):
+            return
         data = await self.get_csrf_params(resp[0])
 
         data['scan_subdomains'] = ''
@@ -29,8 +31,8 @@ class SearchSubdomainfinderc99:
         data['privatequery'] = 'on'
         await asyncio.sleep(get_delay())
         second_resp = await AsyncFetcher.post_fetch(self.server, headers=headers, proxy=self.proxy, data=ujson.dumps(data))
-
-        self.totalresults += second_resp
+        if isinstance(second_resp, str):
+            self.totalresults += second_resp
 
     async def get_hostnames(self):
         rawres = myparser.Parser(self.totalresults, self.word)

--- a/theHarvester/discovery/windvane.py
+++ b/theHarvester/discovery/windvane.py
@@ -3,6 +3,7 @@ import logging
 from types import ModuleType
 
 from theHarvester.lib.core import AsyncFetcher, Core
+from theHarvester.lib.hostnames import normalize_scoped_hostname
 
 logger = logging.getLogger(__name__)
 
@@ -37,13 +38,26 @@ class SearchWindvane:
     """
 
     def __init__(self, word) -> None:
-        self.word = word
+        self.word = word.strip().lower().rstrip('.')
         self.totalhosts: set = set()
         self.totalips: set = set()
         self.totalemails: set = set()
         self.proxy = False
         self.hostname = 'https://windvane.lichoin.com/trpc.backendhub.public.WindvaneService'
         self.api_key = self._get_api_key()
+
+    def _add_host(self, value: object) -> bool:
+        if (hostname := normalize_scoped_hostname(value, self.word)) and hostname != self.word:
+            self.totalhosts.add(hostname)
+            return True
+        return False
+
+    def _add_email(self, value: object) -> None:
+        if not isinstance(value, str) or '@' not in value:
+            return
+        local_part, domain = value.rsplit('@', 1)
+        if local_part and (normalized_domain := normalize_scoped_hostname(domain, self.word)):
+            self.totalemails.add(f'{local_part.lower()}@{normalized_domain}')
 
     def _get_api_key(self) -> str | None:
         try:
@@ -109,9 +123,7 @@ class SearchWindvane:
 
                             for item in subdomains:
                                 if isinstance(item, dict):
-                                    domain = item.get('domain', '')
-                                    if domain and domain.endswith(self.word):
-                                        self.totalhosts.add(domain.lower())
+                                    self._add_host(item.get('domain'))
                         else:
                             # API error - stop pagination
                             if response_data.get('code') != 0:
@@ -148,16 +160,13 @@ class SearchWindvane:
 
                             for record in dns_records:
                                 if isinstance(record, dict):
-                                    domain = record.get('domain', '')
                                     answer = record.get('answer', '')
                                     answer_type = record.get('answer_type', '')
 
-                                    # Add subdomains
-                                    if domain and domain.endswith(self.word):
-                                        self.totalhosts.add(domain.lower())
+                                    domain_is_scoped = self._add_host(record.get('domain'))
 
                                     # Add IP addresses from A records
-                                    if answer and answer_type == 'A' and self._is_valid_ip(answer):
+                                    if domain_is_scoped and answer and answer_type == 'A' and self._is_valid_ip(answer):
                                         self.totalips.add(answer)
                         else:
                             break
@@ -187,14 +196,8 @@ class SearchWindvane:
 
                         for item in email_results:
                             if isinstance(item, dict):
-                                email = item.get('email', '')
-                                if email and self.word in email:
-                                    self.totalemails.add(email.lower())
-
-                                # Also extract domain from whois data if available
-                                domain = item.get('domain', '')
-                                if domain and domain.endswith(self.word):
-                                    self.totalhosts.add(domain.lower())
+                                self._add_email(item.get('email'))
+                                self._add_host(item.get('domain'))
 
             except Exception as e:
                 logger.info(f'Windvane email search request failed: {e}')
@@ -228,9 +231,7 @@ class SearchWindvane:
 
                         for item in subdomains:
                             if isinstance(item, dict):
-                                domain = item.get('domain', '')
-                                if domain and domain.endswith(self.word):
-                                    self.totalhosts.add(domain.lower())
+                                self._add_host(item.get('domain'))
 
                         logger.info(f'[*] Found {len(subdomains)} subdomains with limited access')
                     else:

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -104,7 +104,7 @@ _SPECS = (
     _spec('netlas', ResultRoute.SUBDOMAINS),
     _spec('onyphe', ResultRoute.SUBDOMAINS, ResultRoute.IPS, ResultRoute.ASNS),
     _spec('otx', ResultRoute.SUBDOMAINS, ResultRoute.IPS),
-    _spec('pentesttools', ResultRoute.SUBDOMAINS, activity=ActivityClass.DNS),
+    _spec('pentesttools', ResultRoute.SUBDOMAINS, ResultRoute.IPS, activity=ActivityClass.DNS),
     _spec('projectdiscovery', ResultRoute.SUBDOMAINS),
     _spec('rapiddns', ResultRoute.SUBDOMAINS, ResultRoute.IPS),
     _spec('robtex', ResultRoute.SUBDOMAINS, ResultRoute.IPS),


### PR DESCRIPTION
## Summary

Preserve direct hostname and IP evidence from PentestTools, Shodan InternetDB, SubdomainFinder C99, and Windvane without forcing those sources through a second DNS lookup.

Each adapter now exposes its declared result routes consistently, keeps provider-reported hostname/IP associations, and uses mocked provider responses in focused tests. This is independent of recursive DNS discovery.

## Verification

- 38 focused tests passed
- 459 full tests passed, 6 skipped
- Ruff check passed
- Ruff format check passed
- mypy passed
- `git diff --check` passed

This replaces the direct-provider portion of superseded draft PR #2493.
