### PR TITLE
Add DNS consensus classification

### DIFF
--- a/tests/lib/test_dns_consensus.py
+++ b/tests/lib/test_dns_consensus.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+
+from theHarvester.lib.dns_consensus import (
+    Addressability,
+    AioDNSResolverVantage,
+    DNSResponse,
+    validate_dns_candidates,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class RuleResolver:
+    def __init__(self, name: str, query: Callable[[str], DNSResponse]) -> None:
+        self.name = name
+        self._query = query
+
+    async def query(self, hostname: str) -> DNSResponse:
+        return self._query(hostname)
+
+
+@pytest.mark.asyncio
+async def test_two_resolver_vantages_establish_current_addressability() -> None:
+    candidate = 'api.example.com'
+    resolvers = (
+        RuleResolver(
+            'resolver-a',
+            lambda hostname: DNSResponse(ipv4=('192.0.2.10',)) if hostname == candidate else DNSResponse(rcode='NXDOMAIN'),
+        ),
+        RuleResolver(
+            'resolver-b',
+            lambda hostname: DNSResponse(ipv6=('2001:db8::10',)) if hostname == candidate else DNSResponse(rcode='NXDOMAIN'),
+        ),
+        RuleResolver('resolver-c', lambda _hostname: DNSResponse(rcode='NXDOMAIN')),
+    )
+
+    (result,) = await validate_dns_candidates('example.com', (candidate,), resolvers)
+
+    assert result.hostname == candidate
+    assert result.addressability is Addressability.CURRENT
+    assert result.records.ipv4 == ('192.0.2.10',)
+    assert result.records.ipv6 == ('2001:db8::10',)
+    candidate_evidence = [item for item in result.validations if item.query_name == candidate]
+    assert [item.resolver for item in candidate_evidence] == ['resolver-a', 'resolver-b', 'resolver-c']
+
+
+@pytest.mark.asyncio
+async def test_closest_encloser_wildcard_remains_secondary_evidence() -> None:
+    candidate = 'api.dev.example.com'
+
+    def nested_wildcard(hostname: str) -> DNSResponse:
+        if hostname == candidate or hostname.endswith('.dev.example.com'):
+            return DNSResponse(ipv4=('192.0.2.20',))
+        return DNSResponse(rcode='NXDOMAIN')
+
+    resolvers = tuple(RuleResolver(f'resolver-{index}', nested_wildcard) for index in range(3))
+
+    (result,) = await validate_dns_candidates('example.com', (candidate,), resolvers)
+
+    assert result.addressability is Addressability.WILDCARD_INDISTINGUISHABLE
+    controls = [item for item in result.validations if item.wildcard_depth is not None]
+    assert {item.wildcard_depth for item in controls} == {'example.com', 'dev.example.com'}
+    assert len(controls) == 18
+
+
+@pytest.mark.asyncio
+async def test_distinct_exact_answer_is_not_confused_with_wildcard_distribution() -> None:
+    candidate = 'api.dev.example.com'
+
+    def distinct_exact_answer(hostname: str) -> DNSResponse:
+        if hostname == candidate:
+            return DNSResponse(ipv4=('192.0.2.10',))
+        if hostname.endswith('.dev.example.com'):
+            return DNSResponse(ipv4=('192.0.2.99',))
+        return DNSResponse(rcode='NXDOMAIN')
+
+    resolvers = tuple(RuleResolver(f'resolver-{index}', distinct_exact_answer) for index in range(3))
+
+    (result,) = await validate_dns_candidates('example.com', (candidate,), resolvers)
+
+    assert result.addressability is Addressability.CURRENT
+
+
+@pytest.mark.asyncio
+async def test_aiodns_vantage_follows_a_bounded_cname_chain(monkeypatch: pytest.MonkeyPatch) -> None:
+    from theHarvester.lib import dns_consensus
+
+    aliases = {
+        'alias.example.com': 'Edge.Example.COM.',
+        'edge.example.com': 'Origin.Example.COM.',
+    }
+    closed: list[bool] = []
+
+    class FakeDNSResolver:
+        def __init__(self, *, nameservers: list[str]) -> None:
+            assert nameservers == ['192.0.2.53']
+
+        async def query_dns(self, hostname: str, record_type: str):
+            if record_type == 'CNAME' and hostname in aliases:
+                return SimpleNamespace(answer=[SimpleNamespace(data=SimpleNamespace(cname=aliases[hostname]))])
+            if record_type == 'A' and hostname == 'origin.example.com':
+                return SimpleNamespace(answer=[SimpleNamespace(data=SimpleNamespace(addr='192.0.2.10'))])
+            raise dns_consensus.aiodns.error.DNSError(dns_consensus.aiodns.error.ARES_ENODATA, 'no data')
+
+        async def close(self) -> None:
+            closed.append(True)
+
+    monkeypatch.setattr(dns_consensus.aiodns, 'DNSResolver', FakeDNSResolver)
+    resolver = AioDNSResolverVantage('192.0.2.53', 'example.com')
+
+    response = await resolver.query('alias.example.com')
+    await resolver.close()
+
+    assert response.ipv4 == ('192.0.2.10',)
+    assert response.cnames == ('edge.example.com', 'origin.example.com')
+    assert response.error is None
+    assert closed == [True]
+
+
+@pytest.mark.asyncio
+async def test_aiodns_vantage_does_not_follow_a_cname_outside_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    from theHarvester.lib import dns_consensus
+
+    queries: list[str] = []
+
+    class FakeDNSResolver:
+        def __init__(self, *, nameservers: list[str]) -> None:
+            assert nameservers == ['192.0.2.53']
+
+        async def query_dns(self, hostname: str, record_type: str):
+            queries.append(hostname)
+            if record_type == 'CNAME' and hostname == 'alias.example.com':
+                return SimpleNamespace(answer=[SimpleNamespace(data=SimpleNamespace(cname='external.example.net.'))])
+            raise dns_consensus.aiodns.error.DNSError(dns_consensus.aiodns.error.ARES_ENODATA, 'no data')
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(dns_consensus.aiodns, 'DNSResolver', FakeDNSResolver)
+    resolver = AioDNSResolverVantage('192.0.2.53', 'example.com')
+
+    response = await resolver.query('alias.example.com')
+
+    assert response.cnames == ('external.example.net',)
+    assert set(queries) == {'alias.example.com'}
+
+
+@pytest.mark.asyncio
+async def test_empty_target_is_rejected_before_any_dns_query() -> None:
+    queries: list[str] = []
+
+    def query(hostname: str) -> DNSResponse:
+        queries.append(hostname)
+        return DNSResponse(rcode='NXDOMAIN')
+
+    resolvers = tuple(RuleResolver(f'resolver-{index}', query) for index in range(3))
+
+    with pytest.raises(ValueError, match='target must not be empty'):
+        await validate_dns_candidates('', ('api.example.com',), resolvers)
+
+    assert queries == []
+
+
+@pytest.mark.asyncio
+async def test_resolver_vantages_must_be_canonically_distinct() -> None:
+    resolvers = (
+        RuleResolver('2001:db8::1', lambda _hostname: DNSResponse(rcode='NXDOMAIN')),
+        RuleResolver('2001:0db8:0:0:0:0:0:1', lambda _hostname: DNSResponse(rcode='NXDOMAIN')),
+        RuleResolver('192.0.2.53', lambda _hostname: DNSResponse(rcode='NXDOMAIN')),
+    )
+
+    with pytest.raises(ValueError, match='three distinct resolver vantages'):
+        await validate_dns_candidates('example.com', ('api.example.com',), resolvers)
+
+
+@pytest.mark.asyncio
+async def test_candidates_are_normalized_scoped_and_deduplicated_before_queries() -> None:
+    queries: list[str] = []
+
+    def query(hostname: str) -> DNSResponse:
+        queries.append(hostname)
+        return DNSResponse(rcode='NXDOMAIN')
+
+    resolvers = tuple(RuleResolver(f'resolver-{index}', query) for index in range(3))
+
+    results = await validate_dns_candidates(
+        'Example.COM.',
+        ('API.Example.COM.', 'api.example.com', 'outside.example.net'),
+        resolvers,
+    )
+
+    assert [result.hostname for result in results] == ['api.example.com']
+    assert queries.count('api.example.com') == 3
+
+
+@pytest.mark.asyncio
+async def test_dangling_cname_is_not_currently_addressable() -> None:
+    candidate = 'alias.example.com'
+    resolvers = tuple(
+        RuleResolver(
+            f'resolver-{index}',
+            lambda hostname: (
+                DNSResponse(cnames=('missing.vendor.test',)) if hostname == candidate else DNSResponse(rcode='NXDOMAIN')
+            ),
+        )
+        for index in range(3)
+    )
+
+    (result,) = await validate_dns_candidates('example.com', (candidate,), resolvers)
+
+    assert result.addressability is Addressability.NOT_CURRENT
+    assert result.records.cnames == ('missing.vendor.test',)

--- a/theHarvester/lib/dns_consensus.py
+++ b/theHarvester/lib/dns_consensus.py
@@ -1,3 +1,5 @@
+"""Classify hostnames by comparing three resolvers with wildcard controls."""
+
 from __future__ import annotations
 
 import asyncio
@@ -17,6 +19,8 @@ if TYPE_CHECKING:
 
 
 class Addressability(StrEnum):
+    """DNS classification assigned to a candidate hostname."""
+
     CURRENT = 'currently-addressable'
     NOT_CURRENT = 'not-currently-addressable'
     RESOLVER_DISPUTED = 'resolver-disputed'
@@ -43,6 +47,8 @@ class ResolverVantage(Protocol):
 
 
 class AioDNSResolverVantage:
+    """Query one nameserver and follow CNAMEs that remain under the target."""
+
     def __init__(self, nameserver: str, target: str) -> None:
         self.name = nameserver
         self._target = target
@@ -133,6 +139,8 @@ class DNSValidation:
 
 @dataclass(frozen=True, slots=True)
 class CandidateConsensus:
+    """Classification and resolver evidence for one candidate hostname."""
+
     hostname: str
     addressability: Addressability
     validations: tuple[DNSValidation, ...]
@@ -219,6 +227,11 @@ async def validate_dns_candidates(
     candidates: Sequence[str],
     resolvers: Sequence[ResolverVantage],
 ) -> tuple[CandidateConsensus, ...]:
+    """Compare each in-scope candidate with randomized wildcard controls.
+
+    A candidate is current when at least two of the three resolvers return an
+    address and its records do not match the closest wildcard control.
+    """
     normalized_target = target.strip().lower().rstrip('.')
     if not normalized_target:
         raise ValueError('target must not be empty')

--- a/theHarvester/lib/dns_consensus.py
+++ b/theHarvester/lib/dns_consensus.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Protocol
+from uuid import uuid4
+
+import aiodns
+
+from theHarvester.lib.hostchecker import HostDnsRecords
+from theHarvester.lib.hostnames import normalize_scoped_hostname
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class Addressability(StrEnum):
+    CURRENT = 'currently-addressable'
+    NOT_CURRENT = 'not-currently-addressable'
+    RESOLVER_DISPUTED = 'resolver-disputed'
+    WILDCARD_INDISTINGUISHABLE = 'wildcard-indistinguishable'
+
+
+@dataclass(frozen=True, slots=True)
+class DNSResponse:
+    ipv4: tuple[str, ...] = ()
+    ipv6: tuple[str, ...] = ()
+    cnames: tuple[str, ...] = ()
+    rcode: str = 'NOERROR'
+    error: str | None = None
+
+    @property
+    def records(self) -> HostDnsRecords:
+        return HostDnsRecords(self.ipv4, self.ipv6, self.cnames)
+
+
+class ResolverVantage(Protocol):
+    name: str
+
+    async def query(self, hostname: str) -> DNSResponse: ...
+
+
+class AioDNSResolverVantage:
+    def __init__(self, nameserver: str, target: str) -> None:
+        self.name = nameserver
+        self._target = target
+        self._resolver = aiodns.DNSResolver(nameservers=[nameserver])
+
+    async def query(self, hostname: str) -> DNSResponse:
+        current = hostname.strip().lower().rstrip('.')
+        seen = {current}
+        ipv4: set[str] = set()
+        ipv6: set[str] = set()
+        cnames: list[str] = []
+        dns_errors: list[int] = []
+        errors: list[str] = []
+        successful_query = False
+        for _ in range(16):
+            results = await asyncio.gather(
+                *(self._resolver.query_dns(current, record_type) for record_type in ('A', 'AAAA', 'CNAME')),
+                return_exceptions=True,
+            )
+            next_cnames: list[str] = []
+            for record_type, result in zip(('A', 'AAAA', 'CNAME'), results, strict=True):
+                if isinstance(result, asyncio.CancelledError):
+                    raise result
+                if isinstance(result, BaseException):
+                    if isinstance(result, aiodns.error.DNSError):
+                        dns_errors.append(result.args[0])
+                        if result.args[0] in {aiodns.error.ARES_ENOTFOUND, aiodns.error.ARES_ENODATA}:
+                            continue
+                    errors.append(type(result).__name__)
+                    continue
+                successful_query = True
+                for record in result.answer:
+                    if record_type == 'CNAME':
+                        value = getattr(record.data, 'cname', None)
+                        if isinstance(value, str) and (normalized := value.strip().lower().rstrip('.')):
+                            next_cnames.append(normalized)
+                        continue
+                    value = getattr(record.data, 'addr', None)
+                    if not isinstance(value, str):
+                        continue
+                    try:
+                        address = ipaddress.ip_address(value)
+                    except ValueError:
+                        continue
+                    if address.version == (4 if record_type == 'A' else 6):
+                        (ipv4 if address.version == 4 else ipv6).add(str(address))
+            if not next_cnames:
+                break
+            for cname in next_cnames:
+                if cname not in cnames:
+                    cnames.append(cname)
+            current = next_cnames[-1]
+            if normalize_scoped_hostname(current, self._target) is None:
+                break
+            if current in seen:
+                errors.append(f'CNAME loop detected at {current}')
+                break
+            seen.add(current)
+        else:
+            errors.append('CNAME chain exceeded 16 links')
+        if successful_query:
+            rcode = 'NOERROR'
+        elif dns_errors and all(code == aiodns.error.ARES_ENOTFOUND for code in dns_errors):
+            rcode = 'NXDOMAIN'
+        elif dns_errors and all(code in {aiodns.error.ARES_ENOTFOUND, aiodns.error.ARES_ENODATA} for code in dns_errors):
+            rcode = 'NODATA'
+        else:
+            rcode = 'ERROR'
+        return DNSResponse(
+            ipv4=tuple(sorted(ipv4)),
+            ipv6=tuple(sorted(ipv6)),
+            cnames=tuple(cnames),
+            rcode=rcode,
+            error='; '.join(errors) or None,
+        )
+
+    async def close(self) -> None:
+        await self._resolver.close()
+
+
+@dataclass(frozen=True, slots=True)
+class DNSValidation:
+    query_name: str
+    resolver: str
+    response: DNSResponse
+    wildcard_depth: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateConsensus:
+    hostname: str
+    addressability: Addressability
+    validations: tuple[DNSValidation, ...]
+
+    @property
+    def records(self) -> HostDnsRecords:
+        candidate_responses = (item.response for item in self.validations if item.wildcard_depth is None)
+        return HostDnsRecords(
+            ipv4=tuple(sorted({value for response in candidate_responses for value in response.ipv4})),
+            ipv6=tuple(
+                sorted({value for item in self.validations if item.wildcard_depth is None for value in item.response.ipv6})
+            ),
+            cnames=tuple(
+                sorted({value for item in self.validations if item.wildcard_depth is None for value in item.response.cnames})
+            ),
+        )
+
+
+def _normalize_response(response: DNSResponse) -> DNSResponse:
+    return DNSResponse(
+        ipv4=tuple(sorted({str(ipaddress.IPv4Address(value)) for value in response.ipv4})),
+        ipv6=tuple(sorted({str(ipaddress.IPv6Address(value)) for value in response.ipv6})),
+        cnames=tuple(sorted({value.strip().lower().rstrip('.') for value in response.cnames if value.strip()})),
+        rcode=response.rcode.upper(),
+        error=response.error,
+    )
+
+
+async def _query(
+    query_name: str,
+    resolver: ResolverVantage,
+    *,
+    wildcard_depth: str | None = None,
+) -> DNSValidation:
+    try:
+        response = _normalize_response(await resolver.query(query_name))
+    except asyncio.CancelledError:
+        raise
+    except Exception as error:
+        response = DNSResponse(rcode='ERROR', error=type(error).__name__)
+    return DNSValidation(query_name, resolver.name, response, wildcard_depth)
+
+
+def _wildcard_depths(target: str, candidate: str) -> tuple[str, ...]:
+    target_labels = target.split('.')
+    candidate_labels = candidate.split('.')
+    extra_label_count = len(candidate_labels) - len(target_labels)
+    return (target, *('.'.join(candidate_labels[index:]) for index in range(extra_label_count - 1, 0, -1)))
+
+
+def _has_records(validation: DNSValidation) -> bool:
+    return bool(validation.response.records.addresses or validation.response.records.cnames)
+
+
+def _has_address(validation: DNSValidation) -> bool:
+    return bool(validation.response.records.addresses)
+
+
+def _response_signature(validation: DNSValidation) -> HostDnsRecords:
+    return validation.response.records
+
+
+def _classify(validations: Sequence[DNSValidation]) -> Addressability:
+    candidates = tuple(item for item in validations if item.wildcard_depth is None)
+    controls = tuple(item for item in validations if item.wildcard_depth is not None)
+    closest_depth = max((item.wildcard_depth for item in controls if item.wildcard_depth), key=lambda value: value.count('.'))
+    candidate_signatures = {_response_signature(item) for item in candidates if _has_records(item)}
+    control_signatures = {
+        _response_signature(item) for item in controls if item.wildcard_depth == closest_depth and _has_records(item)
+    }
+    if candidate_signatures & control_signatures:
+        return Addressability.WILDCARD_INDISTINGUISHABLE
+    if sum(map(_has_address, candidates)) >= 2:
+        return Addressability.CURRENT
+    negatives = sum(
+        not _has_address(item) and item.response.error is None and item.response.rcode in {'NOERROR', 'NXDOMAIN', 'NODATA'}
+        for item in candidates
+    )
+    return Addressability.NOT_CURRENT if negatives >= 2 else Addressability.RESOLVER_DISPUTED
+
+
+async def validate_dns_candidates(
+    target: str,
+    candidates: Sequence[str],
+    resolvers: Sequence[ResolverVantage],
+) -> tuple[CandidateConsensus, ...]:
+    normalized_target = target.strip().lower().rstrip('.')
+    if not normalized_target:
+        raise ValueError('target must not be empty')
+    resolver_identities = []
+    for resolver in resolvers:
+        try:
+            resolver_identities.append(str(ipaddress.ip_address(resolver.name)))
+        except ValueError:
+            resolver_identities.append(resolver.name)
+    if len(resolvers) != 3 or len(set(resolver_identities)) != 3:
+        raise ValueError('DNS consensus requires exactly three distinct resolver vantages')
+    results: list[CandidateConsensus] = []
+    normalized_candidates = tuple(
+        dict.fromkeys(
+            candidate for value in candidates if (candidate := normalize_scoped_hostname(value, normalized_target)) is not None
+        )
+    )
+    for candidate in normalized_candidates:
+        controls = tuple(
+            (f'th-{uuid4().hex}.{depth}', depth) for depth in _wildcard_depths(normalized_target, candidate) for _ in range(3)
+        )
+        validations = tuple(
+            await asyncio.gather(
+                *(_query(candidate, resolver) for resolver in resolvers),
+                *(_query(query_name, resolver, wildcard_depth=depth) for query_name, depth in controls for resolver in resolvers),
+            )
+        )
+        results.append(CandidateConsensus(candidate, _classify(validations), validations))
+    return tuple(results)


### PR DESCRIPTION
## Summary

Add the DNS evidence classifier used by the bounded recursive-DNS stack.

For each candidate hostname, it queries three distinct resolver vantages and compares the result with randomized wildcard controls at the closest enclosing DNS depth. The result is one of:

- currently addressable
- not currently addressable
- resolver disputed
- wildcard indistinguishable

This is the first layer of the recursive-DNS stack. It has no CLI behavior by itself. The dependent engine, CLI/persistence, and REST layers remain on separate origin branches so this diff stays reviewable.

## Why three resolvers and wildcard controls

A single positive answer can be a wildcard, and a single negative answer can be a resolver-specific or transient failure. Requiring two address-positive vantages for a current result reduces both false positives and false negatives while retaining disputed evidence instead of silently discarding it.

## Verification

- 9 focused tests passed
- 440 full tests passed, 6 skipped
- Ruff check passed on the complete stack
- Ruff format check passed on the complete stack
- mypy passed on the complete stack
- `git diff --check` passed

The complete stack was also exercised against the authorized `mozilla.org` target. With seeds `www.mozilla.org`, `support.mozilla.org`, and `addons.mozilla.org`, and labels `api`, `dev`, `stage`, and `www`, it found `www.support.mozilla.org` as currently addressable while stopping at the configured depth.

This replaces the consensus portion of superseded draft PR #2493.
