### PR TITLE
Add exact DNS query budgets and PTR lookups

### DIFF
--- a/tests/lib/test_dns_consensus.py
+++ b/tests/lib/test_dns_consensus.py
@@ -152,6 +152,37 @@ async def test_aiodns_vantage_does_not_follow_a_cname_outside_scope(monkeypatch:
 
 
 @pytest.mark.asyncio
+async def test_aiodns_vantage_returns_normalized_ptr_evidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    from theHarvester.lib import dns_consensus
+
+    queries: list[tuple[str, str]] = []
+
+    class FakeDNSResolver:
+        def __init__(self, *, nameservers: list[str]) -> None:
+            assert nameservers == ['192.0.2.53']
+
+        async def query_dns(self, hostname: str, record_type: str):
+            queries.append((hostname, record_type))
+            return SimpleNamespace(
+                answer=[
+                    SimpleNamespace(data=SimpleNamespace(dname='Mail.Example.COM.')),
+                    SimpleNamespace(data=SimpleNamespace(dname='mail.example.com')),
+                ]
+            )
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(dns_consensus.aiodns, 'DNSResolver', FakeDNSResolver)
+    resolver = AioDNSResolverVantage('192.0.2.53', 'example.com')
+
+    ptrs = await resolver.query_ptr('192.0.2.10')
+
+    assert queries == [('10.2.0.192.in-addr.arpa', 'PTR')]
+    assert ptrs == ('mail.example.com',)
+
+
+@pytest.mark.asyncio
 async def test_empty_target_is_rejected_before_any_dns_query() -> None:
     queries: list[str] = []
 

--- a/tests/lib/test_dns_consensus.py
+++ b/tests/lib/test_dns_consensus.py
@@ -8,6 +8,7 @@ import pytest
 from theHarvester.lib.dns_consensus import (
     Addressability,
     AioDNSResolverVantage,
+    DNSQueryBudget,
     DNSResponse,
     validate_dns_candidates,
 )
@@ -121,6 +122,42 @@ async def test_aiodns_vantage_follows_a_bounded_cname_chain(monkeypatch: pytest.
     assert response.cnames == ('edge.example.com', 'origin.example.com')
     assert response.error is None
     assert closed == [True]
+
+
+@pytest.mark.asyncio
+async def test_aiodns_vantage_stops_before_exceeding_cname_query_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    from theHarvester.lib import dns_consensus
+
+    queries: list[tuple[str, str]] = []
+
+    class FakeDNSResolver:
+        def __init__(self, *, nameservers: list[str]) -> None:
+            assert nameservers == ['192.0.2.53']
+
+        async def query_dns(self, hostname: str, record_type: str):
+            queries.append((hostname, record_type))
+            if record_type == 'CNAME':
+                return SimpleNamespace(answer=[SimpleNamespace(data=SimpleNamespace(cname='edge.example.com'))])
+            raise dns_consensus.aiodns.error.DNSError(dns_consensus.aiodns.error.ARES_ENODATA, 'no data')
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(dns_consensus.aiodns, 'DNSResolver', FakeDNSResolver)
+    resolver = AioDNSResolverVantage('192.0.2.53', 'example.com')
+    budget = DNSQueryBudget(3)
+
+    response = await resolver.query('alias.example.com', budget)
+
+    assert queries == [
+        ('alias.example.com', 'A'),
+        ('alias.example.com', 'AAAA'),
+        ('alias.example.com', 'CNAME'),
+    ]
+    assert response.cnames == ('edge.example.com',)
+    assert response.error == 'query-limit'
+    assert budget.used == 3
+    assert budget.blocked
 
 
 @pytest.mark.asyncio

--- a/tests/lib/test_dns_consensus.py
+++ b/tests/lib/test_dns_consensus.py
@@ -10,6 +10,7 @@ from theHarvester.lib.dns_consensus import (
     AioDNSResolverVantage,
     DNSQueryBudget,
     DNSResponse,
+    ResolverVantage,
     validate_dns_candidates,
 )
 
@@ -24,6 +25,10 @@ class RuleResolver:
 
     async def query(self, hostname: str) -> DNSResponse:
         return self._query(hostname)
+
+
+if TYPE_CHECKING:
+    legacy_resolver: ResolverVantage = RuleResolver('resolver', lambda _hostname: DNSResponse())
 
 
 @pytest.mark.asyncio
@@ -86,6 +91,28 @@ async def test_distinct_exact_answer_is_not_confused_with_wildcard_distribution(
     (result,) = await validate_dns_candidates('example.com', (candidate,), resolvers)
 
     assert result.addressability is Addressability.CURRENT
+
+
+@pytest.mark.asyncio
+async def test_exhausted_budget_cannot_classify_incomplete_validation_as_current() -> None:
+    candidate = 'api.example.com'
+    budget = DNSQueryBudget(3)
+
+    class BudgetedResolver:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        async def query(self, hostname: str, query_budget: DNSQueryBudget | None = None) -> DNSResponse:
+            if query_budget is not None and not query_budget.consume(1):
+                return DNSResponse(error='query-limit')
+            return DNSResponse(ipv4=('192.0.2.10',)) if hostname == candidate else DNSResponse(rcode='NXDOMAIN')
+
+    resolvers = tuple(BudgetedResolver(f'resolver-{index}') for index in range(3))
+
+    (result,) = await validate_dns_candidates('example.com', (candidate,), resolvers, budget=budget)
+
+    assert budget.blocked
+    assert result.addressability is Addressability.RESOLVER_DISPUTED
 
 
 @pytest.mark.asyncio
@@ -217,6 +244,29 @@ async def test_aiodns_vantage_returns_normalized_ptr_evidence(monkeypatch: pytes
 
     assert queries == [('10.2.0.192.in-addr.arpa', 'PTR')]
     assert ptrs == ('mail.example.com',)
+
+
+@pytest.mark.asyncio
+async def test_invalid_ptr_address_does_not_consume_query_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    from theHarvester.lib import dns_consensus
+
+    class FakeDNSResolver:
+        def __init__(self, *, nameservers: list[str]) -> None:
+            assert nameservers == ['192.0.2.53']
+
+        async def query_dns(self, _hostname: str, _record_type: str):
+            pytest.fail('invalid input must not issue a DNS query')
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(dns_consensus.aiodns, 'DNSResolver', FakeDNSResolver)
+    resolver = AioDNSResolverVantage('192.0.2.53', 'example.com')
+    budget = DNSQueryBudget(1)
+
+    assert await resolver.query_ptr('not-an-ip', budget) == ()
+    assert budget.used == 0
+    assert not budget.blocked
 
 
 @pytest.mark.asyncio

--- a/theHarvester/lib/dns_consensus.py
+++ b/theHarvester/lib/dns_consensus.py
@@ -45,6 +45,8 @@ class ResolverVantage(Protocol):
 
     async def query(self, hostname: str) -> DNSResponse: ...
 
+    async def query_ptr(self, address: str) -> tuple[str, ...]: ...
+
 
 class AioDNSResolverVantage:
     """Query one nameserver and follow CNAMEs that remain under the target."""
@@ -123,6 +125,24 @@ class AioDNSResolverVantage:
             cnames=tuple(cnames),
             rcode=rcode,
             error='; '.join(errors) or None,
+        )
+
+    async def query_ptr(self, address: str) -> tuple[str, ...]:
+        try:
+            result = await self._resolver.query_dns(ipaddress.ip_address(address).reverse_pointer, 'PTR')
+        except asyncio.CancelledError:
+            raise
+        except (ValueError, aiodns.error.DNSError):
+            return ()
+        return tuple(
+            sorted(
+                {
+                    normalized
+                    for record in result.answer
+                    if isinstance(value := getattr(record.data, 'dname', None), str)
+                    and (normalized := value.strip().lower().rstrip('.'))
+                }
+            )
         )
 
     async def close(self) -> None:

--- a/theHarvester/lib/dns_consensus.py
+++ b/theHarvester/lib/dns_consensus.py
@@ -27,6 +27,26 @@ class Addressability(StrEnum):
     WILDCARD_INDISTINGUISHABLE = 'wildcard-indistinguishable'
 
 
+@dataclass(slots=True)
+class DNSQueryBudget:
+    limit: int
+    used: int = 0
+    blocked: bool = False
+
+    def __post_init__(self) -> None:
+        if self.limit <= 0:
+            raise ValueError('DNS query budget must be greater than zero')
+
+    def consume(self, count: int) -> bool:
+        if count <= 0:
+            raise ValueError('DNS query count must be greater than zero')
+        if self.used + count > self.limit:
+            self.blocked = True
+            return False
+        self.used += count
+        return True
+
+
 @dataclass(frozen=True, slots=True)
 class DNSResponse:
     ipv4: tuple[str, ...] = ()
@@ -43,9 +63,9 @@ class DNSResponse:
 class ResolverVantage(Protocol):
     name: str
 
-    async def query(self, hostname: str) -> DNSResponse: ...
+    async def query(self, hostname: str, budget: DNSQueryBudget | None = None) -> DNSResponse: ...
 
-    async def query_ptr(self, address: str) -> tuple[str, ...]: ...
+    async def query_ptr(self, address: str, budget: DNSQueryBudget | None = None) -> tuple[str, ...]: ...
 
 
 class AioDNSResolverVantage:
@@ -56,7 +76,7 @@ class AioDNSResolverVantage:
         self._target = target
         self._resolver = aiodns.DNSResolver(nameservers=[nameserver])
 
-    async def query(self, hostname: str) -> DNSResponse:
+    async def query(self, hostname: str, budget: DNSQueryBudget | None = None) -> DNSResponse:
         current = hostname.strip().lower().rstrip('.')
         seen = {current}
         ipv4: set[str] = set()
@@ -66,6 +86,9 @@ class AioDNSResolverVantage:
         errors: list[str] = []
         successful_query = False
         for _ in range(16):
+            if budget is not None and not budget.consume(3):
+                errors.append('query-limit')
+                break
             results = await asyncio.gather(
                 *(self._resolver.query_dns(current, record_type) for record_type in ('A', 'AAAA', 'CNAME')),
                 return_exceptions=True,
@@ -127,7 +150,9 @@ class AioDNSResolverVantage:
             error='; '.join(errors) or None,
         )
 
-    async def query_ptr(self, address: str) -> tuple[str, ...]:
+    async def query_ptr(self, address: str, budget: DNSQueryBudget | None = None) -> tuple[str, ...]:
+        if budget is not None and not budget.consume(1):
+            return ()
         try:
             result = await self._resolver.query_dns(ipaddress.ip_address(address).reverse_pointer, 'PTR')
         except asyncio.CancelledError:
@@ -194,9 +219,12 @@ async def _query(
     resolver: ResolverVantage,
     *,
     wildcard_depth: str | None = None,
+    budget: DNSQueryBudget | None = None,
 ) -> DNSValidation:
     try:
-        response = _normalize_response(await resolver.query(query_name))
+        response = _normalize_response(
+            await (resolver.query(query_name) if budget is None else resolver.query(query_name, budget))
+        )
     except asyncio.CancelledError:
         raise
     except Exception as error:
@@ -246,6 +274,8 @@ async def validate_dns_candidates(
     target: str,
     candidates: Sequence[str],
     resolvers: Sequence[ResolverVantage],
+    *,
+    budget: DNSQueryBudget | None = None,
 ) -> tuple[CandidateConsensus, ...]:
     """Compare each in-scope candidate with randomized wildcard controls.
 
@@ -275,8 +305,12 @@ async def validate_dns_candidates(
         )
         validations = tuple(
             await asyncio.gather(
-                *(_query(candidate, resolver) for resolver in resolvers),
-                *(_query(query_name, resolver, wildcard_depth=depth) for query_name, depth in controls for resolver in resolvers),
+                *(_query(candidate, resolver, budget=budget) for resolver in resolvers),
+                *(
+                    _query(query_name, resolver, wildcard_depth=depth, budget=budget)
+                    for query_name, depth in controls
+                    for resolver in resolvers
+                ),
             )
         )
         results.append(CandidateConsensus(candidate, _classify(validations), validations))

--- a/theHarvester/lib/dns_consensus.py
+++ b/theHarvester/lib/dns_consensus.py
@@ -6,7 +6,7 @@ import asyncio
 import ipaddress
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, cast
 from uuid import uuid4
 
 import aiodns
@@ -63,6 +63,10 @@ class DNSResponse:
 class ResolverVantage(Protocol):
     name: str
 
+    async def query(self, hostname: str) -> DNSResponse: ...
+
+
+class BudgetedResolverVantage(ResolverVantage, Protocol):
     async def query(self, hostname: str, budget: DNSQueryBudget | None = None) -> DNSResponse: ...
 
     async def query_ptr(self, address: str, budget: DNSQueryBudget | None = None) -> tuple[str, ...]: ...
@@ -151,13 +155,17 @@ class AioDNSResolverVantage:
         )
 
     async def query_ptr(self, address: str, budget: DNSQueryBudget | None = None) -> tuple[str, ...]:
+        try:
+            reverse_pointer = ipaddress.ip_address(address).reverse_pointer
+        except ValueError:
+            return ()
         if budget is not None and not budget.consume(1):
             return ()
         try:
-            result = await self._resolver.query_dns(ipaddress.ip_address(address).reverse_pointer, 'PTR')
+            result = await self._resolver.query_dns(reverse_pointer, 'PTR')
         except asyncio.CancelledError:
             raise
-        except (ValueError, aiodns.error.DNSError):
+        except aiodns.error.DNSError:
             return ()
         return tuple(
             sorted(
@@ -222,9 +230,11 @@ async def _query(
     budget: DNSQueryBudget | None = None,
 ) -> DNSValidation:
     try:
-        response = _normalize_response(
-            await (resolver.query(query_name) if budget is None else resolver.query(query_name, budget))
-        )
+        if budget is None:
+            response = await resolver.query(query_name)
+        else:
+            response = await cast('BudgetedResolverVantage', resolver).query(query_name, budget)
+        response = _normalize_response(response)
     except asyncio.CancelledError:
         raise
     except Exception as error:
@@ -313,5 +323,6 @@ async def validate_dns_candidates(
                 ),
             )
         )
-        results.append(CandidateConsensus(candidate, _classify(validations), validations))
+        addressability = Addressability.RESOLVER_DISPUTED if budget is not None and budget.blocked else _classify(validations)
+        results.append(CandidateConsensus(candidate, addressability, validations))
     return tuple(results)


### PR DESCRIPTION
## Summary

- add a shared hard query budget for A, AAAA, and CNAME hops
- fail closed as resolver-disputed when budget exhaustion leaves wildcard validation incomplete
- add normalized PTR lookups that consume budget only when a DNS query is issued
- preserve the existing one-argument resolver protocol and isolate budget/PTR behavior in a separate protocol

This PR is the DNS foundation only. It does not include the recursive engine, CLI, REST, provider migrations, or output changes.

## Verification

- 13 focused DNS consensus tests
- 480 full tests passed, 6 skipped
- Ruff check and format check
- mypy, including the legacy resolver compatibility check
- git diff --check
- zero added em dashes
- parallel Standards and Spec reviews with no findings

A bounded live smoke against mozilla.org used exactly four queries: A, AAAA, CNAME, and PTR. It returned 35.190.14.201, one IPv6 result, and PTR 201.14.190.35.bc.googleusercontent.com without blocking the budget.