### PR TITLE
Honor explicit DNS resolution for RapidDNS

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 
@@ -18,6 +19,80 @@ def test_normalize_hosts_for_storage_uses_the_parser_scope(target: str) -> None:
     }
 
     assert theharvester_main._normalize_hosts_for_storage(discovered_hosts, target) == {'api.example.com'}
+
+
+@pytest.mark.asyncio
+async def test_rapiddns_hostnames_honor_explicit_dns_resolution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    completed: list[CompletedResult] = []
+    output_path = tmp_path / 'rapiddns'
+
+    class FakeStash:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args) -> None:
+            return None
+
+        async def store(self, *_args) -> None:
+            return None
+
+        async def store_completed_result(self, result: CompletedResult) -> None:
+            completed.append(result)
+
+    class FakeRapidDNS:
+        def __init__(self, _word: str) -> None:
+            pass
+
+        async def process(self, _proxy: bool) -> None:
+            return None
+
+        async def get_hostnames(self) -> set[str]:
+            return {'api.example.com', 'reported.example.com'}
+
+        async def get_host_ip_pairs(self) -> set[tuple[str, str]]:
+            return {('reported.example.com', '192.0.2.20')}
+
+        async def get_ips(self) -> set[str]:
+            return {'192.0.2.20'}
+
+    class FakeChecker:
+        def __init__(self, hosts: list[str], nameservers: list[str]) -> None:
+            assert hosts == ['api.example.com']
+            assert nameservers == ['192.0.2.53']
+
+        async def check(self) -> tuple[list[str], list[str], list[str]]:
+            return ['api.example.com:192.0.2.10'], ['api.example.com'], ['192.0.2.10']
+
+    monkeypatch.setattr(theharvester_main.stash, 'StashManager', FakeStash)
+    monkeypatch.setattr(theharvester_main.rapiddns, 'SearchRapidDns', FakeRapidDNS)
+    monkeypatch.setattr(theharvester_main.hostchecker, 'Checker', FakeChecker)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'theHarvester',
+            '-d',
+            'example.com',
+            '-b',
+            'rapiddns',
+            '-r',
+            '192.0.2.53',
+            '-f',
+            str(output_path),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    assert ('hostname', 'api.example.com') in completed[0].results
+    assert ('hostname', 'reported.example.com') in completed[0].results
+    assert ('ip-address', '192.0.2.10') in completed[0].results
+    assert ('ip-address', '192.0.2.20') in completed[0].results
+    assert 'reported.example.com' in json.loads(output_path.with_suffix('.json').read_text())['hosts']
 
 
 @pytest.mark.asyncio

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -393,18 +393,22 @@ async def start(
         if ResultRoute.SUBDOMAINS in routes:
             discovered_hosts = await search_engine.get_hostnames()
             host_names = list(_normalize_hosts_for_storage(discovered_hosts, word))
+            paired_hosts: set[str] = set()
             if source == 'rapiddns':
                 for host, address in await search_engine.get_host_ip_pairs():
                     normalized = normalize_scoped_hostname(host, word)
                     if normalized and normalized in host_names:
+                        paired_hosts.add(normalized)
                         reported_host_ip_pairs.add((normalized, address))
-                full.extend(host_names)
-            elif source != 'hackertarget' and source != 'pentesttools':
+
+            if source != 'hackertarget' and source != 'pentesttools':
                 # If a source is inside this conditional, it means the hosts returned must be resolved to obtain ip
                 # This should only be checked if --dns-resolve has a wordlist
                 if dnsresolve is None or len(final_dns_resolver_list) > 0:
                     # indicates that -r was passed in if dnsresolve is None
-                    full_hosts_checker = hostchecker.Checker(host_names, final_dns_resolver_list)
+                    full_hosts_checker = hostchecker.Checker(
+                        [host for host in host_names if host not in paired_hosts], final_dns_resolver_list
+                    )
                     # If full, this is only getting resolved hosts
                     (
                         resolved_pair,
@@ -413,6 +417,8 @@ async def start(
                     ) = await full_hosts_checker.check()
                     all_ip.extend(temp_ips)
                     full.extend(resolved_pair)
+                    if source == 'rapiddns':
+                        full.extend(host for host in host_names if host not in resolved_hosts)
                     resolved_screenshot_hosts.update(resolved_hosts)
                 else:
                     full.extend(host_names)


### PR DESCRIPTION
## Summary

Honor explicit `--dns-resolve` requests for RapidDNS results.

RapidDNS can return both provider-paired hostname/IP rows and hostname-only rows. The CLI now preserves provider pairs, skips redundant lookups for those paired hosts, and sends only hostname-only results through the existing DNS checker. Resolved results and provider evidence both remain available in completed results and legacy JSON output.

## Verification

- Red test reproduced the missing resolved IP
- 18 focused tests passed
- 432 full tests passed, 6 skipped
- Ruff check passed
- Ruff format check passed
- mypy passed
- `git diff --check` passed
- Standards review: no findings
- Spec review: no findings

This fix is independent of recursive DNS discovery.
