### PR TITLE
Contract Hunter and Tomba provider responses

### DIFF
--- a/tests/discovery/test_huntersearch.py
+++ b/tests/discovery/test_huntersearch.py
@@ -119,6 +119,55 @@ async def test_paid_hunter_search_honors_limit_and_offset(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_paid_hunter_search_preserves_first_page_after_rate_limit(monkeypatch, caplog) -> None:
+    requests: list[str] = []
+    responses = iter(
+        [
+            FetcherResponse(
+                body={'data': {'plan_name': 'Growth', 'requests': {'searches': {'available': 10, 'used': 0}}}},
+                status=200,
+                headers={},
+            ),
+            FetcherResponse(body={'data': {'total': 175}}, status=200, headers={}),
+            FetcherResponse(
+                body={
+                    'data': {
+                        'emails': [
+                            {'value': 'alice@example.test', 'sources': [{'domain': 'api.example.test'}]},
+                        ]
+                    }
+                },
+                status=200,
+                headers={},
+            ),
+            FetcherResponse(body={'error': 'provider detail'}, status=429, headers={}),
+        ]
+    )
+
+    async def fake_fetch_all(urls, **_kwargs):
+        requests.append(urls[0])
+        return [next(responses)]
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(huntersearch.Core, 'hunter_key', lambda: 'test-key')
+    monkeypatch.setattr(huntersearch.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(huntersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(huntersearch.asyncio, 'sleep', no_sleep)
+    search = huntersearch.SearchHunter('example.test', 150, 0)
+
+    with caplog.at_level(logging.INFO, logger=huntersearch.__name__):
+        await search.process()
+
+    assert await search.get_emails() == ['alice@example.test']
+    assert await search.get_hostnames() == ['api.example.test']
+    assert requests[-1].endswith('limit=50&offset=100')
+    assert 'Hunter request failed with HTTP 429' in caplog.text
+    assert 'provider detail' not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_free_hunter_search_honors_limit_and_offset(monkeypatch) -> None:
     requests: list[str] = []
     responses = iter(

--- a/tests/discovery/test_huntersearch.py
+++ b/tests/discovery/test_huntersearch.py
@@ -48,23 +48,50 @@ async def test_paid_hunter_search_honors_limit_and_offset(monkeypatch) -> None:
     monkeypatch.setattr(huntersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
     monkeypatch.setattr(huntersearch.asyncio, 'sleep', no_sleep)
 
-    search = huntersearch.SearchHunter('example.test', 150, 0)
+    search = huntersearch.SearchHunter('example.test', 150, 25)
     await search.process(proxy=True)
 
     assert requests == [
         ('https://api.hunter.io/v2/account?api_key=test-key', True),
         ('https://api.hunter.io/v2/email-count?domain=example.test', True),
         (
-            'https://api.hunter.io/v2/domain-search?domain=example.test&api_key=test-key&limit=100&offset=0',
+            'https://api.hunter.io/v2/domain-search?domain=example.test&api_key=test-key&limit=100&offset=25',
             True,
         ),
         (
-            'https://api.hunter.io/v2/domain-search?domain=example.test&api_key=test-key&limit=50&offset=100',
+            'https://api.hunter.io/v2/domain-search?domain=example.test&api_key=test-key&limit=50&offset=125',
             True,
         ),
     ]
     assert await search.get_emails() == ['alice@example.test', 'bob@example.test']
     assert await search.get_hostnames() == ['api.example.test', 'www.example.test']
+
+
+@pytest.mark.asyncio
+async def test_free_hunter_search_honors_limit_and_offset(monkeypatch) -> None:
+    requests: list[str] = []
+    responses = iter(
+        [
+            {'data': {'plan_name': 'Free', 'requests': {'searches': {'available': 10, 'used': 0}}}},
+            {'data': {'emails': []}},
+        ]
+    )
+
+    async def fake_fetch_all(urls, **_kwargs):
+        requests.append(urls[0])
+        return [next(responses)]
+
+    monkeypatch.setattr(huntersearch.Core, 'hunter_key', lambda: 'test-key')
+    monkeypatch.setattr(huntersearch.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(huntersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = huntersearch.SearchHunter('example.test', 5, 3)
+    await search.process()
+
+    assert requests == [
+        'https://api.hunter.io/v2/account?api_key=test-key',
+        'https://api.hunter.io/v2/domain-search?domain=example.test&api_key=test-key&limit=5&offset=3',
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/discovery/test_huntersearch.py
+++ b/tests/discovery/test_huntersearch.py
@@ -1,0 +1,96 @@
+import pytest
+
+from theHarvester.discovery import huntersearch
+from theHarvester.discovery.constants import MissingKey
+
+
+@pytest.mark.parametrize('key', [None, '  '])
+def test_hunter_rejects_missing_or_blank_key(monkeypatch, key) -> None:
+    monkeypatch.setattr(huntersearch.Core, 'hunter_key', lambda: key)
+
+    with pytest.raises(MissingKey):
+        huntersearch.SearchHunter('example.test', 10, 0)
+
+
+@pytest.mark.asyncio
+async def test_paid_hunter_search_honors_limit_and_offset(monkeypatch) -> None:
+    requests: list[tuple[str, bool]] = []
+    responses = iter(
+        [
+            {'data': {'plan_name': 'Growth', 'requests': {'searches': {'available': 10, 'used': 0}}}},
+            {'data': {'total': 175}},
+            {
+                'data': {
+                    'emails': [
+                        {'value': 'alice@example.test', 'sources': [{'domain': 'api.example.test'}]},
+                    ]
+                }
+            },
+            {
+                'data': {
+                    'emails': [
+                        {'value': 'bob@example.test', 'sources': [{'domain': 'www.example.test'}]},
+                    ]
+                }
+            },
+        ]
+    )
+
+    async def fake_fetch_all(urls, *, proxy=False, **_kwargs):
+        requests.append((urls[0], proxy))
+        return [next(responses)]
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(huntersearch.Core, 'hunter_key', lambda: 'test-key')
+    monkeypatch.setattr(huntersearch.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(huntersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(huntersearch.asyncio, 'sleep', no_sleep)
+
+    search = huntersearch.SearchHunter('example.test', 150, 0)
+    await search.process(proxy=True)
+
+    assert requests == [
+        ('https://api.hunter.io/v2/account?api_key=test-key', True),
+        ('https://api.hunter.io/v2/email-count?domain=example.test', True),
+        (
+            'https://api.hunter.io/v2/domain-search?domain=example.test&api_key=test-key&limit=100&offset=0',
+            True,
+        ),
+        (
+            'https://api.hunter.io/v2/domain-search?domain=example.test&api_key=test-key&limit=50&offset=100',
+            True,
+        ),
+    ]
+    assert await search.get_emails() == ['alice@example.test', 'bob@example.test']
+    assert await search.get_hostnames() == ['api.example.test', 'www.example.test']
+
+
+@pytest.mark.asyncio
+async def test_paid_hunter_search_stops_before_exceeding_quota(monkeypatch) -> None:
+    requests: list[str] = []
+    responses = iter(
+        [
+            {'data': {'plan_name': 'Growth', 'requests': {'searches': {'available': 1, 'used': 0}}}},
+            {'data': {'total': 250}},
+        ]
+    )
+
+    async def fake_fetch_all(urls, **_kwargs):
+        requests.append(urls[0])
+        return [next(responses)]
+
+    monkeypatch.setattr(huntersearch.Core, 'hunter_key', lambda: 'test-key')
+    monkeypatch.setattr(huntersearch.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(huntersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = huntersearch.SearchHunter('example.test', 250, 0)
+    await search.process()
+
+    assert requests == [
+        'https://api.hunter.io/v2/account?api_key=test-key',
+        'https://api.hunter.io/v2/email-count?domain=example.test',
+    ]
+    assert await search.get_emails() == []
+    assert await search.get_hostnames() == []

--- a/tests/discovery/test_huntersearch.py
+++ b/tests/discovery/test_huntersearch.py
@@ -1,7 +1,11 @@
+import logging
+from typing import Any
+
 import pytest
 
 from theHarvester.discovery import huntersearch
 from theHarvester.discovery.constants import MissingKey
+from theHarvester.lib.core import FetcherResponse
 
 
 @pytest.mark.parametrize('key', [None, '  '])
@@ -10,6 +14,53 @@ def test_hunter_rejects_missing_or_blank_key(monkeypatch, key) -> None:
 
     with pytest.raises(MissingKey):
         huntersearch.SearchHunter('example.test', 10, 0)
+
+
+@pytest.mark.parametrize('status', [401, 403, 429])
+@pytest.mark.asyncio
+async def test_hunter_http_failures_return_no_results(monkeypatch, caplog, status: int) -> None:
+    async def fake_fetch_all(*_args: Any, **kwargs: Any) -> list[FetcherResponse]:
+        assert kwargs['include_metadata'] is True
+        return [FetcherResponse(body={'error': 'provider detail'}, status=status, headers={})]
+
+    monkeypatch.setattr(huntersearch.Core, 'hunter_key', lambda: 'test-key')
+    monkeypatch.setattr(huntersearch.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(huntersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = huntersearch.SearchHunter('example.test', 10, 0)
+
+    with caplog.at_level(logging.INFO, logger=huntersearch.__name__):
+        await search.process()
+
+    assert await search.get_emails() == []
+    assert await search.get_hostnames() == []
+    assert f'Hunter request failed with HTTP {status}' in caplog.text
+    assert 'provider detail' not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ('response', 'message'),
+    [
+        ([], 'Hunter request failed without a response'),
+        ([FetcherResponse(body='not json', status=200, headers={})], 'Hunter returned malformed data'),
+        ([FetcherResponse(body={}, status=200, headers={})], 'Hunter returned malformed data'),
+    ],
+)
+@pytest.mark.asyncio
+async def test_hunter_empty_or_malformed_response_returns_no_results(monkeypatch, caplog, response, message) -> None:
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any):
+        return response
+
+    monkeypatch.setattr(huntersearch.Core, 'hunter_key', lambda: 'test-key')
+    monkeypatch.setattr(huntersearch.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(huntersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = huntersearch.SearchHunter('example.test', 10, 0)
+
+    with caplog.at_level(logging.INFO, logger=huntersearch.__name__):
+        await search.process()
+
+    assert await search.get_emails() == []
+    assert await search.get_hostnames() == []
+    assert message in caplog.text
 
 
 @pytest.mark.asyncio
@@ -38,7 +89,7 @@ async def test_paid_hunter_search_honors_limit_and_offset(monkeypatch) -> None:
 
     async def fake_fetch_all(urls, *, proxy=False, **_kwargs):
         requests.append((urls[0], proxy))
-        return [next(responses)]
+        return [FetcherResponse(body=next(responses), status=200, headers={})]
 
     async def no_sleep(_seconds: float) -> None:
         return None
@@ -79,7 +130,7 @@ async def test_free_hunter_search_honors_limit_and_offset(monkeypatch) -> None:
 
     async def fake_fetch_all(urls, **_kwargs):
         requests.append(urls[0])
-        return [next(responses)]
+        return [FetcherResponse(body=next(responses), status=200, headers={})]
 
     monkeypatch.setattr(huntersearch.Core, 'hunter_key', lambda: 'test-key')
     monkeypatch.setattr(huntersearch.Core, 'get_user_agent', lambda: 'test-agent')
@@ -106,7 +157,7 @@ async def test_paid_hunter_search_stops_before_exceeding_quota(monkeypatch) -> N
 
     async def fake_fetch_all(urls, **_kwargs):
         requests.append(urls[0])
-        return [next(responses)]
+        return [FetcherResponse(body=next(responses), status=200, headers={})]
 
     monkeypatch.setattr(huntersearch.Core, 'hunter_key', lambda: 'test-key')
     monkeypatch.setattr(huntersearch.Core, 'get_user_agent', lambda: 'test-agent')

--- a/tests/discovery/test_tombasearch.py
+++ b/tests/discovery/test_tombasearch.py
@@ -4,6 +4,20 @@ from theHarvester.discovery import tombasearch
 from theHarvester.discovery.constants import MissingKey
 
 
+def tomba_page(first: int, count: int = 50) -> dict:
+    return {
+        'data': {
+            'emails': [
+                {
+                    'email': f'user{index}@example.test',
+                    'sources': [{'website_url': f'user{index}.example.test'}],
+                }
+                for index in range(first, first + count)
+            ]
+        }
+    }
+
+
 @pytest.mark.parametrize(
     'credentials',
     [
@@ -31,22 +45,10 @@ async def test_paid_tomba_search_uses_documented_pages_and_page_size(monkeypatch
                     'requests': {'domains': {'available': 10, 'used': 0}},
                 }
             },
-            {'data': {'total': 120}},
-            {
-                'data': {
-                    'emails': [
-                        {'email': 'alice@example.test', 'sources': [{'website_url': 'api.example.test'}]},
-                    ]
-                }
-            },
-            {
-                'data': {
-                    'emails': [
-                        {'email': 'bob@example.test', 'sources': [{'website_url': 'www.example.test'}]},
-                    ]
-                }
-            },
-            {'data': {'emails': []}},
+            {'data': {'total': 175}},
+            tomba_page(0),
+            tomba_page(50),
+            tomba_page(100),
         ]
     )
 
@@ -72,8 +74,97 @@ async def test_paid_tomba_search_uses_documented_pages_and_page_size(monkeypatch
         ('https://api.tomba.io/v1/domain-search?domain=example.test&limit=50&page=2', True),
         ('https://api.tomba.io/v1/domain-search?domain=example.test&limit=50&page=3', True),
     ]
-    assert await search.get_emails() == ['alice@example.test', 'bob@example.test']
-    assert await search.get_hostnames() == ['api.example.test', 'www.example.test']
+    emails = await search.get_emails()
+    hostnames = await search.get_hostnames()
+    assert len(emails) == 120
+    assert len(hostnames) == 120
+    assert 'user119@example.test' in emails
+    assert 'user119.example.test' in hostnames
+    assert 'user120@example.test' not in emails
+    assert 'user120.example.test' not in hostnames
+
+
+@pytest.mark.asyncio
+async def test_paid_tomba_search_honors_nonzero_start(monkeypatch) -> None:
+    requests: list[str] = []
+    responses = iter(
+        [
+            {
+                'data': {
+                    'pricing': {'name': 'Growth'},
+                    'requests': {'domains': {'available': 10, 'used': 0}},
+                }
+            },
+            {'data': {'total': 200}},
+            tomba_page(50),
+        ]
+    )
+
+    async def fake_fetch_all(urls, **_kwargs):
+        requests.append(urls[0])
+        return [next(responses)]
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(tombasearch.Core, 'tomba_key', lambda: ('test-key', 'test-secret'))
+    monkeypatch.setattr(tombasearch.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(tombasearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(tombasearch.asyncio, 'sleep', no_sleep)
+
+    search = tombasearch.SearchTomba('example.test', 20, 60)
+    await search.process()
+
+    assert requests == [
+        'https://api.tomba.io/v1/me',
+        'https://api.tomba.io/v1/email-count?domain=example.test',
+        'https://api.tomba.io/v1/domain-search?domain=example.test&limit=50&page=2',
+    ]
+    emails = await search.get_emails()
+    assert len(emails) == 20
+    assert 'user60@example.test' in emails
+    assert 'user79@example.test' in emails
+    assert 'user59@example.test' not in emails
+    assert 'user80@example.test' not in emails
+
+
+@pytest.mark.asyncio
+async def test_free_tomba_search_honors_limit_and_start(monkeypatch) -> None:
+    requests: list[str] = []
+    responses = iter(
+        [
+            {
+                'data': {
+                    'pricing': {'name': 'Free'},
+                    'requests': {'domains': {'available': 10, 'used': 0}},
+                }
+            },
+            tomba_page(0, 10),
+        ]
+    )
+
+    async def fake_fetch_all(urls, **_kwargs):
+        requests.append(urls[0])
+        return [next(responses)]
+
+    monkeypatch.setattr(tombasearch.Core, 'tomba_key', lambda: ('test-key', 'test-secret'))
+    monkeypatch.setattr(tombasearch.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(tombasearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = tombasearch.SearchTomba('example.test', 5, 3)
+    await search.process()
+
+    assert requests == [
+        'https://api.tomba.io/v1/me',
+        'https://api.tomba.io/v1/domain-search?domain=example.test&limit=10&page=1',
+    ]
+    assert set(await search.get_emails()) == {
+        'user3@example.test',
+        'user4@example.test',
+        'user5@example.test',
+        'user6@example.test',
+        'user7@example.test',
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/discovery/test_tombasearch.py
+++ b/tests/discovery/test_tombasearch.py
@@ -180,6 +180,50 @@ async def test_paid_tomba_search_honors_nonzero_start(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_paid_tomba_search_preserves_first_page_after_rate_limit(monkeypatch, caplog) -> None:
+    requests: list[str] = []
+    responses = iter(
+        [
+            FetcherResponse(
+                body={
+                    'data': {
+                        'pricing': {'name': 'Growth'},
+                        'requests': {'domains': {'available': 10, 'used': 0}},
+                    }
+                },
+                status=200,
+                headers={},
+            ),
+            FetcherResponse(body={'data': {'total': 175}}, status=200, headers={}),
+            FetcherResponse(body=tomba_page(0), status=200, headers={}),
+            FetcherResponse(body={'error': 'provider detail'}, status=429, headers={}),
+        ]
+    )
+
+    async def fake_fetch_all(urls, **_kwargs):
+        requests.append(urls[0])
+        return [next(responses)]
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(tombasearch.Core, 'tomba_key', lambda: ('test-key', 'test-secret'))
+    monkeypatch.setattr(tombasearch.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(tombasearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(tombasearch.asyncio, 'sleep', no_sleep)
+    search = tombasearch.SearchTomba('example.test', 120, 0)
+
+    with caplog.at_level(logging.INFO, logger=tombasearch.__name__):
+        await search.process()
+
+    assert len(await search.get_emails()) == 50
+    assert len(await search.get_hostnames()) == 50
+    assert requests[-1] == 'https://api.tomba.io/v1/domain-search?domain=example.test&limit=50&page=2'
+    assert 'Tomba request failed with HTTP 429' in caplog.text
+    assert 'provider detail' not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_free_tomba_search_honors_limit_and_start(monkeypatch) -> None:
     requests: list[str] = []
     responses = iter(

--- a/tests/discovery/test_tombasearch.py
+++ b/tests/discovery/test_tombasearch.py
@@ -1,0 +1,110 @@
+import pytest
+
+from theHarvester.discovery import tombasearch
+from theHarvester.discovery.constants import MissingKey
+
+
+@pytest.mark.parametrize(
+    'credentials',
+    [
+        (None, 'test-secret'),
+        ('test-key', None),
+        ('  ', 'test-secret'),
+        ('test-key', '  '),
+    ],
+)
+def test_tomba_rejects_missing_or_blank_credentials(monkeypatch, credentials) -> None:
+    monkeypatch.setattr(tombasearch.Core, 'tomba_key', lambda: credentials)
+
+    with pytest.raises(MissingKey):
+        tombasearch.SearchTomba('example.test', 10, 0)
+
+
+@pytest.mark.asyncio
+async def test_paid_tomba_search_uses_documented_pages_and_page_size(monkeypatch) -> None:
+    requests: list[tuple[str, bool]] = []
+    responses = iter(
+        [
+            {
+                'data': {
+                    'pricing': {'name': 'Growth'},
+                    'requests': {'domains': {'available': 10, 'used': 0}},
+                }
+            },
+            {'data': {'total': 120}},
+            {
+                'data': {
+                    'emails': [
+                        {'email': 'alice@example.test', 'sources': [{'website_url': 'api.example.test'}]},
+                    ]
+                }
+            },
+            {
+                'data': {
+                    'emails': [
+                        {'email': 'bob@example.test', 'sources': [{'website_url': 'www.example.test'}]},
+                    ]
+                }
+            },
+            {'data': {'emails': []}},
+        ]
+    )
+
+    async def fake_fetch_all(urls, *, proxy=False, **_kwargs):
+        requests.append((urls[0], proxy))
+        return [next(responses)]
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(tombasearch.Core, 'tomba_key', lambda: ('test-key', 'test-secret'))
+    monkeypatch.setattr(tombasearch.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(tombasearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(tombasearch.asyncio, 'sleep', no_sleep)
+
+    search = tombasearch.SearchTomba('example.test', 120, 0)
+    await search.process(proxy=True)
+
+    assert requests == [
+        ('https://api.tomba.io/v1/me', True),
+        ('https://api.tomba.io/v1/email-count?domain=example.test', True),
+        ('https://api.tomba.io/v1/domain-search?domain=example.test&limit=50&page=1', True),
+        ('https://api.tomba.io/v1/domain-search?domain=example.test&limit=50&page=2', True),
+        ('https://api.tomba.io/v1/domain-search?domain=example.test&limit=50&page=3', True),
+    ]
+    assert await search.get_emails() == ['alice@example.test', 'bob@example.test']
+    assert await search.get_hostnames() == ['api.example.test', 'www.example.test']
+
+
+@pytest.mark.asyncio
+async def test_paid_tomba_search_stops_before_exceeding_quota(monkeypatch) -> None:
+    requests: list[str] = []
+    responses = iter(
+        [
+            {
+                'data': {
+                    'pricing': {'name': 'Growth'},
+                    'requests': {'domains': {'available': 2, 'used': 0}},
+                }
+            },
+            {'data': {'total': 120}},
+        ]
+    )
+
+    async def fake_fetch_all(urls, **_kwargs):
+        requests.append(urls[0])
+        return [next(responses)]
+
+    monkeypatch.setattr(tombasearch.Core, 'tomba_key', lambda: ('test-key', 'test-secret'))
+    monkeypatch.setattr(tombasearch.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(tombasearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = tombasearch.SearchTomba('example.test', 120, 0)
+    await search.process()
+
+    assert requests == [
+        'https://api.tomba.io/v1/me',
+        'https://api.tomba.io/v1/email-count?domain=example.test',
+    ]
+    assert await search.get_emails() == []
+    assert await search.get_hostnames() == []

--- a/tests/discovery/test_tombasearch.py
+++ b/tests/discovery/test_tombasearch.py
@@ -1,7 +1,11 @@
+import logging
+from typing import Any
+
 import pytest
 
 from theHarvester.discovery import tombasearch
 from theHarvester.discovery.constants import MissingKey
+from theHarvester.lib.core import FetcherResponse
 
 
 def tomba_page(first: int, count: int = 50) -> dict:
@@ -34,6 +38,53 @@ def test_tomba_rejects_missing_or_blank_credentials(monkeypatch, credentials) ->
         tombasearch.SearchTomba('example.test', 10, 0)
 
 
+@pytest.mark.parametrize('status', [401, 403, 429])
+@pytest.mark.asyncio
+async def test_tomba_http_failures_return_no_results(monkeypatch, caplog, status: int) -> None:
+    async def fake_fetch_all(*_args: Any, **kwargs: Any) -> list[FetcherResponse]:
+        assert kwargs['include_metadata'] is True
+        return [FetcherResponse(body={'error': 'provider detail'}, status=status, headers={})]
+
+    monkeypatch.setattr(tombasearch.Core, 'tomba_key', lambda: ('test-key', 'test-secret'))
+    monkeypatch.setattr(tombasearch.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(tombasearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = tombasearch.SearchTomba('example.test', 10, 0)
+
+    with caplog.at_level(logging.INFO, logger=tombasearch.__name__):
+        await search.process()
+
+    assert await search.get_emails() == []
+    assert await search.get_hostnames() == []
+    assert f'Tomba request failed with HTTP {status}' in caplog.text
+    assert 'provider detail' not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ('response', 'message'),
+    [
+        ([], 'Tomba request failed without a response'),
+        ([FetcherResponse(body='not json', status=200, headers={})], 'Tomba returned malformed data'),
+        ([FetcherResponse(body={}, status=200, headers={})], 'Tomba returned malformed data'),
+    ],
+)
+@pytest.mark.asyncio
+async def test_tomba_empty_or_malformed_response_returns_no_results(monkeypatch, caplog, response, message) -> None:
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any):
+        return response
+
+    monkeypatch.setattr(tombasearch.Core, 'tomba_key', lambda: ('test-key', 'test-secret'))
+    monkeypatch.setattr(tombasearch.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(tombasearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = tombasearch.SearchTomba('example.test', 10, 0)
+
+    with caplog.at_level(logging.INFO, logger=tombasearch.__name__):
+        await search.process()
+
+    assert await search.get_emails() == []
+    assert await search.get_hostnames() == []
+    assert message in caplog.text
+
+
 @pytest.mark.asyncio
 async def test_paid_tomba_search_uses_documented_pages_and_page_size(monkeypatch) -> None:
     requests: list[tuple[str, bool]] = []
@@ -54,7 +105,7 @@ async def test_paid_tomba_search_uses_documented_pages_and_page_size(monkeypatch
 
     async def fake_fetch_all(urls, *, proxy=False, **_kwargs):
         requests.append((urls[0], proxy))
-        return [next(responses)]
+        return [FetcherResponse(body=next(responses), status=200, headers={})]
 
     async def no_sleep(_seconds: float) -> None:
         return None
@@ -102,7 +153,7 @@ async def test_paid_tomba_search_honors_nonzero_start(monkeypatch) -> None:
 
     async def fake_fetch_all(urls, **_kwargs):
         requests.append(urls[0])
-        return [next(responses)]
+        return [FetcherResponse(body=next(responses), status=200, headers={})]
 
     async def no_sleep(_seconds: float) -> None:
         return None
@@ -145,7 +196,7 @@ async def test_free_tomba_search_honors_limit_and_start(monkeypatch) -> None:
 
     async def fake_fetch_all(urls, **_kwargs):
         requests.append(urls[0])
-        return [next(responses)]
+        return [FetcherResponse(body=next(responses), status=200, headers={})]
 
     monkeypatch.setattr(tombasearch.Core, 'tomba_key', lambda: ('test-key', 'test-secret'))
     monkeypatch.setattr(tombasearch.Core, 'get_user_agent', lambda: 'test-agent')
@@ -184,7 +235,7 @@ async def test_paid_tomba_search_stops_before_exceeding_quota(monkeypatch) -> No
 
     async def fake_fetch_all(urls, **_kwargs):
         requests.append(urls[0])
-        return [next(responses)]
+        return [FetcherResponse(body=next(responses), status=200, headers={})]
 
     monkeypatch.setattr(tombasearch.Core, 'tomba_key', lambda: ('test-key', 'test-secret'))
     monkeypatch.setattr(tombasearch.Core, 'get_user_agent', lambda: 'test-agent')

--- a/theHarvester/discovery/huntersearch.py
+++ b/theHarvester/discovery/huntersearch.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 
 from theHarvester.discovery.constants import MissingKey
-from theHarvester.lib.core import AsyncFetcher, Core
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
 
 logger = logging.getLogger(__name__)
 
@@ -26,30 +26,53 @@ class SearchHunter:
         self.hostnames: list = []
         self.emails: list = []
 
+    async def _fetch_json(self, url: str, headers: dict[str, str]) -> dict | None:
+        response = await AsyncFetcher.fetch_all(
+            [url],
+            headers=headers,
+            proxy=self.proxy,
+            json=True,
+            include_metadata=True,
+        )
+        metadata = response[0] if response and isinstance(response[0], FetcherResponse) else None
+        if metadata is None:
+            logger.info('Hunter request failed without a response')
+            return None
+        if not 200 <= metadata.status < 300:
+            logger.info(f'Hunter request failed with HTTP {metadata.status}')
+            return None
+        if not isinstance(metadata.body, dict):
+            logger.info('Hunter returned malformed data')
+            return None
+        return metadata.body
+
     async def do_search(self) -> None:
         # First determine if a user account is not a free account, this call is free
         is_free = True
         headers = {'User-Agent': Core.get_user_agent()}
         acc_info_url = f'https://api.hunter.io/v2/account?api_key={self.key}'
-        response = await AsyncFetcher.fetch_all([acc_info_url], headers=headers, proxy=self.proxy, json=True)
-        is_free = (
-            is_free if 'plan_name' in response[0]['data'].keys() and response[0]['data']['plan_name'].lower() == 'free' else False
-        )
+        response = await self._fetch_json(acc_info_url, headers)
+        if response is None:
+            return
+        is_free = is_free if 'plan_name' in response['data'].keys() and response['data']['plan_name'].lower() == 'free' else False
         # Extract the total number of requests that are available for an account
 
         total_requests_avail = (
-            response[0]['data']['requests']['searches']['available'] - response[0]['data']['requests']['searches']['used']
+            response['data']['requests']['searches']['available'] - response['data']['requests']['searches']['used']
         )
         if is_free:
-            response = await AsyncFetcher.fetch_all([self.database], headers=headers, proxy=self.proxy, json=True)
-            self.emails, self.hostnames = await self.parse_resp(json_resp=response[0])
+            response = await self._fetch_json(self.database, headers)
+            if response is not None:
+                self.emails, self.hostnames = await self.parse_resp(json_resp=response)
         else:
             # Determine the total number of emails that are available
             # As the most emails you can get within one query are 100
             # This is only done where paid accounts are in play
             hunter_dinfo_url = f'https://api.hunter.io/v2/email-count?domain={self.word}'
-            response = await AsyncFetcher.fetch_all([hunter_dinfo_url], headers=headers, proxy=self.proxy, json=True)
-            total_results = min(max(0, response[0]['data']['total'] - self.start), self.requested_limit)
+            response = await self._fetch_json(hunter_dinfo_url, headers)
+            if response is None:
+                return
+            total_results = min(max(0, response['data']['total'] - self.start), self.requested_limit)
             total_number_reqs = (total_results + 99) // 100
             # Parse out meta field within initial JSON response to determine the total number of results
             if total_requests_avail < total_number_reqs:
@@ -66,8 +89,10 @@ class SearchHunter:
             for offset in range(self.start, result_end, 100):
                 page_limit = min(100, result_end - offset)
                 req_url = f'https://api.hunter.io/v2/domain-search?domain={self.word}&api_key={self.key}&limit={page_limit}&offset={offset}'
-                response = await AsyncFetcher.fetch_all([req_url], headers=headers, proxy=self.proxy, json=True)
-                temp_emails, temp_hostnames = await self.parse_resp(response[0])
+                response = await self._fetch_json(req_url, headers)
+                if response is None:
+                    return
+                temp_emails, temp_hostnames = await self.parse_resp(response)
                 self.emails.extend(temp_emails)
                 self.hostnames.extend(temp_hostnames)
                 await asyncio.sleep(1)
@@ -88,7 +113,10 @@ class SearchHunter:
 
     async def process(self, proxy: bool = False) -> None:
         self.proxy = proxy
-        await self.do_search()  # Only need to do it once.
+        try:
+            await self.do_search()  # Only need to do it once.
+        except (AttributeError, KeyError, TypeError):
+            logger.info('Hunter returned malformed data')
 
     async def get_emails(self):
         return self.emails

--- a/theHarvester/discovery/huntersearch.py
+++ b/theHarvester/discovery/huntersearch.py
@@ -10,15 +10,16 @@ logger = logging.getLogger(__name__)
 class SearchHunter:
     def __init__(self, word, limit, start) -> None:
         self.word = word
-        self.limit = limit
+        self.requested_limit = limit
         self.limit = min(limit, 10)
         self.start = start
-        self.key = Core.hunter_key()
-        if self.key is None:
+        key = Core.hunter_key()
+        self.key = key.strip() if key else ''
+        if not self.key:
             raise MissingKey('Hunter')
         self.total_results = ''
         self.counter = start
-        self.database = f'https://api.hunter.io/v2/domain-search?domain={self.word}&api_key={self.key}&limit=10'
+        self.database = f'https://api.hunter.io/v2/domain-search?domain={self.word}&api_key={self.key}&limit={self.limit}'
         self.proxy = False
         self.hostnames: list = []
         self.emails: list = []
@@ -28,7 +29,7 @@ class SearchHunter:
         is_free = True
         headers = {'User-Agent': Core.get_user_agent()}
         acc_info_url = f'https://api.hunter.io/v2/account?api_key={self.key}'
-        response = await AsyncFetcher.fetch_all([acc_info_url], headers=headers, json=True)
+        response = await AsyncFetcher.fetch_all([acc_info_url], headers=headers, proxy=self.proxy, json=True)
         is_free = (
             is_free if 'plan_name' in response[0]['data'].keys() and response[0]['data']['plan_name'].lower() == 'free' else False
         )
@@ -46,7 +47,8 @@ class SearchHunter:
             # This is only done where paid accounts are in play
             hunter_dinfo_url = f'https://api.hunter.io/v2/email-count?domain={self.word}'
             response = await AsyncFetcher.fetch_all([hunter_dinfo_url], headers=headers, proxy=self.proxy, json=True)
-            total_number_reqs = response[0]['data']['total'] // 100
+            total_results = min(response[0]['data']['total'], self.requested_limit)
+            total_number_reqs = (total_results + 99) // 100
             # Parse out meta field within initial JSON response to determine the total number of results
             if total_requests_avail < total_number_reqs:
                 logger.info('WARNING: account does not have enough requests to gather all emails')
@@ -55,12 +57,12 @@ class SearchHunter:
                 )
                 logger.info('RETURNING current results, if you would still like to run this module comment out the if request')
                 return
-            self.limit = 100
             # max number of emails you can get per request is 100
             # increments of 100 with offset determining where to start
             # See docs for more details: https://hunter.io/api-documentation/v2#domain-search
-            for offset in range(0, 100 * total_number_reqs, 100):
-                req_url = f'https://api.hunter.io/v2/domain-search?domain={self.word}&api_key={self.key}&limit{self.limit}&offset={offset}'
+            for offset in range(0, total_results, 100):
+                page_limit = min(100, total_results - offset)
+                req_url = f'https://api.hunter.io/v2/domain-search?domain={self.word}&api_key={self.key}&limit={page_limit}&offset={offset}'
                 response = await AsyncFetcher.fetch_all([req_url], headers=headers, proxy=self.proxy, json=True)
                 temp_emails, temp_hostnames = await self.parse_resp(response[0])
                 self.emails.extend(temp_emails)

--- a/theHarvester/discovery/huntersearch.py
+++ b/theHarvester/discovery/huntersearch.py
@@ -19,7 +19,9 @@ class SearchHunter:
             raise MissingKey('Hunter')
         self.total_results = ''
         self.counter = start
-        self.database = f'https://api.hunter.io/v2/domain-search?domain={self.word}&api_key={self.key}&limit={self.limit}'
+        self.database = (
+            f'https://api.hunter.io/v2/domain-search?domain={self.word}&api_key={self.key}&limit={self.limit}&offset={self.start}'
+        )
         self.proxy = False
         self.hostnames: list = []
         self.emails: list = []
@@ -47,7 +49,7 @@ class SearchHunter:
             # This is only done where paid accounts are in play
             hunter_dinfo_url = f'https://api.hunter.io/v2/email-count?domain={self.word}'
             response = await AsyncFetcher.fetch_all([hunter_dinfo_url], headers=headers, proxy=self.proxy, json=True)
-            total_results = min(response[0]['data']['total'], self.requested_limit)
+            total_results = min(max(0, response[0]['data']['total'] - self.start), self.requested_limit)
             total_number_reqs = (total_results + 99) // 100
             # Parse out meta field within initial JSON response to determine the total number of results
             if total_requests_avail < total_number_reqs:
@@ -60,8 +62,9 @@ class SearchHunter:
             # max number of emails you can get per request is 100
             # increments of 100 with offset determining where to start
             # See docs for more details: https://hunter.io/api-documentation/v2#domain-search
-            for offset in range(0, total_results, 100):
-                page_limit = min(100, total_results - offset)
+            result_end = self.start + total_results
+            for offset in range(self.start, result_end, 100):
+                page_limit = min(100, result_end - offset)
                 req_url = f'https://api.hunter.io/v2/domain-search?domain={self.word}&api_key={self.key}&limit={page_limit}&offset={offset}'
                 response = await AsyncFetcher.fetch_all([req_url], headers=headers, proxy=self.proxy, json=True)
                 temp_emails, temp_hostnames = await self.parse_resp(response[0])

--- a/theHarvester/discovery/tombasearch.py
+++ b/theHarvester/discovery/tombasearch.py
@@ -19,7 +19,6 @@ class SearchTomba:
             raise MissingKey('Tomba Key and/or Secret')
         self.total_results = ''
         self.counter = start
-        self.database = f'https://api.tomba.io/v1/domain-search?domain={self.word}&limit=10'
         self.proxy = False
         self.hostnames: list = []
         self.emails: list = []
@@ -46,36 +45,32 @@ class SearchTomba:
         )
 
         if is_free:
-            response = await AsyncFetcher.fetch_all([self.database], headers=headers, proxy=self.proxy, json=True)
-            self.emails, self.hostnames = await self.parse_resp(json_resp=response[0])
+            page_size = 10
+            total_results = self.limit
         else:
-            # Determine the total number of emails that are available
-            # As the most emails you can get within one query are 100
-            # This is only done where paid accounts are in play
             tomba_counter = f'https://api.tomba.io/v1/email-count?domain={self.word}'
             response = await AsyncFetcher.fetch_all([tomba_counter], headers=headers, proxy=self.proxy, json=True)
-            total_results = min(response[0]['data']['total'], self.requested_limit)
-            total_number_reqs = (total_results + 49) // 50
-            # Parse out meta field within initial JSON response to determine the total number of results
-            if total_requests_avail < total_number_reqs:
-                logger.info('WARNING: The account does not have enough requests to gather all the emails.')
-                logger.info(
-                    f'Total requests available: {total_requests_avail}, total requests needed to be made: {total_number_reqs}'
-                )
-                logger.info(
-                    'RETURNING current results, If you still wish to run this module despite the current results, please comment out the "if request" line.'
-                )
-                return
-            self.limit = 50
-            # max number of emails you can get per request
-            # increments of max number with page determining where to start
-            # See docs for more details: https://developer.tomba.io/#domain-search
-            for page in range(1, total_number_reqs + 1):
-                req_url = f'https://api.tomba.io/v1/domain-search?domain={self.word}&limit={self.limit}&page={page}'
-                response = await AsyncFetcher.fetch_all([req_url], headers=headers, proxy=self.proxy, json=True)
-                temp_emails, temp_hostnames = await self.parse_resp(response[0])
-                self.emails.extend(temp_emails)
-                self.hostnames.extend(temp_hostnames)
+            total_results = min(max(0, response[0]['data']['total'] - self.start), self.requested_limit)
+            page_size = 50
+
+        first_page = self.start // page_size + 1
+        first_page_skip = self.start % page_size
+        total_number_reqs = (first_page_skip + total_results + page_size - 1) // page_size if total_results else 0
+        if total_requests_avail < total_number_reqs:
+            logger.info('WARNING: The account does not have enough requests to gather all the emails.')
+            return
+
+        remaining = total_results
+        for page in range(first_page, first_page + total_number_reqs):
+            req_url = f'https://api.tomba.io/v1/domain-search?domain={self.word}&limit={page_size}&page={page}'
+            response = await AsyncFetcher.fetch_all([req_url], headers=headers, proxy=self.proxy, json=True)
+            skip = first_page_skip if page == first_page else 0
+            response[0]['data']['emails'] = response[0]['data']['emails'][skip : skip + remaining]
+            temp_emails, temp_hostnames = await self.parse_resp(response[0])
+            self.emails.extend(temp_emails)
+            self.hostnames.extend(temp_hostnames)
+            remaining -= len(response[0]['data']['emails'])
+            if not is_free:
                 await asyncio.sleep(1)
 
     async def parse_resp(self, json_resp):

--- a/theHarvester/discovery/tombasearch.py
+++ b/theHarvester/discovery/tombasearch.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 
 from theHarvester.discovery.constants import MissingKey
-from theHarvester.lib.core import AsyncFetcher, Core
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +23,26 @@ class SearchTomba:
         self.hostnames: list = []
         self.emails: list = []
 
+    async def _fetch_json(self, url: str, headers: dict[str, str]) -> dict | None:
+        response = await AsyncFetcher.fetch_all(
+            [url],
+            headers=headers,
+            proxy=self.proxy,
+            json=True,
+            include_metadata=True,
+        )
+        metadata = response[0] if response and isinstance(response[0], FetcherResponse) else None
+        if metadata is None:
+            logger.info('Tomba request failed without a response')
+            return None
+        if not 200 <= metadata.status < 300:
+            logger.info(f'Tomba request failed with HTTP {metadata.status}')
+            return None
+        if not isinstance(metadata.body, dict):
+            logger.info('Tomba returned malformed data')
+            return None
+        return metadata.body
+
     async def do_search(self) -> None:
         # First determine if a user account is not a free account, this call is free
         is_free = True
@@ -32,16 +52,18 @@ class SearchTomba:
             'X-Tomba-Secret': self.key[1],
         }
         acc_info_url = 'https://api.tomba.io/v1/me'
-        response = await AsyncFetcher.fetch_all([acc_info_url], headers=headers, proxy=self.proxy, json=True)
+        response = await self._fetch_json(acc_info_url, headers)
+        if response is None:
+            return
         is_free = (
             is_free
-            if 'name' in response[0]['data']['pricing'].keys() and response[0]['data']['pricing']['name'].lower() == 'free'
+            if 'name' in response['data']['pricing'].keys() and response['data']['pricing']['name'].lower() == 'free'
             else False
         )
         # Extract the total number of requests that are available for an account
 
         total_requests_avail = (
-            response[0]['data']['requests']['domains']['available'] - response[0]['data']['requests']['domains']['used']
+            response['data']['requests']['domains']['available'] - response['data']['requests']['domains']['used']
         )
 
         if is_free:
@@ -49,8 +71,10 @@ class SearchTomba:
             total_results = self.limit
         else:
             tomba_counter = f'https://api.tomba.io/v1/email-count?domain={self.word}'
-            response = await AsyncFetcher.fetch_all([tomba_counter], headers=headers, proxy=self.proxy, json=True)
-            total_results = min(max(0, response[0]['data']['total'] - self.start), self.requested_limit)
+            response = await self._fetch_json(tomba_counter, headers)
+            if response is None:
+                return
+            total_results = min(max(0, response['data']['total'] - self.start), self.requested_limit)
             page_size = 50
 
         first_page = self.start // page_size + 1
@@ -63,13 +87,15 @@ class SearchTomba:
         remaining = total_results
         for page in range(first_page, first_page + total_number_reqs):
             req_url = f'https://api.tomba.io/v1/domain-search?domain={self.word}&limit={page_size}&page={page}'
-            response = await AsyncFetcher.fetch_all([req_url], headers=headers, proxy=self.proxy, json=True)
+            response = await self._fetch_json(req_url, headers)
+            if response is None:
+                return
             skip = first_page_skip if page == first_page else 0
-            response[0]['data']['emails'] = response[0]['data']['emails'][skip : skip + remaining]
-            temp_emails, temp_hostnames = await self.parse_resp(response[0])
+            response['data']['emails'] = response['data']['emails'][skip : skip + remaining]
+            temp_emails, temp_hostnames = await self.parse_resp(response)
             self.emails.extend(temp_emails)
             self.hostnames.extend(temp_hostnames)
-            remaining -= len(response[0]['data']['emails'])
+            remaining -= len(response['data']['emails'])
             if not is_free:
                 await asyncio.sleep(1)
 
@@ -89,7 +115,10 @@ class SearchTomba:
 
     async def process(self, proxy: bool = False) -> None:
         self.proxy = proxy
-        await self.do_search()  # Only need to do it once.
+        try:
+            await self.do_search()  # Only need to do it once.
+        except (AttributeError, KeyError, TypeError):
+            logger.info('Tomba returned malformed data')
 
     async def get_emails(self):
         return self.emails

--- a/theHarvester/discovery/tombasearch.py
+++ b/theHarvester/discovery/tombasearch.py
@@ -10,11 +10,12 @@ logger = logging.getLogger(__name__)
 class SearchTomba:
     def __init__(self, word, limit, start) -> None:
         self.word = word
-        self.limit = limit
+        self.requested_limit = limit
         self.limit = min(limit, 10)
         self.start = start
-        self.key = Core.tomba_key()
-        if self.key[0] is None or self.key[1] is None:
+        key, secret = Core.tomba_key()
+        self.key = (key.strip() if key else '', secret.strip() if secret else '')
+        if not all(self.key):
             raise MissingKey('Tomba Key and/or Secret')
         self.total_results = ''
         self.counter = start
@@ -32,7 +33,7 @@ class SearchTomba:
             'X-Tomba-Secret': self.key[1],
         }
         acc_info_url = 'https://api.tomba.io/v1/me'
-        response = await AsyncFetcher.fetch_all([acc_info_url], headers=headers, json=True)
+        response = await AsyncFetcher.fetch_all([acc_info_url], headers=headers, proxy=self.proxy, json=True)
         is_free = (
             is_free
             if 'name' in response[0]['data']['pricing'].keys() and response[0]['data']['pricing']['name'].lower() == 'free'
@@ -53,7 +54,8 @@ class SearchTomba:
             # This is only done where paid accounts are in play
             tomba_counter = f'https://api.tomba.io/v1/email-count?domain={self.word}'
             response = await AsyncFetcher.fetch_all([tomba_counter], headers=headers, proxy=self.proxy, json=True)
-            total_number_reqs = response[0]['data']['total'] // 100
+            total_results = min(response[0]['data']['total'], self.requested_limit)
+            total_number_reqs = (total_results + 49) // 50
             # Parse out meta field within initial JSON response to determine the total number of results
             if total_requests_avail < total_number_reqs:
                 logger.info('WARNING: The account does not have enough requests to gather all the emails.')
@@ -64,11 +66,11 @@ class SearchTomba:
                     'RETURNING current results, If you still wish to run this module despite the current results, please comment out the "if request" line.'
                 )
                 return
-            self.limit = 100
+            self.limit = 50
             # max number of emails you can get per request
             # increments of max number with page determining where to start
             # See docs for more details: https://developer.tomba.io/#domain-search
-            for page in range(0, total_number_reqs + 1):
+            for page in range(1, total_number_reqs + 1):
                 req_url = f'https://api.tomba.io/v1/domain-search?domain={self.word}&limit={self.limit}&page={page}'
                 response = await AsyncFetcher.fetch_all([req_url], headers=headers, proxy=self.proxy, json=True)
                 temp_emails, temp_hostnames = await self.parse_resp(response[0])


### PR DESCRIPTION
## Summary

- reject blank Hunter and Tomba credentials before network access
- honor result limits and start windows with documented provider pagination
- handle HTTP failures and malformed responses without logging provider payload details
- preserve earlier normalized results when a later page fails

This is a focused partial slice of NotoriousRebel/theHarvester#101.

## Verification

- 528 passed, 6 skipped
- Ruff check and format check
- mypy
- git diff --check
- parallel Standards and Spec reviews against eb758322