### PR TITLE
Contract Leak-Lookup evidence handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Read the **API key** column as follows:
 | `hunterhow` | ✓ | No | No | No | No | No | No | No | ✓ |
 | `intelx` | ✓ | ✓ | No | No | ✓ | No | No | No | ✓ |
 | `leakix` | ✓ | ✓ | No | No | No | No | No | No | Optional |
-| `leaklookup` | No | ✓ | No | No | No | No | No | `POST /additional/leaks` response | ✓ |
+| `leaklookup` | No | ✓ | No | No | No | No | ✓ | `POST /additional/leaks` response | ✓ |
 | `mojeek` | ✓ | ✓ | No | No | No | No | No | No | Optional |
 | `netlas` | ✓ | No | No | No | No | No | No | No | ✓ |
 | `onyphe` | ✓ | No | ✓ | ✓ | No | No | No | No | ✓ |

--- a/tests/discovery/test_leaklookup.py
+++ b/tests/discovery/test_leaklookup.py
@@ -1,0 +1,229 @@
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from theHarvester.discovery import leaklookup
+from theHarvester.discovery.constants import MissingKey
+from theHarvester.lib.completed_result import CompletedResult
+from theHarvester.lib.api import additional_endpoints
+from theHarvester.lib.core import FetcherResponse
+from theHarvester import __main__ as theharvester_main
+
+
+@pytest.mark.parametrize('key', [None, '', ' '])
+def test_leaklookup_rejects_missing_or_blank_key(monkeypatch, key) -> None:
+    monkeypatch.setattr(leaklookup.Core, 'leaklookup_key', lambda: key)
+
+    with pytest.raises(MissingKey):
+        leaklookup.SearchLeakLookup('example.test')
+
+
+@pytest.mark.asyncio
+async def test_leaklookup_posts_domain_search_and_keeps_normalized_evidence(monkeypatch) -> None:
+    requests: list[tuple[str, dict[str, str], bool]] = []
+
+    async def fake_post_fetch(url: str, *, data, proxy=False, **kwargs: Any) -> FetcherResponse:
+        assert kwargs['include_metadata'] is True
+        assert 'Authorization' not in kwargs['headers']
+        requests.append((url, data, proxy))
+        return FetcherResponse(
+            body={
+                'error': 'false',
+                'message': {
+                    'Example Breach': [
+                        {
+                            'email_address': 'alice@example.test',
+                            'password': 'fixture-password-must-not-be-retained',
+                            'ipaddress': '192.0.2.10',
+                        },
+                        {'email': 'bob@example.test', 'secret': 'fixture-secret-must-not-be-retained'},
+                        {'email_address': 7},
+                    ],
+                    'Public Only Breach': {'fields': ['email_address', 'password']},
+                },
+            },
+            status=200,
+            headers={},
+        )
+
+    monkeypatch.setattr(leaklookup.Core, 'leaklookup_key', lambda: 'test-key')
+    monkeypatch.setattr(leaklookup.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(leaklookup.AsyncFetcher, 'post_fetch', fake_post_fetch)
+    search = leaklookup.SearchLeakLookup('example.test')
+
+    await search.process(proxy=True)
+
+    assert requests == [
+        (
+            'https://leak-lookup.com/api/search',
+            {'key': 'test-key', 'type': 'domain', 'query': 'example.test'},
+            True,
+        )
+    ]
+    assert await search.get_emails() == {'alice@example.test', 'bob@example.test'}
+    assert await search.get_breach_names() == {'Example Breach', 'Public Only Breach'}
+    assert await search.get_sources() == {'Example Breach', 'Public Only Breach'}
+    assert await search.get_leaks() == [
+        {'breach': 'Example Breach', 'email': 'alice@example.test'},
+        {'breach': 'Example Breach', 'email': 'bob@example.test'},
+        {'breach': 'Public Only Breach'},
+    ]
+    assert await search.get_passwords() == set()
+    assert await search.get_hostnames() == set()
+    assert await search.get_leak_dates() == set()
+    assert 'fixture-password' not in repr(await search.get_leaks())
+    assert 'fixture-secret' not in repr(await search.get_leaks())
+
+
+@pytest.mark.parametrize('status', [401, 403, 429])
+@pytest.mark.asyncio
+async def test_leaklookup_http_failure_returns_no_results(monkeypatch, caplog, status: int) -> None:
+    async def fake_post_fetch(*_args: Any, **_kwargs: Any) -> FetcherResponse:
+        return FetcherResponse(body={'message': 'provider detail'}, status=status, headers={})
+
+    monkeypatch.setattr(leaklookup.Core, 'leaklookup_key', lambda: 'test-key')
+    monkeypatch.setattr(leaklookup.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(leaklookup.AsyncFetcher, 'post_fetch', fake_post_fetch)
+    search = leaklookup.SearchLeakLookup('example.test')
+
+    with caplog.at_level(logging.INFO, logger=leaklookup.__name__):
+        await search.process()
+
+    assert await search.get_emails() == set()
+    assert await search.get_breach_names() == set()
+    assert f'Leak-Lookup request failed with HTTP {status}' in caplog.text
+    assert 'provider detail' not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ('response', 'message'),
+    [
+        (None, 'Leak-Lookup request failed without a response'),
+        (FetcherResponse(body='not json', status=200, headers={}), 'Leak-Lookup returned malformed data'),
+        (FetcherResponse(body={}, status=200, headers={}), 'Leak-Lookup returned malformed data'),
+        (
+            FetcherResponse(
+                body={'error': 'true', 'message': 'RATE LIMIT REACHED provider detail'},
+                status=200,
+                headers={},
+            ),
+            'Leak-Lookup request failed',
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_leaklookup_empty_or_malformed_response_fails_closed(monkeypatch, caplog, response, message) -> None:
+    async def fake_post_fetch(*_args: Any, **_kwargs: Any):
+        return response
+
+    monkeypatch.setattr(leaklookup.Core, 'leaklookup_key', lambda: 'test-key')
+    monkeypatch.setattr(leaklookup.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(leaklookup.AsyncFetcher, 'post_fetch', fake_post_fetch)
+    search = leaklookup.SearchLeakLookup('example.test')
+
+    with caplog.at_level(logging.INFO, logger=leaklookup.__name__):
+        await search.process()
+
+    assert await search.get_emails() == set()
+    assert await search.get_leaks() == []
+    assert message in caplog.text
+    assert 'provider detail' not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_leaklookup_empty_success_returns_no_results(monkeypatch) -> None:
+    async def fake_post_fetch(*_args: Any, **_kwargs: Any) -> FetcherResponse:
+        return FetcherResponse(body={'error': 'false', 'message': {}}, status=200, headers={})
+
+    monkeypatch.setattr(leaklookup.Core, 'leaklookup_key', lambda: 'test-key')
+    monkeypatch.setattr(leaklookup.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(leaklookup.AsyncFetcher, 'post_fetch', fake_post_fetch)
+    search = leaklookup.SearchLeakLookup('example.test')
+
+    await search.process()
+
+    assert await search.get_emails() == set()
+    assert await search.get_breach_names() == set()
+
+
+@pytest.mark.asyncio
+async def test_additional_leaks_endpoint_uses_only_leaklookup(monkeypatch) -> None:
+    class FakeSearchLeakLookup:
+        def __init__(self, domain: str) -> None:
+            assert domain == 'example.test'
+
+        async def process(self) -> None:
+            return None
+
+        async def get_leaks(self) -> list[dict[str, str]]:
+            return [{'breach': 'Example Breach', 'email': 'alice@example.test'}]
+
+    class UnexpectedAdditionalAPIs:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            raise AssertionError('unrelated providers must not be initialized')
+
+    monkeypatch.setattr(additional_endpoints, 'SearchLeakLookup', FakeSearchLeakLookup, raising=False)
+    monkeypatch.setattr(additional_endpoints, 'AdditionalAPIs', UnexpectedAdditionalAPIs)
+
+    result = await additional_endpoints.get_leaks(
+        additional_endpoints.DomainRequest(domain='example.test'),
+        _api_key='local-api-key',
+    )
+
+    assert result == {
+        'status': 'success',
+        'data': [{'breach': 'Example Breach', 'email': 'alice@example.test'}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_leaklookup_emails_and_breaches_reach_completed_result_and_jsonl(monkeypatch, tmp_path: Path) -> None:
+    completed_results: list[CompletedResult] = []
+
+    class FakeStash:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args: object) -> None:
+            return None
+
+        async def store_completed_result(self, result: CompletedResult) -> None:
+            completed_results.append(result)
+
+    class FakeLeakLookup:
+        def __init__(self, domain: str) -> None:
+            assert domain == 'example.com'
+
+        async def process(self, _proxy: bool) -> None:
+            return None
+
+        async def get_emails(self) -> set[str]:
+            return {'alice@example.com'}
+
+        async def get_breach_names(self) -> set[str]:
+            return {'Example Breach'}
+
+    report = tmp_path / 'leaklookup-report'
+    monkeypatch.setattr(theharvester_main.stash, 'StashManager', FakeStash)
+    monkeypatch.setattr(theharvester_main.leaklookup, 'SearchLeakLookup', FakeLeakLookup)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['theHarvester', '-d', 'example.com', '-b', 'leaklookup', '-f', str(report)],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    assert completed_results[0].results == (
+        ('breach', 'Example Breach'),
+        ('email', 'alice@example.com'),
+    )
+    records = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
+    assert {'type': 'breach', 'value': 'Example Breach'} in records
+    assert {'type': 'email', 'value': 'alice@example.com'} in records

--- a/tests/discovery/test_leaklookup.py
+++ b/tests/discovery/test_leaklookup.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from theHarvester.discovery import leaklookup
+from theHarvester.discovery import additional_apis, leaklookup
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib.completed_result import CompletedResult
 from theHarvester.lib.api import additional_endpoints
@@ -177,6 +177,47 @@ async def test_additional_leaks_endpoint_uses_only_leaklookup(monkeypatch) -> No
     assert result == {
         'status': 'success',
         'data': [{'breach': 'Example Breach', 'email': 'alice@example.test'}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_missing_leaklookup_key_does_not_break_security_score_endpoint(monkeypatch) -> None:
+    class PassiveProvider:
+        def __init__(self, _domain: str) -> None:
+            return None
+
+    class FakeSecurityScorecard(PassiveProvider):
+        score = 95
+        grades = {'network': 'A'}
+        issues: list[object] = []
+        recommendations: list[object] = []
+        hosts: set[str] = set()
+
+        async def process(self, _proxy: bool) -> None:
+            return None
+
+    class UnexpectedLeakLookup:
+        def __init__(self, _domain: str) -> None:
+            raise AssertionError('Leak-Lookup must be constructed only when requested')
+
+    monkeypatch.setattr(additional_apis, 'SearchHaveIBeenPwned', PassiveProvider)
+    monkeypatch.setattr(additional_apis, 'SearchBuiltWith', PassiveProvider)
+    monkeypatch.setattr(additional_apis, 'SearchSecurityScorecard', FakeSecurityScorecard)
+    monkeypatch.setattr(additional_apis, 'SearchLeakLookup', UnexpectedLeakLookup)
+
+    result = await additional_endpoints.get_security_score(
+        additional_endpoints.DomainRequest(domain='example.test'),
+        _api_key='local-api-key',
+    )
+
+    assert result == {
+        'status': 'success',
+        'data': {
+            'score': 95,
+            'grades': {'network': 'A'},
+            'issues': [],
+            'recommendations': [],
+        },
     }
 
 

--- a/tests/lib/test_core.py
+++ b/tests/lib/test_core.py
@@ -69,11 +69,11 @@ def test_multiple_capabilities_form_a_union() -> None:
 
 
 def test_breach_capability_includes_every_matching_source() -> None:
-    assert Core.expand_source_selection('breaches') == ['haveibeenpwned', 'hibpverified']
+    assert Core.expand_source_selection('breaches') == ['haveibeenpwned', 'hibpverified', 'leaklookup']
 
 
 def test_named_source_can_be_combined_with_a_capability() -> None:
-    assert Core.expand_source_selection('breaches,hibpverified') == ['haveibeenpwned', 'hibpverified']
+    assert Core.expand_source_selection('breaches,hibpverified') == ['haveibeenpwned', 'hibpverified', 'leaklookup']
 
 
 def test_all_selects_only_passive_catalog_sources() -> None:

--- a/tests/lib/test_source_catalog.py
+++ b/tests/lib/test_source_catalog.py
@@ -60,6 +60,7 @@ def test_source_specs_describe_consolidated_routes_not_getter_presence() -> None
     )
     assert SOURCE_SPECS['haveibeenpwned'].routes == frozenset({ResultRoute.BREACHES})
     assert SOURCE_SPECS['hibpverified'].routes == frozenset({ResultRoute.EMAILS, ResultRoute.BREACHES})
+    assert SOURCE_SPECS['leaklookup'].routes == frozenset({ResultRoute.EMAILS, ResultRoute.BREACHES})
     assert SOURCE_SPECS['urlscan'].routes == frozenset(
         {
             ResultRoute.SUBDOMAINS,

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -241,7 +241,8 @@ def test_query_requires_operator_auth_for_configured_leaklookup(monkeypatch) -> 
     assert response.status_code == 401
 
 
-def test_query_skips_operator_auth_when_verified_hibp_provider_key_is_absent(monkeypatch) -> None:
+@pytest.mark.parametrize('leaklookup_key', [None, '', ' '])
+def test_query_skips_operator_auth_when_credentialed_provider_keys_are_blank(monkeypatch, leaklookup_key) -> None:
     captured: list[Namespace] = []
 
     async def fake_start(
@@ -255,7 +256,7 @@ def test_query_skips_operator_auth_when_verified_hibp_provider_key_is_absent(mon
 
     monkeypatch.delenv('THEHARVESTER_API_KEY', raising=False)
     monkeypatch.setattr(api.__main__.Core, 'hibpverified_key', lambda: None)
-    monkeypatch.setattr(api.__main__.Core, 'leaklookup_key', lambda: None)
+    monkeypatch.setattr(api.__main__.Core, 'leaklookup_key', lambda: leaklookup_key)
     monkeypatch.setattr(api.__main__, 'start', fake_start)
 
     response = TestClient(api.app).get('/query?domain=example.test&source=breaches')

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -225,7 +225,20 @@ def test_authenticated_query_includes_verified_hibp_from_capability_selection(mo
     )
 
     assert response.status_code == 200
-    assert captured[0].source == 'haveibeenpwned,hibpverified'
+    assert captured[0].source == 'haveibeenpwned,hibpverified,leaklookup'
+
+
+def test_query_requires_operator_auth_for_configured_leaklookup(monkeypatch) -> None:
+    async def unexpected_start(*_args, **_kwargs):
+        raise AssertionError('collection must not start without operator authentication')
+
+    monkeypatch.setenv('THEHARVESTER_API_KEY', 'operator-secret')
+    monkeypatch.setattr(api.__main__.Core, 'leaklookup_key', lambda: 'provider-secret')
+    monkeypatch.setattr(api.__main__, 'start', unexpected_start)
+
+    response = TestClient(api.app).get('/query?domain=example.test&source=leaklookup')
+
+    assert response.status_code == 401
 
 
 def test_query_skips_operator_auth_when_verified_hibp_provider_key_is_absent(monkeypatch) -> None:
@@ -242,12 +255,13 @@ def test_query_skips_operator_auth_when_verified_hibp_provider_key_is_absent(mon
 
     monkeypatch.delenv('THEHARVESTER_API_KEY', raising=False)
     monkeypatch.setattr(api.__main__.Core, 'hibpverified_key', lambda: None)
+    monkeypatch.setattr(api.__main__.Core, 'leaklookup_key', lambda: None)
     monkeypatch.setattr(api.__main__, 'start', fake_start)
 
     response = TestClient(api.app).get('/query?domain=example.test&source=breaches')
 
     assert response.status_code == 200
-    assert captured[0].source == 'haveibeenpwned,hibpverified'
+    assert captured[0].source == 'haveibeenpwned,hibpverified,leaklookup'
 
 
 def test_sources_advertises_authenticated_verified_hibp(monkeypatch) -> None:

--- a/theHarvester/discovery/additional_apis.py
+++ b/theHarvester/discovery/additional_apis.py
@@ -21,7 +21,7 @@ class AdditionalAPIs:
 
         # Initialize API services
         self.haveibeenpwned = SearchHaveIBeenPwned(domain)
-        self.leaklookup = SearchLeakLookup(domain)
+        self.leaklookup: SearchLeakLookup | None = None
         self.securityscorecard = SearchSecurityScorecard(domain)
         self.builtwith = SearchBuiltWith(domain)
         self.shodan: SearchShodan | None = None  # Will be initialized when needed
@@ -74,6 +74,8 @@ class AdditionalAPIs:
     async def _process_leaklookup(self, proxy: bool = False):
         """Process Leak-Lookup API."""
         try:
+            if self.leaklookup is None:
+                self.leaklookup = SearchLeakLookup(self.domain)
             await self.leaklookup.process(proxy)
             self.results['leaks'] = self.leaklookup.leaks
             self.hosts.update(self.leaklookup.hosts)

--- a/theHarvester/discovery/leaklookup.py
+++ b/theHarvester/discovery/leaklookup.py
@@ -1,9 +1,7 @@
 import logging
 
-import aiohttp
-
 from theHarvester.discovery.constants import MissingKey
-from theHarvester.lib.core import AsyncFetcher, Core
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
 
 logger = logging.getLogger(__name__)
 
@@ -11,54 +9,72 @@ logger = logging.getLogger(__name__)
 class SearchLeakLookup:
     def __init__(self, word: str):
         self.word = word
-        self.api_key = Core.leaklookup_key()
-        self.base_url = 'https://leak-lookup.com/api'
-        self.headers = {'Authorization': f'Bearer {self.api_key}', 'Content-Type': 'application/json'}
+        key = Core.leaklookup_key()
+        self.api_key = key.strip() if key else ''
+        if not self.api_key:
+            raise MissingKey('Leak-Lookup')
+        self.url = 'https://leak-lookup.com/api/search'
         self.hosts: set[str] = set()
         self.emails: set[str] = set()
-        self.leaks: list[dict] = []
+        self.leaks: list[dict[str, str]] = []
         self.passwords: set[str] = set()
         self.sources: set[str] = set()
         self.leak_dates: set[str] = set()
+        self.breach_names: set[str] = set()
 
     async def process(self, proxy: bool = False) -> None:
-        """Search for leaked credentials associated with an email."""
-        try:
-            if proxy:
-                response = await AsyncFetcher.fetch(
-                    session=None,
-                    url=f'{self.base_url}/search?key={self.api_key}&type=email&query={self.word}',
-                    headers=self.headers,
-                    proxy=proxy,
-                )
-                if response:
-                    self.leaks = response
-                    self._extract_data()
-            else:
-                async with aiohttp.ClientSession(headers=self.headers) as session:
-                    async with session.get(f'{self.base_url}/search?key={self.api_key}&type=email&query={self.word}') as response:
-                        if response.status == 200:
-                            self.leaks = await response.json()
-                            self._extract_data()
-                        elif response.status == 401:
-                            logger.info('[!] Missing API key for Leak-Lookup.')
-                            raise MissingKey('Leak-Lookup')
-        except Exception as e:
-            logger.info(f'Error in Leak-Lookup search: {e}')
+        response = await AsyncFetcher.post_fetch(
+            self.url,
+            headers={'User-Agent': Core.get_user_agent()},
+            data={'key': self.api_key, 'type': 'domain', 'query': self.word},
+            proxy=proxy,
+            include_metadata=True,
+        )
+        if not isinstance(response, FetcherResponse):
+            logger.info('Leak-Lookup request failed without a response')
+            return
+        if not 200 <= response.status < 300:
+            logger.info(f'Leak-Lookup request failed with HTTP {response.status}')
+            return
+        if not isinstance(response.body, dict):
+            logger.info('Leak-Lookup returned malformed data')
+            return
+        if response.body.get('error') in (True, 'true', 1, '1'):
+            logger.info('Leak-Lookup request failed')
+            return
 
-    def _extract_data(self) -> None:
-        """Extract and categorize leak information."""
-        for leak in self.leaks:
-            if 'domain' in leak:
-                self.hosts.add(leak['domain'])
-            if 'email' in leak:
-                self.emails.add(leak['email'])
-            if 'password' in leak:
-                self.passwords.add(leak['password'])
-            if 'source' in leak:
-                self.sources.add(leak['source'])
-            if 'date' in leak:
-                self.leak_dates.add(leak['date'])
+        self._extract_data(response.body.get('message'))
+
+    def _extract_data(self, message: object) -> None:
+        if not isinstance(message, dict):
+            logger.info('Leak-Lookup returned malformed data')
+            return
+
+        normalized_leaks: set[tuple[str, str | None]] = set()
+        email_fields = ('email', 'email_address', 'emailaddress', 'email2', 'email_address2', 'emailaddress2')
+        for breach, records in message.items():
+            if not isinstance(breach, str) or not breach.strip():
+                continue
+            breach_name = breach.strip()
+            self.breach_names.add(breach_name)
+            self.sources.add(breach_name)
+            breach_emails: set[str] = set()
+            if isinstance(records, list):
+                for record in records:
+                    if not isinstance(record, dict):
+                        continue
+                    breach_emails.update(
+                        value.strip() for field in email_fields if isinstance((value := record.get(field)), str) and value.strip()
+                    )
+            self.emails.update(breach_emails)
+            normalized_leaks.update((breach_name, email) for email in breach_emails)
+            if not breach_emails:
+                normalized_leaks.add((breach_name, None))
+
+        self.leaks = [
+            {'breach': breach, **({'email': email} if email else {})}
+            for breach, email in sorted(normalized_leaks, key=lambda item: (item[0], item[1] or ''))
+        ]
 
     async def get_hostnames(self) -> set[str]:
         return self.hosts
@@ -66,7 +82,7 @@ class SearchLeakLookup:
     async def get_emails(self) -> set[str]:
         return self.emails
 
-    async def get_leaks(self) -> list[dict]:
+    async def get_leaks(self) -> list[dict[str, str]]:
         return self.leaks
 
     async def get_passwords(self) -> set[str]:
@@ -77,3 +93,6 @@ class SearchLeakLookup:
 
     async def get_leak_dates(self) -> set[str]:
         return self.leak_dates
+
+    async def get_breach_names(self) -> set[str]:
+        return self.breach_names

--- a/theHarvester/lib/api/additional_endpoints.py
+++ b/theHarvester/lib/api/additional_endpoints.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 
 from theHarvester.discovery.additional_apis import AdditionalAPIs
 from theHarvester.discovery.haveibeenpwned import SearchHaveIBeenPwned
+from theHarvester.discovery.leaklookup import SearchLeakLookup
 from theHarvester.lib.api.auth import get_api_key
 
 router = APIRouter()
@@ -37,10 +38,9 @@ async def get_breaches(request: DomainRequest, _api_key: Annotated[str, Depends(
 async def get_leaks(request: DomainRequest, _api_key: Annotated[str, Depends(get_api_key)]):
     """Get leaked credentials for a domain using Leak-Lookup."""
     try:
-        apis = AdditionalAPIs(request.domain, request.api_keys or {})
-        await apis._process_leaklookup()
-        results = apis.results['leaks']
-        return {'status': 'success', 'data': results}
+        search = SearchLeakLookup(request.domain)
+        await search.process()
+        return {'status': 'success', 'data': await search.get_leaks()}
     except Exception as e:
         _raise_processing_error('leaks', e)
 

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -401,7 +401,10 @@ async def query(
     try:
         # Validate sources
         selected_sources = __main__.Core.expand_source_selection(','.join(source))
-        if 'hibpverified' in selected_sources and __main__.Core.hibpverified_key() is not None:
+        credentialed_breach_source = ('hibpverified' in selected_sources and __main__.Core.hibpverified_key() is not None) or (
+            'leaklookup' in selected_sources and __main__.Core.leaklookup_key() is not None
+        )
+        if credentialed_breach_source:
             get_api_key(x_api_key)
         supported_engines = __main__.Core.get_supportedengines()
         for s in selected_sources:

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -401,9 +401,9 @@ async def query(
     try:
         # Validate sources
         selected_sources = __main__.Core.expand_source_selection(','.join(source))
-        credentialed_breach_source = ('hibpverified' in selected_sources and __main__.Core.hibpverified_key() is not None) or (
-            'leaklookup' in selected_sources and __main__.Core.leaklookup_key() is not None
-        )
+        credentialed_breach_source = (
+            'hibpverified' in selected_sources and bool((__main__.Core.hibpverified_key() or '').strip())
+        ) or ('leaklookup' in selected_sources and bool((__main__.Core.leaklookup_key() or '').strip()))
         if credentialed_breach_source:
             get_api_key(x_api_key)
         supported_engines = __main__.Core.get_supportedengines()

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -99,7 +99,7 @@ _SPECS = (
     _spec('hunterhow', ResultRoute.SUBDOMAINS),
     _spec('intelx', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS, ResultRoute.INTERESTING_URLS),
     _spec('leakix', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS),
-    _spec('leaklookup', ResultRoute.EMAILS),
+    _spec('leaklookup', ResultRoute.EMAILS, ResultRoute.BREACHES),
     _spec('mojeek', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS),
     _spec('netlas', ResultRoute.SUBDOMAINS),
     _spec('onyphe', ResultRoute.SUBDOMAINS, ResultRoute.IPS, ResultRoute.ASNS),


### PR DESCRIPTION
## Summary
- send Leak-Lookup searches as documented HTTPS form requests without placing credentials in URLs
- retain only normalized email and breach evidence, excluding unrelated sensitive provider fields
- keep CLI, JSONL, REST, and source catalog behavior aligned while isolating missing credentials from unrelated additional API routes

## Provider contract
Validated against the official Leak-Lookup search documentation: https://leak-lookup.com/docs/search

## Verification
- 546 passed, 6 skipped
- Ruff check and format check
- mypy
- git diff --check
- parallel Standards and Spec reviews with no findings

Partial progress for NotoriousRebel/theHarvester#101. The issue remains open for DeHashed and LeakIX.