### PR TITLE
Add bounded recursive DNS discovery engine

### DIFF
--- a/tests/lib/test_recursive_dns.py
+++ b/tests/lib/test_recursive_dns.py
@@ -73,6 +73,12 @@ class CnameHeavyResolver:
         return () if not budget.consume(1) else ('edge.example.net',)
 
 
+@pytest.mark.parametrize('runtime_seconds', [float('nan'), float('inf')])
+def test_recursive_dns_limits_require_a_finite_runtime(runtime_seconds: float) -> None:
+    with pytest.raises(ValueError, match='runtime'):
+        RecursiveDNSLimits(depth=1, query_limit=100, runtime_seconds=runtime_seconds)
+
+
 @pytest.mark.asyncio
 async def test_seed_normalization_stops_at_runtime_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
     from theHarvester.lib import recursive_dns

--- a/tests/lib/test_recursive_dns.py
+++ b/tests/lib/test_recursive_dns.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -70,6 +71,40 @@ class CnameHeavyResolver:
     async def query_ptr(self, _address: str, budget: DNSQueryBudget | None = None) -> tuple[str, ...]:
         assert budget is not None
         return () if not budget.consume(1) else ('edge.example.net',)
+
+
+@pytest.mark.asyncio
+async def test_seed_normalization_stops_at_runtime_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    from theHarvester.lib import recursive_dns
+
+    class GuardedSeeds(list[str]):
+        def __init__(self) -> None:
+            super().__init__(('api.example.com', 'unused.example.com'))
+            self.consumed = 0
+
+        def __iter__(self):
+            for value in super().__iter__():
+                self.consumed += 1
+                if self.consumed > 1:
+                    pytest.fail('seeds beyond the runtime limit must remain unconsumed')
+                yield value
+
+    seeds = GuardedSeeds()
+    times = iter((0.0, 1.0))
+    monkeypatch.setattr(recursive_dns, 'time', SimpleNamespace(monotonic=lambda: next(times)))
+    resolvers = tuple(FakeResolver(f'resolver-{index}', set()) for index in range(3))
+
+    result = await discover_recursive_dns(
+        'example.com',
+        seeds,
+        ('dev',),
+        resolvers,
+        RecursiveDNSLimits(depth=1, query_limit=100, runtime_seconds=0.5),
+    )
+
+    assert seeds.consumed == 1
+    assert result.query_count == 0
+    assert result.stop_reason == 'runtime-limit'
 
 
 @pytest.mark.asyncio
@@ -146,6 +181,7 @@ async def test_recursive_dns_does_not_exceed_query_limit_for_ptrs() -> None:
     assert result.findings[0].hostname == 'dev.api.example.com'
     assert result.findings[0].ptrs == ()
     assert result.query_count == 99
+    assert result.depth_reached == 1
     assert result.stop_reason == 'query-limit'
 
 
@@ -203,19 +239,50 @@ async def test_recursive_dns_runtime_limit_cancels_pending_queries() -> None:
 
 @pytest.mark.asyncio
 async def test_recursive_dns_stops_after_three_zero_yield_batches() -> None:
+    class GuardedLabels(list[str]):
+        def __init__(self) -> None:
+            super().__init__(f'unused{index}' for index in range(1_000))
+            self.consumed = 0
+
+        def __iter__(self):
+            for value in super().__iter__():
+                self.consumed += 1
+                if self.consumed > 150:
+                    pytest.fail('labels beyond the zero-yield stop must remain lazy')
+                yield value
+
+    current = {'api.example.com'}
+    resolvers = tuple(FakeResolver(f'resolver-{index}', current) for index in range(3))
+    labels = GuardedLabels()
+
+    result = await discover_recursive_dns(
+        'example.com',
+        ('api.example.com',),
+        labels,
+        resolvers,
+        RecursiveDNSLimits(depth=1, query_limit=10_000, runtime_seconds=5),
+    )
+
+    assert labels.consumed == 150
+    assert result.findings == ()
+    assert result.query_count == 9_486
+    assert result.depth_reached == 1
+    assert result.zero_yield_batches == 3
+    assert result.stop_reason == 'zero-yield'
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_does_not_reach_a_depth_without_labels() -> None:
     current = {'api.example.com'}
     resolvers = tuple(FakeResolver(f'resolver-{index}', current) for index in range(3))
 
     result = await discover_recursive_dns(
         'example.com',
         ('api.example.com',),
-        tuple(f'unused{index}' for index in range(151)),
+        (),
         resolvers,
-        RecursiveDNSLimits(depth=1, query_limit=10_000, runtime_seconds=5),
+        RecursiveDNSLimits(depth=1, query_limit=100, runtime_seconds=5),
     )
 
-    assert result.findings == ()
-    assert result.query_count == 9_486
     assert result.depth_reached == 0
-    assert result.zero_yield_batches == 3
-    assert result.stop_reason == 'zero-yield'
+    assert result.stop_reason == 'frontier-exhausted'

--- a/tests/lib/test_recursive_dns.py
+++ b/tests/lib/test_recursive_dns.py
@@ -30,6 +30,9 @@ class FakeResolver:
             return DNSResponse(rcode='NODATA')
         return DNSResponse(rcode='NXDOMAIN')
 
+    async def query_ptr(self, address: str) -> tuple[str, ...]:
+        return ('edge.example.net',) if address == '192.0.2.10' else ()
+
 
 class BlockingResolver:
     def __init__(self, name: str) -> None:
@@ -79,9 +82,46 @@ async def test_recursive_dns_advances_only_current_candidates_breadth_first() ->
         ('v2.dev.api.example.com', 'dev.api.example.com', 'currently-addressable'),
     ]
     assert result.classifications[1].records.cnames == ('missing.vendor.test',)
-    assert result.query_count == 114
+    assert result.query_count == 120
     assert result.depth_reached == 2
     assert result.stop_reason == 'depth-limit'
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_retains_ptrs_as_secondary_evidence() -> None:
+    current = {'api.example.com', 'dev.api.example.com'}
+    resolvers = tuple(FakeResolver(f'resolver-{index}', current) for index in range(3))
+
+    result = await discover_recursive_dns(
+        'example.com',
+        ('api.example.com',),
+        ('dev',),
+        resolvers,
+        RecursiveDNSLimits(depth=1, query_limit=100, runtime_seconds=5),
+    )
+
+    assert result.findings[0].ptrs == ('edge.example.net',)
+    assert result.classifications[0].ptrs == ('edge.example.net',)
+    assert result.query_count == 36
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_does_not_exceed_query_limit_for_ptrs() -> None:
+    current = {'api.example.com', 'dev.api.example.com'}
+    resolvers = tuple(FakeResolver(f'resolver-{index}', current) for index in range(3))
+
+    result = await discover_recursive_dns(
+        'example.com',
+        ('api.example.com',),
+        ('dev',),
+        resolvers,
+        RecursiveDNSLimits(depth=1, query_limit=33, runtime_seconds=5),
+    )
+
+    assert result.findings[0].hostname == 'dev.api.example.com'
+    assert result.findings[0].ptrs == ()
+    assert result.query_count == 33
+    assert result.stop_reason == 'query-limit'
 
 
 @pytest.mark.asyncio

--- a/tests/lib/test_recursive_dns.py
+++ b/tests/lib/test_recursive_dns.py
@@ -4,7 +4,7 @@ import asyncio
 
 import pytest
 
-from theHarvester.lib.dns_consensus import DNSResponse
+from theHarvester.lib.dns_consensus import DNSQueryBudget, DNSResponse
 from theHarvester.lib.recursive_dns import RecursiveDNSLimits, discover_recursive_dns
 
 
@@ -21,7 +21,9 @@ class FakeResolver:
         self.aliases = aliases or {}
         self.nodata = nodata or set()
 
-    async def query(self, hostname: str) -> DNSResponse:
+    async def query(self, hostname: str, budget: DNSQueryBudget | None = None) -> DNSResponse:
+        if budget is not None and not budget.consume(3):
+            return DNSResponse(rcode='ERROR', error='query-limit')
         if hostname in self.current:
             return DNSResponse(ipv4=('192.0.2.10',))
         if hostname in self.aliases:
@@ -30,7 +32,9 @@ class FakeResolver:
             return DNSResponse(rcode='NODATA')
         return DNSResponse(rcode='NXDOMAIN')
 
-    async def query_ptr(self, address: str) -> tuple[str, ...]:
+    async def query_ptr(self, address: str, budget: DNSQueryBudget | None = None) -> tuple[str, ...]:
+        if budget is not None and not budget.consume(1):
+            return ()
         return ('edge.example.net',) if address == '192.0.2.10' else ()
 
 
@@ -39,12 +43,29 @@ class BlockingResolver:
         self.name = name
         self.cancelled = 0
 
-    async def query(self, _hostname: str) -> DNSResponse:
+    async def query(self, _hostname: str, budget: DNSQueryBudget | None = None) -> DNSResponse:
+        if budget is not None and not budget.consume(3):
+            return DNSResponse(rcode='ERROR', error='query-limit')
         try:
             await asyncio.Event().wait()
         except asyncio.CancelledError:
             self.cancelled += 1
             raise
+
+
+class CnameHeavyResolver:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    async def query(self, _hostname: str, budget: DNSQueryBudget | None = None) -> DNSResponse:
+        assert budget is not None
+        if not budget.consume(3) or not budget.consume(3):
+            return DNSResponse(rcode='ERROR', error='query-limit')
+        return DNSResponse(ipv4=('192.0.2.10',), cnames=('edge.example.com',))
+
+    async def query_ptr(self, _address: str, budget: DNSQueryBudget | None = None) -> tuple[str, ...]:
+        assert budget is not None
+        return () if not budget.consume(1) else ('edge.example.net',)
 
 
 @pytest.mark.asyncio
@@ -82,7 +103,7 @@ async def test_recursive_dns_advances_only_current_candidates_breadth_first() ->
         ('v2.dev.api.example.com', 'dev.api.example.com', 'currently-addressable'),
     ]
     assert result.classifications[1].records.cnames == ('missing.vendor.test',)
-    assert result.query_count == 120
+    assert result.query_count == 348
     assert result.depth_reached == 2
     assert result.stop_reason == 'depth-limit'
 
@@ -97,12 +118,12 @@ async def test_recursive_dns_retains_ptrs_as_secondary_evidence() -> None:
         ('api.example.com',),
         ('dev',),
         resolvers,
-        RecursiveDNSLimits(depth=1, query_limit=100, runtime_seconds=5),
+        RecursiveDNSLimits(depth=1, query_limit=200, runtime_seconds=5),
     )
 
     assert result.findings[0].ptrs == ('edge.example.net',)
     assert result.classifications[0].ptrs == ('edge.example.net',)
-    assert result.query_count == 36
+    assert result.query_count == 102
 
 
 @pytest.mark.asyncio
@@ -115,12 +136,28 @@ async def test_recursive_dns_does_not_exceed_query_limit_for_ptrs() -> None:
         ('api.example.com',),
         ('dev',),
         resolvers,
-        RecursiveDNSLimits(depth=1, query_limit=33, runtime_seconds=5),
+        RecursiveDNSLimits(depth=1, query_limit=99, runtime_seconds=5),
     )
 
     assert result.findings[0].hostname == 'dev.api.example.com'
     assert result.findings[0].ptrs == ()
-    assert result.query_count == 33
+    assert result.query_count == 99
+    assert result.stop_reason == 'query-limit'
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_counts_cname_hops_before_stopping() -> None:
+    resolvers = tuple(CnameHeavyResolver(f'resolver-{index}') for index in range(3))
+
+    result = await discover_recursive_dns(
+        'example.com',
+        ('api.example.com',),
+        ('dev',),
+        resolvers,
+        RecursiveDNSLimits(depth=1, query_limit=12, runtime_seconds=5),
+    )
+
+    assert result.query_count == 12
     assert result.stop_reason == 'query-limit'
 
 
@@ -138,7 +175,7 @@ async def test_recursive_dns_stops_before_exceeding_query_limit() -> None:
     )
 
     assert result.findings == ()
-    assert result.query_count == 0
+    assert result.query_count == 9
     assert result.depth_reached == 0
     assert result.stop_reason == 'query-limit'
 
@@ -155,7 +192,7 @@ async def test_recursive_dns_runtime_limit_cancels_pending_queries() -> None:
         RecursiveDNSLimits(depth=1, query_limit=100, runtime_seconds=0.01),
     )
 
-    assert result.query_count == 12
+    assert result.query_count == 36
     assert result.stop_reason == 'runtime-limit'
     assert sum(resolver.cancelled for resolver in resolvers) == 12
 
@@ -174,7 +211,7 @@ async def test_recursive_dns_stops_after_three_zero_yield_batches() -> None:
     )
 
     assert result.findings == ()
-    assert result.query_count == 3_162
+    assert result.query_count == 9_486
     assert result.depth_reached == 0
     assert result.zero_yield_batches == 3
     assert result.stop_reason == 'zero-yield'

--- a/tests/lib/test_recursive_dns.py
+++ b/tests/lib/test_recursive_dns.py
@@ -51,6 +51,10 @@ class BlockingResolver:
         except asyncio.CancelledError:
             self.cancelled += 1
             raise
+        raise AssertionError('unreachable')
+
+    async def query_ptr(self, _address: str, _budget: DNSQueryBudget | None = None) -> tuple[str, ...]:
+        return ()
 
 
 class CnameHeavyResolver:

--- a/tests/lib/test_recursive_dns.py
+++ b/tests/lib/test_recursive_dns.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from theHarvester.lib.dns_consensus import DNSResponse
+from theHarvester.lib.recursive_dns import RecursiveDNSLimits, discover_recursive_dns
+
+
+class FakeResolver:
+    def __init__(
+        self,
+        name: str,
+        current: set[str],
+        aliases: dict[str, str] | None = None,
+        nodata: set[str] | None = None,
+    ) -> None:
+        self.name = name
+        self.current = current
+        self.aliases = aliases or {}
+        self.nodata = nodata or set()
+
+    async def query(self, hostname: str) -> DNSResponse:
+        if hostname in self.current:
+            return DNSResponse(ipv4=('192.0.2.10',))
+        if hostname in self.aliases:
+            return DNSResponse(cnames=(self.aliases[hostname],))
+        if hostname in self.nodata:
+            return DNSResponse(rcode='NODATA')
+        return DNSResponse(rcode='NXDOMAIN')
+
+
+class BlockingResolver:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.cancelled = 0
+
+    async def query(self, _hostname: str) -> DNSResponse:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled += 1
+            raise
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_advances_only_current_candidates_breadth_first() -> None:
+    current = {'api.example.com', 'dev.api.example.com', 'v2.dev.api.example.com'}
+    resolvers = tuple(
+        FakeResolver(
+            f'resolver-{index}',
+            current,
+            {'v2.api.example.com': 'missing.vendor.test'},
+            {'dev.dev.api.example.com'},
+        )
+        for index in range(3)
+    )
+
+    result = await discover_recursive_dns(
+        'example.com',
+        ('api.example.com',),
+        ('dev', 'v2'),
+        resolvers,
+        RecursiveDNSLimits(depth=2, query_limit=1_000, runtime_seconds=5),
+    )
+
+    assert [(finding.hostname, finding.parent) for finding in result.findings] == [
+        ('dev.api.example.com', 'api.example.com'),
+        ('v2.dev.api.example.com', 'dev.api.example.com'),
+    ]
+    assert [
+        (classification.hostname, classification.parent, classification.addressability.value)
+        for classification in result.classifications
+    ] == [
+        ('dev.api.example.com', 'api.example.com', 'currently-addressable'),
+        ('v2.api.example.com', 'api.example.com', 'not-currently-addressable'),
+        ('dev.dev.api.example.com', 'dev.api.example.com', 'not-currently-addressable'),
+        ('v2.dev.api.example.com', 'dev.api.example.com', 'currently-addressable'),
+    ]
+    assert result.classifications[1].records.cnames == ('missing.vendor.test',)
+    assert result.query_count == 114
+    assert result.depth_reached == 2
+    assert result.stop_reason == 'depth-limit'
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_stops_before_exceeding_query_limit() -> None:
+    current = {'api.example.com'}
+    resolvers = tuple(FakeResolver(f'resolver-{index}', current) for index in range(3))
+
+    result = await discover_recursive_dns(
+        'example.com',
+        ('api.example.com',),
+        ('dev',),
+        resolvers,
+        RecursiveDNSLimits(depth=1, query_limit=11, runtime_seconds=5),
+    )
+
+    assert result.findings == ()
+    assert result.query_count == 0
+    assert result.depth_reached == 0
+    assert result.stop_reason == 'query-limit'
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_runtime_limit_cancels_pending_queries() -> None:
+    resolvers = tuple(BlockingResolver(f'resolver-{index}') for index in range(3))
+
+    result = await discover_recursive_dns(
+        'example.com',
+        ('api.example.com',),
+        ('dev',),
+        resolvers,
+        RecursiveDNSLimits(depth=1, query_limit=100, runtime_seconds=0.01),
+    )
+
+    assert result.query_count == 12
+    assert result.stop_reason == 'runtime-limit'
+    assert sum(resolver.cancelled for resolver in resolvers) == 12
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_stops_after_three_zero_yield_batches() -> None:
+    current = {'api.example.com'}
+    resolvers = tuple(FakeResolver(f'resolver-{index}', current) for index in range(3))
+
+    result = await discover_recursive_dns(
+        'example.com',
+        ('api.example.com',),
+        tuple(f'unused{index}' for index in range(151)),
+        resolvers,
+        RecursiveDNSLimits(depth=1, query_limit=10_000, runtime_seconds=5),
+    )
+
+    assert result.findings == ()
+    assert result.query_count == 3_162
+    assert result.depth_reached == 0
+    assert result.zero_yield_batches == 3
+    assert result.stop_reason == 'zero-yield'

--- a/theHarvester/lib/recursive_dns.py
+++ b/theHarvester/lib/recursive_dns.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import dataclass
+from itertools import islice
 from typing import TYPE_CHECKING
 
 from theHarvester.lib.dns_consensus import (
@@ -15,7 +16,7 @@ from theHarvester.lib.dns_consensus import (
 from theHarvester.lib.hostnames import normalize_scoped_hostname
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
 
     from theHarvester.lib.hostchecker import HostDnsRecords
 
@@ -65,23 +66,18 @@ class RecursiveDNSResult:
     classifications: tuple[RecursiveDNSClassification, ...] = ()
 
 
-def _normalize_labels(labels: Sequence[str], deadline: float) -> tuple[str, ...]:
-    normalized: list[str] = []
-    for value in labels:
-        if time.monotonic() >= deadline:
-            break
-        label = value.strip().lower()
-        if (
-            not label
-            or '.' in label
-            or len(label) > 63
-            or label.startswith('-')
-            or label.endswith('-')
-            or not all(character.isascii() and (character.isalnum() or character in {'-', '_'}) for character in label)
-        ):
-            continue
-        normalized.append(label)
-    return tuple(dict.fromkeys(normalized))
+def _normalize_label(value: str) -> str | None:
+    label = value.strip().lower()
+    if (
+        not label
+        or '.' in label
+        or len(label) > 63
+        or label.startswith('-')
+        or label.endswith('-')
+        or not all(character.isascii() and (character.isalnum() or character in {'-', '_'}) for character in label)
+    ):
+        return None
+    return label
 
 
 async def discover_recursive_dns(
@@ -95,10 +91,37 @@ async def discover_recursive_dns(
     if not normalized_target:
         raise ValueError('target must not be empty')
     deadline = time.monotonic() + limits.runtime_seconds
-    normalized_labels = _normalize_labels(labels, deadline)
-    seen = {candidate for value in seeds if (candidate := normalize_scoped_hostname(value, normalized_target)) is not None}
     budget = DNSQueryBudget(limits.query_limit)
     stop_reason = 'frontier-exhausted'
+    seen: set[str] = set()
+    for value in seeds:
+        if time.monotonic() >= deadline:
+            stop_reason = 'runtime-limit'
+            break
+        if (candidate := normalize_scoped_hostname(value, normalized_target)) is not None:
+            seen.add(candidate)
+
+    def iter_candidates(parents: Sequence[str]) -> Iterator[tuple[str, str]]:
+        nonlocal stop_reason
+        seen_labels: set[str] = set()
+        ordered_parents = tuple(sorted(parents))
+        for value in labels:
+            if time.monotonic() >= deadline:
+                stop_reason = 'runtime-limit'
+                return
+            label = _normalize_label(value)
+            if label is None or label in seen_labels:
+                continue
+            seen_labels.add(label)
+            for parent in ordered_parents:
+                if time.monotonic() >= deadline:
+                    stop_reason = 'runtime-limit'
+                    return
+                candidate = f'{label}.{parent}'
+                if candidate in seen:
+                    continue
+                seen.add(candidate)
+                yield candidate, parent
 
     async def validate(candidate: str) -> CandidateConsensus | None:
         nonlocal stop_reason
@@ -160,21 +183,16 @@ async def discover_recursive_dns(
     for depth in range(1, limits.depth + 1):
         if stopped or not frontier:
             break
-        candidates = [
-            (f'{label}.{parent}', parent)
-            for parent in sorted(frontier)
-            for label in normalized_labels
-            if f'{label}.{parent}' not in seen
-        ]
-        seen.update(candidate for candidate, _parent in candidates)
         next_frontier: list[str] = []
-        for offset in range(0, len(candidates), 50):
+        candidates = iter_candidates(frontier)
+        while batch := tuple(islice(candidates, 50)):
             batch_yield = 0
-            for candidate, parent in candidates[offset : offset + 50]:
+            for candidate, parent in batch:
                 consensus = await validate(candidate)
                 if consensus is None:
                     stopped = True
                     break
+                depth_reached = depth
                 ptrs = await resolve_ptrs(consensus.records) if consensus.addressability is Addressability.CURRENT else ()
                 if (
                     consensus.addressability is not Addressability.NOT_CURRENT
@@ -207,9 +225,10 @@ async def discover_recursive_dns(
                     stop_reason = 'zero-yield'
                     stopped = True
                     break
+        if stop_reason in {'query-limit', 'runtime-limit'}:
+            stopped = True
         if stopped:
             break
-        depth_reached = depth
         frontier = next_frontier
         if not frontier:
             stop_reason = 'frontier-exhausted'

--- a/theHarvester/lib/recursive_dns.py
+++ b/theHarvester/lib/recursive_dns.py
@@ -5,7 +5,13 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from theHarvester.lib.dns_consensus import Addressability, CandidateConsensus, ResolverVantage, validate_dns_candidates
+from theHarvester.lib.dns_consensus import (
+    Addressability,
+    CandidateConsensus,
+    DNSQueryBudget,
+    ResolverVantage,
+    validate_dns_candidates,
+)
 from theHarvester.lib.hostnames import normalize_scoped_hostname
 
 if TYPE_CHECKING:
@@ -14,7 +20,7 @@ if TYPE_CHECKING:
     from theHarvester.lib.hostchecker import HostDnsRecords
 
 
-DEFAULT_RECURSIVE_DNS_QUERY_LIMIT = 1_000
+DEFAULT_RECURSIVE_DNS_QUERY_LIMIT = 3_000
 
 
 @dataclass(frozen=True, slots=True)
@@ -59,11 +65,6 @@ class RecursiveDNSResult:
     classifications: tuple[RecursiveDNSClassification, ...] = ()
 
 
-def _query_cost(target: str, candidate: str) -> int:
-    wildcard_depths = max(1, len(candidate.split('.')) - len(target.split('.')))
-    return 3 + wildcard_depths * 9
-
-
 def _normalize_labels(labels: Sequence[str], deadline: float) -> tuple[str, ...]:
     normalized: list[str] = []
     for value in labels:
@@ -93,49 +94,41 @@ async def discover_recursive_dns(
     normalized_target = target.strip().lower().rstrip('.')
     if not normalized_target:
         raise ValueError('target must not be empty')
-    started = time.monotonic()
-    deadline = started + limits.runtime_seconds
+    deadline = time.monotonic() + limits.runtime_seconds
     normalized_labels = _normalize_labels(labels, deadline)
     seen = {candidate for value in seeds if (candidate := normalize_scoped_hostname(value, normalized_target)) is not None}
-    query_count = 0
+    budget = DNSQueryBudget(limits.query_limit)
     stop_reason = 'frontier-exhausted'
 
     async def validate(candidate: str) -> CandidateConsensus | None:
-        nonlocal query_count, stop_reason
-        query_cost = _query_cost(normalized_target, candidate)
-        if query_count + query_cost > limits.query_limit:
-            stop_reason = 'query-limit'
-            return None
+        nonlocal stop_reason
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             stop_reason = 'runtime-limit'
             return None
-        query_count += query_cost
         try:
             async with asyncio.timeout(remaining):
-                (consensus,) = await validate_dns_candidates(normalized_target, (candidate,), resolvers)
+                (consensus,) = await validate_dns_candidates(normalized_target, (candidate,), resolvers, budget=budget)
+                if budget.blocked:
+                    stop_reason = 'query-limit'
+                    return None
                 return consensus
         except TimeoutError:
             stop_reason = 'runtime-limit'
             return None
 
     async def resolve_ptrs(records: HostDnsRecords) -> tuple[str, ...]:
-        nonlocal query_count, stop_reason
+        nonlocal stop_reason
         ptrs: set[str] = set()
         for address in records.addresses:
-            query_cost = len(resolvers)
-            if query_count + query_cost > limits.query_limit:
-                stop_reason = 'query-limit'
-                break
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 stop_reason = 'runtime-limit'
                 break
-            query_count += query_cost
             try:
                 async with asyncio.timeout(remaining):
                     results = await asyncio.gather(
-                        *(resolver.query_ptr(address) for resolver in resolvers), return_exceptions=True
+                        *(resolver.query_ptr(address, budget) for resolver in resolvers), return_exceptions=True
                     )
             except TimeoutError:
                 stop_reason = 'runtime-limit'
@@ -145,6 +138,9 @@ async def discover_recursive_dns(
                     raise result
                 if not isinstance(result, BaseException):
                     ptrs.update(result)
+            if budget.blocked:
+                stop_reason = 'query-limit'
+                break
         return tuple(sorted(ptrs))
 
     frontier: list[str] = []
@@ -221,5 +217,5 @@ async def discover_recursive_dns(
     else:
         stop_reason = 'depth-limit'
     return RecursiveDNSResult(
-        tuple(findings), query_count, depth_reached, zero_yield_batches, stop_reason, tuple(classifications)
+        tuple(findings), budget.used, depth_reached, zero_yield_batches, stop_reason, tuple(classifications)
     )

--- a/theHarvester/lib/recursive_dns.py
+++ b/theHarvester/lib/recursive_dns.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from theHarvester.lib.dns_consensus import Addressability, CandidateConsensus, ResolverVantage, validate_dns_candidates
+from theHarvester.lib.hostnames import normalize_scoped_hostname
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from theHarvester.lib.hostchecker import HostDnsRecords
+
+
+@dataclass(frozen=True, slots=True)
+class RecursiveDNSLimits:
+    depth: int
+    query_limit: int
+    runtime_seconds: float
+
+    def __post_init__(self) -> None:
+        if self.depth <= 0:
+            raise ValueError('recursive DNS depth must be greater than zero')
+        if self.query_limit <= 0:
+            raise ValueError('recursive DNS query limit must be greater than zero')
+        if self.runtime_seconds <= 0:
+            raise ValueError('recursive DNS runtime must be greater than zero')
+
+
+@dataclass(frozen=True, slots=True)
+class RecursiveDNSFinding:
+    hostname: str
+    parent: str
+    records: HostDnsRecords
+
+
+@dataclass(frozen=True, slots=True)
+class RecursiveDNSClassification:
+    hostname: str
+    parent: str
+    addressability: Addressability
+    records: HostDnsRecords
+
+
+@dataclass(frozen=True, slots=True)
+class RecursiveDNSResult:
+    findings: tuple[RecursiveDNSFinding, ...]
+    query_count: int
+    depth_reached: int
+    zero_yield_batches: int
+    stop_reason: str
+    classifications: tuple[RecursiveDNSClassification, ...] = ()
+
+
+def _query_cost(target: str, candidate: str) -> int:
+    wildcard_depths = max(1, len(candidate.split('.')) - len(target.split('.')))
+    return 3 + wildcard_depths * 9
+
+
+def _normalize_labels(labels: Sequence[str], deadline: float) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for value in labels:
+        if time.monotonic() >= deadline:
+            break
+        label = value.strip().lower()
+        if (
+            not label
+            or '.' in label
+            or len(label) > 63
+            or label.startswith('-')
+            or label.endswith('-')
+            or not all(character.isascii() and (character.isalnum() or character in {'-', '_'}) for character in label)
+        ):
+            continue
+        normalized.append(label)
+    return tuple(dict.fromkeys(normalized))
+
+
+async def discover_recursive_dns(
+    target: str,
+    seeds: Sequence[str],
+    labels: Sequence[str],
+    resolvers: Sequence[ResolverVantage],
+    limits: RecursiveDNSLimits,
+) -> RecursiveDNSResult:
+    normalized_target = target.strip().lower().rstrip('.')
+    if not normalized_target:
+        raise ValueError('target must not be empty')
+    started = time.monotonic()
+    deadline = started + limits.runtime_seconds
+    normalized_labels = _normalize_labels(labels, deadline)
+    seen = {candidate for value in seeds if (candidate := normalize_scoped_hostname(value, normalized_target)) is not None}
+    query_count = 0
+    stop_reason = 'frontier-exhausted'
+
+    async def validate(candidate: str) -> CandidateConsensus | None:
+        nonlocal query_count, stop_reason
+        query_cost = _query_cost(normalized_target, candidate)
+        if query_count + query_cost > limits.query_limit:
+            stop_reason = 'query-limit'
+            return None
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            stop_reason = 'runtime-limit'
+            return None
+        query_count += query_cost
+        try:
+            async with asyncio.timeout(remaining):
+                (consensus,) = await validate_dns_candidates(normalized_target, (candidate,), resolvers)
+                return consensus
+        except TimeoutError:
+            stop_reason = 'runtime-limit'
+            return None
+
+    frontier: list[str] = []
+    for seed in sorted(seen):
+        consensus = await validate(seed)
+        if consensus is None:
+            break
+        if consensus.addressability is Addressability.CURRENT:
+            frontier.append(seed)
+
+    findings: list[RecursiveDNSFinding] = []
+    classifications: list[RecursiveDNSClassification] = []
+    zero_yield_batches = 0
+    consecutive_zero_yield_batches = 0
+    depth_reached = 0
+    stopped = stop_reason in {'query-limit', 'runtime-limit'}
+    for depth in range(1, limits.depth + 1):
+        if stopped or not frontier:
+            break
+        candidates = [
+            (f'{label}.{parent}', parent)
+            for parent in sorted(frontier)
+            for label in normalized_labels
+            if f'{label}.{parent}' not in seen
+        ]
+        seen.update(candidate for candidate, _parent in candidates)
+        next_frontier: list[str] = []
+        for offset in range(0, len(candidates), 50):
+            batch_yield = 0
+            for candidate, parent in candidates[offset : offset + 50]:
+                consensus = await validate(candidate)
+                if consensus is None:
+                    stopped = True
+                    break
+                if (
+                    consensus.addressability is not Addressability.NOT_CURRENT
+                    or (consensus.records.addresses or consensus.records.cnames)
+                    or any(
+                        validation.wildcard_depth is None
+                        and validation.response.error is None
+                        and validation.response.rcode in {'NOERROR', 'NODATA'}
+                        for validation in consensus.validations
+                    )
+                ):
+                    classifications.append(
+                        RecursiveDNSClassification(candidate, parent, consensus.addressability, consensus.records)
+                    )
+                if consensus.addressability is Addressability.CURRENT:
+                    findings.append(RecursiveDNSFinding(candidate, parent, consensus.records))
+                    next_frontier.append(candidate)
+                    batch_yield += 1
+            if stopped:
+                break
+            if batch_yield:
+                consecutive_zero_yield_batches = 0
+            else:
+                consecutive_zero_yield_batches += 1
+                zero_yield_batches += 1
+                if consecutive_zero_yield_batches >= 3:
+                    stop_reason = 'zero-yield'
+                    stopped = True
+                    break
+        if stopped:
+            break
+        depth_reached = depth
+        frontier = next_frontier
+        if not frontier:
+            stop_reason = 'frontier-exhausted'
+            break
+    else:
+        stop_reason = 'depth-limit'
+    return RecursiveDNSResult(
+        tuple(findings), query_count, depth_reached, zero_yield_batches, stop_reason, tuple(classifications)
+    )

--- a/theHarvester/lib/recursive_dns.py
+++ b/theHarvester/lib/recursive_dns.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import time
 from dataclasses import dataclass
 from itertools import islice
@@ -35,8 +36,8 @@ class RecursiveDNSLimits:
             raise ValueError('recursive DNS depth must be greater than zero')
         if self.query_limit <= 0:
             raise ValueError('recursive DNS query limit must be greater than zero')
-        if self.runtime_seconds <= 0:
-            raise ValueError('recursive DNS runtime must be greater than zero')
+        if not math.isfinite(self.runtime_seconds) or self.runtime_seconds <= 0:
+            raise ValueError('recursive DNS runtime must be finite and greater than zero')
 
 
 @dataclass(frozen=True, slots=True)

--- a/theHarvester/lib/recursive_dns.py
+++ b/theHarvester/lib/recursive_dns.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
     from theHarvester.lib.hostchecker import HostDnsRecords
 
 
+DEFAULT_RECURSIVE_DNS_QUERY_LIMIT = 1_000
+
+
 @dataclass(frozen=True, slots=True)
 class RecursiveDNSLimits:
     depth: int
@@ -34,6 +37,7 @@ class RecursiveDNSFinding:
     hostname: str
     parent: str
     records: HostDnsRecords
+    ptrs: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,6 +46,7 @@ class RecursiveDNSClassification:
     parent: str
     addressability: Addressability
     records: HostDnsRecords
+    ptrs: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -114,6 +119,34 @@ async def discover_recursive_dns(
             stop_reason = 'runtime-limit'
             return None
 
+    async def resolve_ptrs(records: HostDnsRecords) -> tuple[str, ...]:
+        nonlocal query_count, stop_reason
+        ptrs: set[str] = set()
+        for address in records.addresses:
+            query_cost = len(resolvers)
+            if query_count + query_cost > limits.query_limit:
+                stop_reason = 'query-limit'
+                break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                stop_reason = 'runtime-limit'
+                break
+            query_count += query_cost
+            try:
+                async with asyncio.timeout(remaining):
+                    results = await asyncio.gather(
+                        *(resolver.query_ptr(address) for resolver in resolvers), return_exceptions=True
+                    )
+            except TimeoutError:
+                stop_reason = 'runtime-limit'
+                break
+            for result in results:
+                if isinstance(result, asyncio.CancelledError):
+                    raise result
+                if not isinstance(result, BaseException):
+                    ptrs.update(result)
+        return tuple(sorted(ptrs))
+
     frontier: list[str] = []
     for seed in sorted(seen):
         consensus = await validate(seed)
@@ -146,6 +179,7 @@ async def discover_recursive_dns(
                 if consensus is None:
                     stopped = True
                     break
+                ptrs = await resolve_ptrs(consensus.records) if consensus.addressability is Addressability.CURRENT else ()
                 if (
                     consensus.addressability is not Addressability.NOT_CURRENT
                     or (consensus.records.addresses or consensus.records.cnames)
@@ -157,12 +191,15 @@ async def discover_recursive_dns(
                     )
                 ):
                     classifications.append(
-                        RecursiveDNSClassification(candidate, parent, consensus.addressability, consensus.records)
+                        RecursiveDNSClassification(candidate, parent, consensus.addressability, consensus.records, ptrs)
                     )
                 if consensus.addressability is Addressability.CURRENT:
-                    findings.append(RecursiveDNSFinding(candidate, parent, consensus.records))
+                    findings.append(RecursiveDNSFinding(candidate, parent, consensus.records, ptrs))
                     next_frontier.append(candidate)
                     batch_yield += 1
+                if stop_reason in {'query-limit', 'runtime-limit'}:
+                    stopped = True
+                    break
             if stopped:
                 break
             if batch_yield:

--- a/theHarvester/lib/recursive_dns.py
+++ b/theHarvester/lib/recursive_dns.py
@@ -7,9 +7,9 @@ from typing import TYPE_CHECKING
 
 from theHarvester.lib.dns_consensus import (
     Addressability,
+    BudgetedResolverVantage,
     CandidateConsensus,
     DNSQueryBudget,
-    ResolverVantage,
     validate_dns_candidates,
 )
 from theHarvester.lib.hostnames import normalize_scoped_hostname
@@ -88,7 +88,7 @@ async def discover_recursive_dns(
     target: str,
     seeds: Sequence[str],
     labels: Sequence[str],
-    resolvers: Sequence[ResolverVantage],
+    resolvers: Sequence[BudgetedResolverVantage],
     limits: RecursiveDNSLimits,
 ) -> RecursiveDNSResult:
     normalized_target = target.strip().lower().rstrip('.')


### PR DESCRIPTION
## Summary

- add breadth-first recursive DNS discovery using current-addressability consensus
- enforce exact shared DNS query budgets, finite runtime limits, and three-zero-yield termination
- retain PTR answers as secondary evidence without using them as recursion seeds
- generate candidates lazily so limits stop work before unused labels are materialized

All limits are supplied through `RecursiveDNSLimits`; the engine contains no target-specific tuning. Mozilla was used only for an authorized acceptance smoke.

## Verification

- `.venv/bin/pytest tests/lib/test_dns_consensus.py tests/lib/test_recursive_dns.py` (24 passed)
- `.venv/bin/ruff check theHarvester/lib/recursive_dns.py tests/lib/test_recursive_dns.py`
- `.venv/bin/mypy theHarvester/lib/recursive_dns.py`
- stable patch ID matches the previously reviewed engine slice after rebasing onto upstream PR #2499 squash