### PR TITLE
Persist per-source run provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,14 +237,14 @@ The JSON report is a single object that preserves the legacy automation contract
 
 The XML report contains the command, emails, hosts, and virtual hosts. Use JSON when you need the additional result types above.
 
-The JSONL report is finalized after the selected one-shot actions finish. The first line identifies the run with its UUID, target, UTC timestamps, result counts, and schema version. Each later line is one sorted, deduplicated finding. When you concatenate report files, treat each summary line as the start of a new run.
+The JSONL report is finalized after the selected one-shot actions finish. The first line identifies the run with its UUID, target, UTC timestamps, and result counts. Each later line is one sorted, deduplicated finding. When you concatenate report files, treat each summary line as the start of a new run.
 
 ```jsonl
-{"completed_at":"2026-08-07T12:01:00Z","counts":{"hostname":1},"result_count":1,"run_id":"123e4567-e89b-12d3-a456-426614174000","schema_version":"theharvester-results-v1","started_at":"2026-08-07T12:00:00Z","target":"example.com","type":"summary"}
-{"type":"hostname","value":"api.example.com"}
+{"completed_at":"2026-08-07T12:01:00Z","counts":{"hostname":1},"result_count":1,"run_id":"123e4567-e89b-12d3-a456-426614174000","started_at":"2026-08-07T12:00:00Z","target":"example.com","type":"summary"}
+{"sources":[],"type":"hostname","value":"api.example.com"}
 ```
 
-JSONL v1 is easy to stream for simple findings, but it is not uniformly self-describing. Finding lines inherit their run ID and target from the preceding summary. Structured result types, including recursive DNS records plus `person`, `infostealer`, `shodan`, and `takeover`, store a JSON object inside the string `value` to preserve the v1 wire format. Parse those values a second time with `fromjson`. JSONL v1 does not include source execution records or source attribution.
+JSONL is easy to stream for simple findings, but it is not uniformly self-describing. Finding lines inherit their run ID and target from the preceding summary. Structured result types, including recursive DNS records plus `person`, `infostealer`, `shodan`, and `takeover`, store a JSON object inside the string `value`. Parse those values a second time with `fromjson`. JSONL does not include source execution records. Finding records include source attribution when it is available.
 
 Parse recursive DNS findings as JSON objects:
 

--- a/tests/discovery/test_builtwith.py
+++ b/tests/discovery/test_builtwith.py
@@ -193,9 +193,9 @@ async def test_normalized_builtwith_results_reach_completed_jsonl(
         ('server', 'nginx'),
     )
     records = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
-    assert {'type': 'interesting-url', 'value': 'https://example.com/login'} in records
-    assert {'type': 'framework', 'value': 'Django'} in records
-    assert {'type': 'language', 'value': 'Python'} in records
-    assert {'type': 'server', 'value': 'nginx'} in records
-    assert {'type': 'cms', 'value': 'WordPress'} in records
-    assert {'type': 'analytics', 'value': 'Google Analytics'} in records
+    assert {'type': 'interesting-url', 'value': 'https://example.com/login', 'sources': ['builtwith']} in records
+    assert {'type': 'framework', 'value': 'Django', 'sources': ['builtwith']} in records
+    assert {'type': 'language', 'value': 'Python', 'sources': ['builtwith']} in records
+    assert {'type': 'server', 'value': 'nginx', 'sources': ['builtwith']} in records
+    assert {'type': 'cms', 'value': 'WordPress', 'sources': ['builtwith']} in records
+    assert {'type': 'analytics', 'value': 'Google Analytics', 'sources': ['builtwith']} in records

--- a/tests/discovery/test_certspotter.py
+++ b/tests/discovery/test_certspotter.py
@@ -21,7 +21,7 @@ class TestCertspotterSearch(object):
     @pytest.mark.live_network
     def test_api(self, live_test_domain: str) -> None:
         base_url = f'https://api.certspotter.com/v1/issuances?domain={live_test_domain}&expand=dns_names'
-        headers = {"User-Agent": Core.get_user_agent()}
+        headers = {'User-Agent': Core.get_user_agent()}
         request = httpx.get(base_url, headers=headers, timeout=30)
         assert request.status_code == 200
         payload = request.json()
@@ -96,6 +96,8 @@ class TestCertspotterSearch(object):
 
         assert requests == 2
         assert await search.get_hostnames() == {'host-1.example.com', 'host-2.example.com'}
+        assert search.execution_status == 'partial'
+        assert search.stop_reason == 'page-limit'
         assert 'page limit reached; results may be incomplete' in caplog.text
 
     @pytest.mark.asyncio
@@ -147,6 +149,8 @@ class TestCertspotterSearch(object):
             await search.process()
 
         assert await search.get_hostnames() == {'first.example.com'}
+        assert search.execution_status == 'rate-limited'
+        assert search.stop_reason == 'rate_limited'
         assert 'rate_limited' in caplog.text
         assert 'results may be incomplete' in caplog.text
         assert 'provider details must not be logged' not in caplog.text
@@ -169,12 +173,18 @@ class TestCertspotterSearch(object):
             await search.process()
 
         assert await search.get_hostnames() == {'first.example.com'}
+        assert search.execution_status == 'partial'
+        assert search.stop_reason == 'invalid-response'
         assert 'results may be incomplete' in caplog.text
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize('response', [[], [{}]])
+    @pytest.mark.parametrize(('response', 'stop_reason'), [([], 'no-response'), ([{}], 'invalid-response')])
     async def test_search_reports_invalid_response_as_incomplete(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, response: list[Any]
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        response: list[Any],
+        stop_reason: str,
     ) -> None:
         async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[Any]:
             return response
@@ -185,6 +195,8 @@ class TestCertspotterSearch(object):
             await search.process()
 
         assert await search.get_hostnames() == set()
+        assert search.execution_status == 'partial'
+        assert search.stop_reason == stop_reason
         assert 'results may be incomplete' in caplog.text
 
     @pytest.mark.asyncio
@@ -205,18 +217,24 @@ class TestCertspotterSearch(object):
             await search.process()
 
         assert await search.get_hostnames() == {'first.example.com'}
+        assert search.execution_status == 'partial'
+        assert search.stop_reason == 'malformed-issuance'
         assert 'results may be incomplete' in caplog.text
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        'error',
+        ('error', 'stop_reason'),
         [
-            ConnectionError('private connection details'),
-            RuntimeError('private provider payload'),
+            (ConnectionError('private connection details'), 'connection-error'),
+            (RuntimeError('private provider payload'), 'unexpected-error'),
         ],
     )
     async def test_search_redacts_unexpected_errors(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, error: Exception
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        error: Exception,
+        stop_reason: str,
     ) -> None:
         responses: list[Any] = [
             [{'id': '1', 'dns_names': ['first.example.com']}],
@@ -235,6 +253,8 @@ class TestCertspotterSearch(object):
             await search.process()
 
         assert await search.get_hostnames() == {'first.example.com'}
+        assert search.execution_status == 'partial'
+        assert search.stop_reason == stop_reason
         assert 'results may be incomplete' in caplog.text
         assert str(error) not in caplog.text
 
@@ -260,14 +280,13 @@ class TestCertspotterSearch(object):
 
         assert await search.get_hostnames() == {'first.example.com', 'second.example.com'}
         assert calls == 2
+        assert search.execution_status == 'partial'
+        assert search.stop_reason == 'repeated-cursor'
         assert 'results may be incomplete' in caplog.text
 
     @pytest.mark.asyncio
     async def test_search_continues_until_empty_page(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        pages = [
-            [{'id': str(page_number), 'dns_names': [f'page-{page_number}.example.com']}]
-            for page_number in range(1, 12)
-        ]
+        pages = [[{'id': str(page_number), 'dns_names': [f'page-{page_number}.example.com']}] for page_number in range(1, 12)]
         pages.append([])
         calls = 0
 
@@ -311,8 +330,10 @@ class TestCertspotterSearch(object):
 
         assert await search.get_hostnames() == {'first.example.com'}
         assert calls == 1
+        assert search.execution_status == 'partial'
+        assert search.stop_reason == 'invalid-cursor'
         assert 'results may be incomplete' in caplog.text
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     pytest.main()

--- a/tests/discovery/test_gitlabsearch.py
+++ b/tests/discovery/test_gitlabsearch.py
@@ -173,4 +173,4 @@ async def test_gitlab_urls_reach_completed_jsonl(
     assert exit_info.value.code == 0
     assert completed_results[0].results == (('url', 'https://gitlab.com/group/project'),)
     records = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
-    assert {'type': 'url', 'value': 'https://gitlab.com/group/project'} in records
+    assert {'type': 'url', 'value': 'https://gitlab.com/group/project', 'sources': ['gitlab']} in records

--- a/tests/discovery/test_haveibeenpwned.py
+++ b/tests/discovery/test_haveibeenpwned.py
@@ -173,5 +173,5 @@ async def test_public_breach_names_reach_completed_result_and_jsonl(
         ('breach', 'ExampleBreach'),
     )
     records = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
-    assert {'type': 'breach', 'value': 'Adobe'} in records
-    assert {'type': 'breach', 'value': 'ExampleBreach'} in records
+    assert {'type': 'breach', 'value': 'Adobe', 'sources': ['haveibeenpwned']} in records
+    assert {'type': 'breach', 'value': 'ExampleBreach', 'sources': ['haveibeenpwned']} in records

--- a/tests/discovery/test_hibpverified.py
+++ b/tests/discovery/test_hibpverified.py
@@ -188,5 +188,5 @@ async def test_verified_domain_results_reach_completed_jsonl_and_sqlite_handoff(
         ('email', 'alice@example.com'),
     )
     records = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
-    assert {'type': 'breach', 'value': 'ExampleBreach'} in records
-    assert {'type': 'email', 'value': 'alice@example.com'} in records
+    assert {'type': 'breach', 'value': 'ExampleBreach', 'sources': ['hibpverified']} in records
+    assert {'type': 'email', 'value': 'alice@example.com', 'sources': ['hibpverified']} in records

--- a/tests/discovery/test_hudsonrock.py
+++ b/tests/discovery/test_hudsonrock.py
@@ -258,4 +258,4 @@ async def test_infostealer_data_reaches_completed_result_and_jsonl(
     )
     assert ('infostealer', stealer) in completed_results[0].results
     records = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
-    assert {'type': 'infostealer', 'value': stealer} in records
+    assert {'type': 'infostealer', 'value': stealer, 'sources': ['hudsonrock']} in records

--- a/tests/discovery/test_intelxsearch.py
+++ b/tests/discovery/test_intelxsearch.py
@@ -5,6 +5,7 @@ import pytest
 from theHarvester import __main__ as theharvester_main
 from theHarvester.discovery import intelxsearch
 from theHarvester.discovery.constants import MissingKey
+from theHarvester.lib.completed_result import CompletedResult, ResultObservation
 
 
 class _Response:
@@ -116,15 +117,14 @@ async def test_process_treats_denied_and_malformed_responses_as_empty(
 
 @pytest.mark.asyncio
 async def test_orchestrator_stores_intelx_subdomains_without_dns(monkeypatch: pytest.MonkeyPatch) -> None:
-    stored_hosts: list[set[str]] = []
+    completed_results: list[CompletedResult] = []
 
     class _ResultStore:
         async def initialize(self) -> None:
             return None
 
-        async def record_observations(self, _domain: str, values: list[str], result_type: str, _source: str) -> None:
-            if result_type == 'hostname':
-                stored_hosts.append(set(values))
+        async def save_run(self, result: CompletedResult) -> None:
+            completed_results.append(result)
 
     class _Intelx:
         def __init__(self, _domain: str) -> None:
@@ -165,8 +165,9 @@ async def test_orchestrator_stores_intelx_subdomains_without_dns(monkeypatch: py
             domain='Example.COM',
             take_over=False,
             proxies=False,
-        )
+        ),
+        persist_completed_result=True,
     )
 
     assert results[-1] == ['api.example.com']
-    assert stored_hosts == [{'api.example.com'}]
+    assert completed_results[0].observations == (ResultObservation('intelx', 'hostname', 'api.example.com'),)

--- a/tests/discovery/test_leaklookup.py
+++ b/tests/discovery/test_leaklookup.py
@@ -266,5 +266,5 @@ async def test_leaklookup_emails_and_breaches_reach_completed_result_and_jsonl(m
         ('email', 'alice@example.com'),
     )
     records = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
-    assert {'type': 'breach', 'value': 'Example Breach'} in records
-    assert {'type': 'email', 'value': 'alice@example.com'} in records
+    assert {'type': 'breach', 'value': 'Example Breach', 'sources': ['leaklookup']} in records
+    assert {'type': 'email', 'value': 'alice@example.com', 'sources': ['leaklookup']} in records

--- a/tests/discovery/test_rapiddns.py
+++ b/tests/discovery/test_rapiddns.py
@@ -114,6 +114,10 @@ async def test_rapiddns_evidence_reaches_existing_outputs(
 ) -> None:
     stored: list[tuple[str, tuple[str, ...], str]] = []
     completed_results: list[CompletedResult] = []
+    checkpoints: list[CompletedResult] = []
+
+    async def capture_checkpoint(result: CompletedResult) -> None:
+        checkpoints.append(result)
 
     class FakeResultStore:
         fail_completed_write = False
@@ -225,11 +229,9 @@ async def test_rapiddns_evidence_reaches_existing_outputs(
     configure_logging(verbose=False)
 
     with pytest.raises(SystemExit) as exit_info:
-        await theharvester_main.start()
+        await theharvester_main.start(completed_result_checkpoint=capture_checkpoint)
 
     assert exit_info.value.code == 0
-    assert ('hostname', ('alias.example.com', 'api.example.com', 'broken.example.com'), 'rapiddns') in stored
-    assert ('ip-address', ('192.0.2.1',), 'rapiddns') in stored
     assert stored.count(('api-endpoint', ('/health',), 'api_scan')) == 1
 
     report_json = json.loads(report.with_suffix('.json').read_text())
@@ -242,12 +244,25 @@ async def test_rapiddns_evidence_reaches_existing_outputs(
     assert jsonl_records[0]['target'] == 'example.com'
     UUID(jsonl_records[0]['run_id'])
     assert [str(result.run_id) for result in completed_results] == [jsonl_records[0]['run_id']]
-    assert {'type': 'interesting-url', 'value': 'https://example.com/health'} in jsonl_records
-    assert {'type': 'url', 'value': 'https://example.com/health'} in jsonl_records
-    assert {'type': 'hostname', 'value': 'reverse.example.com'} in jsonl_records
-    assert {'type': 'ip-address', 'value': '198.51.100.9'} in jsonl_records
-    assert {'type': 'ip-address', 'value': '2001:db8::1'} in jsonl_records
+    assert checkpoints
+    assert {result.run_id for result in checkpoints} == {completed_results[0].run_id}
+    assert {'type': 'interesting-url', 'value': 'https://example.com/health', 'sources': []} in jsonl_records
+    assert {'type': 'url', 'value': 'https://example.com/health', 'sources': []} in jsonl_records
+    assert {'type': 'hostname', 'value': 'reverse.example.com', 'sources': []} in jsonl_records
+    assert {'type': 'ip-address', 'value': '198.51.100.9', 'sources': ['securityscorecard']} in jsonl_records
+    assert {'type': 'ip-address', 'value': '2001:db8::1', 'sources': ['securityscorecard']} in jsonl_records
     assert not any(record.get('value') == 'not-an-ip' for record in jsonl_records)
+    assert {(observation.source, observation.kind, observation.value) for observation in completed_results[0].observations} >= {
+        ('rapiddns', 'hostname', 'api.example.com'),
+        ('rapiddns', 'ip-address', '192.0.2.1'),
+        ('securityscorecard', 'ip-address', '198.51.100.9'),
+        ('securityscorecard', 'ip-address', '2001:db8::1'),
+    }
+    securityscorecard_execution = next(
+        execution for execution in completed_results[0].source_executions if execution.source == 'securityscorecard'
+    )
+    assert securityscorecard_execution.status == 'completed'
+    assert securityscorecard_execution.result_count == 2
 
     xml_hosts = {
         (element.findtext('hostname') or (element.text or '').strip(), element.findtext('ip'))
@@ -306,17 +321,18 @@ async def test_rapiddns_evidence_reaches_existing_outputs(
     assert set(rest_results[6]) == {'192.0.2.1', '198.51.100.2'}
     assert rest_results[7] == ['user@example.com']
     assert rest_results[8] == ['alias.example.com', 'api.example.com', 'broken.example.com']
-    assert stored[stored_before_rest:] == [
-        ('email', ('user@example.com',), 'dehashed'),
-        ('ip-address', ('198.51.100.2',), 'dehashed'),
-        ('hostname', ('alias.example.com', 'api.example.com', 'broken.example.com'), 'rapiddns'),
-        ('ip-address', ('192.0.2.1',), 'rapiddns'),
-    ]
+    assert stored[stored_before_rest:] == []
     assert len(completed_results) == 2
     assert FakeSecurityScorecard.created == 1
     assert completed_results[1].target == 'example.com'
     assert {'192.0.2.1', '198.51.100.2'} <= {value for kind, value in completed_results[1].results if kind == 'ip-address'}
     assert ('email', 'user@example.com') in completed_results[1].results
+    assert {(observation.source, observation.kind, observation.value) for observation in completed_results[1].observations} >= {
+        ('dehashed', 'email', 'user@example.com'),
+        ('dehashed', 'ip-address', '198.51.100.2'),
+        ('rapiddns', 'hostname', 'api.example.com'),
+        ('rapiddns', 'ip-address', '192.0.2.1'),
+    }
 
     monkeypatch.setattr(sys, 'argv', ['theHarvester', '-d', 'example.com', '-b', 'rapiddns'])
     with pytest.raises(SystemExit) as no_file_exit:

--- a/tests/lib/test_completed_persistence.py
+++ b/tests/lib/test_completed_persistence.py
@@ -8,7 +8,7 @@ from uuid import UUID
 import pytest
 
 from theHarvester.lib import database as database_module
-from theHarvester.lib.completed_result import CompletedResult
+from theHarvester.lib.completed_result import CompletedResult, ResultObservation, SourceExecution
 from theHarvester.lib.database import (
     DuplicateRunError,
     ResultStore,
@@ -42,6 +42,18 @@ CREATE TABLE results (
     find_date DATE,
     source TEXT
 );
+"""
+
+SCHEMA_V1_DISCOVERY_OBSERVATIONS = """
+CREATE TABLE discovery_observations (
+    id INTEGER NOT NULL PRIMARY KEY,
+    domain TEXT NOT NULL,
+    resource TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    discovered_on DATE NOT NULL,
+    source TEXT NOT NULL
+);
+PRAGMA user_version = 1;
 """
 
 
@@ -112,10 +124,10 @@ async def test_newer_schema_is_rejected_without_changing_journal_mode(tmp_path) 
     database = tmp_path / 'stash.sqlite'
     store = ResultStore(database)
     with sqlite3.connect(database) as db:
-        db.execute('PRAGMA user_version = 2')
+        db.execute('PRAGMA user_version = 3')
         original_journal_mode = db.execute('PRAGMA journal_mode').fetchone()[0]
 
-    with pytest.raises(RuntimeError, match='schema version 2 is newer than supported version 1'):
+    with pytest.raises(RuntimeError, match='schema version 3 is newer than supported version 2'):
         await store.initialize()
 
     with sqlite3.connect(database) as db:
@@ -167,7 +179,7 @@ async def test_schema_enforces_foreign_keys_and_cascades_results(tmp_path) -> No
 
 
 @pytest.mark.asyncio
-async def test_completed_result_round_trip_preserves_discovery_observations(tmp_path) -> None:
+async def test_completed_result_round_trip_preserves_legacy_observations(tmp_path) -> None:
     database = tmp_path / 'stash.sqlite'
     store = ResultStore(database)
     await store.initialize()
@@ -178,7 +190,7 @@ async def test_completed_result_round_trip_preserves_discovery_observations(tmp_
 
     assert await store.load_run(result.run_id) == result
     with sqlite3.connect(database) as db:
-        stored = db.execute('SELECT domain, resource, kind, source FROM discovery_observations').fetchall()
+        stored = db.execute('SELECT domain, resource, kind, source FROM legacy_observations').fetchall()
         stored_items = set(db.execute('SELECT kind, value FROM results').fetchall())
         run_types = {row[1]: row[2] for row in db.execute('PRAGMA table_info(runs)')}
         result_types = {row[1]: row[2] for row in db.execute('PRAGMA table_info(results)')}
@@ -192,6 +204,101 @@ async def test_completed_result_round_trip_preserves_discovery_observations(tmp_
         'kind': 'TEXT',
         'value': 'TEXT',
     }
+
+
+@pytest.mark.asyncio
+async def test_completed_result_round_trip_preserves_source_provenance(tmp_path) -> None:
+    database = tmp_path / 'stash.sqlite'
+    store = ResultStore(database)
+    await store.initialize()
+    result = CompletedResult.finish(
+        run_id=UUID('9c024fb7-4877-4f6e-89ef-0bf6af59ade0'),
+        target='example.com',
+        started_at=datetime(2026, 8, 5, 12, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 8, 5, 12, 1, tzinfo=UTC),
+        groups={'hostname': ['api.example.com', 'mail.example.com']},
+        observations=(
+            ResultObservation('crtsh', 'hostname', 'api.example.com'),
+            ResultObservation('certspotter', 'hostname', 'api.example.com'),
+            ResultObservation('crtsh', 'hostname', 'mail.example.com'),
+        ),
+        source_executions=(
+            SourceExecution('crtsh', 'completed', 12.5, 2),
+            SourceExecution('certspotter', 'completed', 8.0, 1),
+        ),
+    )
+
+    await store.save_run(result)
+
+    assert await store.load_run(result.run_id) == result
+    with sqlite3.connect(database) as db:
+        observations = db.execute(
+            'SELECT o.run_id, e.name, r.kind, r.value '
+            'FROM result_origins AS o '
+            'JOIN executions AS e ON e.run_id = o.run_id AND e.position = o.execution_position '
+            'JOIN results AS r ON r.run_id = o.run_id AND r.position = o.result_position '
+            'ORDER BY e.name, r.value'
+        ).fetchall()
+        executions = db.execute(
+            'SELECT run_id, producer_kind, name, status, result_count FROM executions ORDER BY position'
+        ).fetchall()
+    assert observations == [
+        (str(result.run_id), 'certspotter', 'hostname', 'api.example.com'),
+        (str(result.run_id), 'crtsh', 'hostname', 'api.example.com'),
+        (str(result.run_id), 'crtsh', 'hostname', 'mail.example.com'),
+    ]
+    assert executions == [
+        (str(result.run_id), 'source', 'crtsh', 'completed', 2),
+        (str(result.run_id), 'source', 'certspotter', 'completed', 1),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_source_yields_distinguish_unique_and_shared_results(tmp_path) -> None:
+    store = ResultStore(tmp_path / 'stash.sqlite')
+    await store.initialize()
+    result = CompletedResult.finish(
+        run_id=UUID('bb2e9a76-f7fc-4eec-acbc-6da55a389d88'),
+        target='example.com',
+        started_at=datetime(2026, 8, 5, 12, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 8, 5, 12, 1, tzinfo=UTC),
+        groups={'hostname': ['api.example.com', 'mail.example.com', 'www.example.com']},
+        observations=(
+            ResultObservation('crtsh', 'hostname', 'api.example.com'),
+            ResultObservation('certspotter', 'hostname', 'api.example.com'),
+            ResultObservation('crtsh', 'hostname', 'mail.example.com'),
+            ResultObservation('certspotter', 'hostname', 'www.example.com'),
+        ),
+        source_executions=(
+            SourceExecution('crtsh', 'completed', 12.5, 2),
+            SourceExecution('certspotter', 'completed', 8.0, 2),
+            SourceExecution('empty-source', 'completed', 5.0, 0),
+        ),
+    )
+    await store.save_run(result)
+
+    yields = await store.source_yields(result.run_id)
+
+    assert [item.to_dict() for item in yields] == [
+        {
+            'source': 'certspotter',
+            'observed_result_count': 2,
+            'unique_result_count': 1,
+            'shared_result_count': 1,
+        },
+        {
+            'source': 'crtsh',
+            'observed_result_count': 2,
+            'unique_result_count': 1,
+            'shared_result_count': 1,
+        },
+        {
+            'source': 'empty-source',
+            'observed_result_count': 0,
+            'unique_result_count': 0,
+            'shared_result_count': 0,
+        },
+    ]
 
 
 @pytest.mark.asyncio
@@ -219,7 +326,7 @@ async def test_existing_completed_records_survive_initialization(tmp_path) -> No
     assert await store.load_run(existing.run_id) == existing
     with sqlite3.connect(database) as db:
         tables = {row[0] for row in db.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
-        migrated = db.execute('SELECT resource, kind, source FROM discovery_observations').fetchall()
+        migrated = db.execute('SELECT resource, kind, source FROM legacy_observations').fetchall()
     assert {'completed_results', 'completed_result_items', 'legacy_results'}.isdisjoint(tables)
     assert migrated == [('legacy.example.com', 'hostname', 'crtsh')]
 
@@ -240,7 +347,7 @@ async def test_current_schema_reopens_without_running_legacy_migration(tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_released_results_migrate_to_discovery_observations(tmp_path) -> None:
+async def test_released_results_migrate_to_legacy_observations(tmp_path) -> None:
     database = tmp_path / 'stash.sqlite'
     store = ResultStore(database)
     released_rows = [
@@ -262,7 +369,7 @@ async def test_released_results_migrate_to_discovery_observations(tmp_path) -> N
 
     with sqlite3.connect(database) as db:
         tables = {row[0] for row in db.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
-        observations = db.execute('SELECT resource, kind FROM discovery_observations ORDER BY id').fetchall()
+        observations = db.execute('SELECT resource, kind FROM legacy_observations ORDER BY id').fetchall()
         result_columns = [row[1] for row in db.execute('PRAGMA table_info(results)')]
         schema_version = db.execute('PRAGMA user_version').fetchone()[0]
     assert 'legacy_results' not in tables
@@ -277,7 +384,7 @@ async def test_released_results_migrate_to_discovery_observations(tmp_path) -> N
         ('/api/v1', 'api-endpoint'),
         ('admin@example.com', 'email'),
     ]
-    assert schema_version == 1
+    assert schema_version == 2
 
 
 @pytest.mark.asyncio
@@ -294,7 +401,7 @@ async def test_released_null_observation_fields_survive_migration(tmp_path) -> N
     await store.initialize()
 
     with sqlite3.connect(database) as db:
-        migrated = db.execute('SELECT domain, resource, kind, discovered_on, source FROM discovery_observations').fetchall()
+        migrated = db.execute('SELECT domain, resource, kind, discovered_on, source FROM legacy_observations').fetchall()
     assert migrated == [(None, None, None, None, None)]
 
 
@@ -313,7 +420,7 @@ async def test_concurrent_initialization_migrates_released_results_once(tmp_path
     await asyncio.gather(first.initialize(), second.initialize())
 
     with sqlite3.connect(database) as db:
-        rows = db.execute('SELECT domain, resource, kind, source FROM discovery_observations').fetchall()
+        rows = db.execute('SELECT domain, resource, kind, source FROM legacy_observations').fetchall()
     assert rows == [('example.com', 'api.example.com', 'hostname', 'crtsh')]
 
 
@@ -351,7 +458,7 @@ async def test_completed_result_write_is_atomic_and_rejects_duplicate_run_id(tmp
 
 
 @pytest.mark.asyncio
-async def test_discovery_observations_use_the_normalized_schema(tmp_path) -> None:
+async def test_legacy_observations_keep_the_released_normalized_schema(tmp_path) -> None:
     database = tmp_path / 'stash.sqlite'
     store = ResultStore(database)
     await store.initialize()
@@ -363,8 +470,8 @@ async def test_discovery_observations_use_the_normalized_schema(tmp_path) -> Non
     await store.record_observations('example.com', ['443'], 'shodan', 'shodan')
 
     with sqlite3.connect(database) as db:
-        columns = [row[1] for row in db.execute('PRAGMA table_info(discovery_observations)')]
-        rows = db.execute('SELECT domain, resource, kind, source FROM discovery_observations ORDER BY id').fetchall()
+        columns = [row[1] for row in db.execute('PRAGMA table_info(legacy_observations)')]
+        rows = db.execute('SELECT domain, resource, kind, source FROM legacy_observations ORDER BY id').fetchall()
 
     assert columns == ['id', 'domain', 'resource', 'kind', 'discovered_on', 'source']
     assert rows == [
@@ -376,6 +483,28 @@ async def test_discovery_observations_use_the_normalized_schema(tmp_path) -> Non
         ('example.com', 'vhost.example.com', 'vhost', 'virtual-host'),
         ('example.com', '443', 'shodan', 'shodan'),
     ]
+
+
+@pytest.mark.asyncio
+async def test_schema_v1_observations_upgrade_without_losing_rows(tmp_path) -> None:
+    database = tmp_path / 'stash.sqlite'
+    store = ResultStore(database)
+    with sqlite3.connect(database) as db:
+        db.executescript(SCHEMA_V1_DISCOVERY_OBSERVATIONS)
+        db.execute(
+            'INSERT INTO discovery_observations (domain, resource, kind, discovered_on, source) VALUES (?, ?, ?, ?, ?)',
+            ('example.com', 'api.example.com', 'hostname', '2026-08-08', 'crtsh'),
+        )
+
+    await store.initialize()
+
+    with sqlite3.connect(database) as db:
+        tables = {row[0] for row in db.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+        rows = db.execute('SELECT domain, resource, kind, source FROM legacy_observations').fetchall()
+        schema_version = db.execute('PRAGMA user_version').fetchone()[0]
+    assert 'discovery_observations' not in tables
+    assert rows == [('example.com', 'api.example.com', 'hostname', 'crtsh')]
+    assert schema_version == 2
 
 
 @pytest.mark.asyncio

--- a/tests/lib/test_completed_result.py
+++ b/tests/lib/test_completed_result.py
@@ -28,7 +28,6 @@ def test_completed_result_is_deterministic_and_deduplicated() -> None:
             'counts': {'email': 1, 'hostname': 2},
             'result_count': 3,
             'run_id': 'f047261c-0afb-4e18-89d5-28a7d977f51f',
-            'schema_version': 'theharvester-results-v1',
             'started_at': '2026-08-05T12:00:00Z',
             'target': 'example.com',
             'type': 'summary',
@@ -49,6 +48,8 @@ def test_completed_result_is_deterministic_and_deduplicated() -> None:
             'value': 'www.example.com',
         },
     ]
+    assert 'schema' not in records[0]
+    assert 'schema_version' not in records[0]
     assert result.jsonl().endswith('\n')
 
 

--- a/tests/lib/test_completed_result.py
+++ b/tests/lib/test_completed_result.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 import pytest
 
-from theHarvester.lib.completed_result import CompletedResult, SourceExecution
+from theHarvester.lib.completed_result import CompletedResult, ResultObservation, SourceExecution
 
 
 def test_completed_result_is_deterministic_and_deduplicated() -> None:
@@ -34,14 +34,17 @@ def test_completed_result_is_deterministic_and_deduplicated() -> None:
             'type': 'summary',
         },
         {
+            'sources': [],
             'type': 'email',
             'value': 'admin@example.com',
         },
         {
+            'sources': [],
             'type': 'hostname',
             'value': 'api.example.com',
         },
         {
+            'sources': [],
             'type': 'hostname',
             'value': 'www.example.com',
         },
@@ -57,9 +60,10 @@ def test_completed_result_exposes_truthful_source_execution_evidence() -> None:
         completed_at=started_at,
         groups={'hostname': ['www.example.com']},
         source_executions=(
-            SourceExecution('crtsh', 'succeeded', 12.5, 1),
-            SourceExecution('builtwith', 'skipped', 0, 0, 'SourceDidNotStart'),
+            SourceExecution('crtsh', 'completed', 12.5, 1),
+            SourceExecution('builtwith', 'partial', 0, 0, stop_reason='invalid-response'),
         ),
+        observations=(ResultObservation('crtsh', 'hostname', 'www.example.com'),),
     )
 
     evidence = result.evidence_dict()
@@ -68,7 +72,7 @@ def test_completed_result_exposes_truthful_source_execution_evidence() -> None:
     assert evidence['source_executions'] == [
         {
             'source': 'crtsh',
-            'status': 'succeeded',
+            'status': 'completed',
             'duration_ms': 12.5,
             'result_count': 1,
             'error_type': None,
@@ -76,13 +80,90 @@ def test_completed_result_exposes_truthful_source_execution_evidence() -> None:
         },
         {
             'source': 'builtwith',
-            'status': 'skipped',
+            'status': 'partial',
             'duration_ms': 0,
             'result_count': 0,
-            'error_type': 'SourceDidNotStart',
-            'stop_reason': None,
+            'error_type': None,
+            'stop_reason': 'invalid-response',
         },
     ]
+
+
+def test_completed_result_attributes_each_finding_to_its_sources() -> None:
+    completed_at = datetime(2026, 8, 5, 12, 1, tzinfo=UTC)
+    result = CompletedResult.finish(
+        target='example.com',
+        started_at=completed_at,
+        completed_at=completed_at,
+        groups={'hostname': ['api.example.com', 'mail.example.com']},
+        source_executions=(
+            SourceExecution('crtsh', 'completed', 12.5, 2),
+            SourceExecution('certspotter', 'completed', 8.0, 1),
+        ),
+        observations=(
+            ResultObservation('crtsh', 'hostname', 'api.example.com'),
+            ResultObservation('certspotter', 'hostname', 'api.example.com'),
+            ResultObservation('crtsh', 'hostname', 'mail.example.com'),
+        ),
+    )
+
+    records = [json.loads(line) for line in result.jsonl().splitlines()]
+
+    assert records[1:] == [
+        {
+            'sources': ['certspotter', 'crtsh'],
+            'type': 'hostname',
+            'value': 'api.example.com',
+        },
+        {
+            'sources': ['crtsh'],
+            'type': 'hostname',
+            'value': 'mail.example.com',
+        },
+    ]
+    assert result.evidence_dict()['results'] == records[1:]
+
+
+def test_completed_result_rejects_observation_without_execution() -> None:
+    completed_at = datetime(2026, 8, 5, 12, 1, tzinfo=UTC)
+
+    with pytest.raises(ValueError, match='matching source execution'):
+        CompletedResult.finish(
+            target='example.com',
+            started_at=completed_at,
+            completed_at=completed_at,
+            groups={'hostname': ['api.example.com']},
+            observations=(ResultObservation('crtsh', 'hostname', 'api.example.com'),),
+        )
+
+
+def test_completed_result_rejects_duplicate_source_executions() -> None:
+    completed_at = datetime(2026, 8, 5, 12, 1, tzinfo=UTC)
+
+    with pytest.raises(ValueError, match='source executions must be unique'):
+        CompletedResult.finish(
+            target='example.com',
+            started_at=completed_at,
+            completed_at=completed_at,
+            groups={},
+            source_executions=(
+                SourceExecution('crtsh', 'completed', 1.0, 0),
+                SourceExecution('crtsh', 'failed', 2.0, 0, error_type='RuntimeError'),
+            ),
+        )
+
+
+def test_completed_result_rejects_source_count_without_matching_origins() -> None:
+    completed_at = datetime(2026, 8, 5, 12, 1, tzinfo=UTC)
+
+    with pytest.raises(ValueError, match='result count must match'):
+        CompletedResult.finish(
+            target='example.com',
+            started_at=completed_at,
+            completed_at=completed_at,
+            groups={'hostname': ['api.example.com']},
+            source_executions=(SourceExecution('crtsh', 'completed', 1.0, 1),),
+        )
 
 
 def test_completed_result_keeps_terminal_action_evidence_in_jsonl() -> None:

--- a/tests/test_all_source_orchestration.py
+++ b/tests/test_all_source_orchestration.py
@@ -168,6 +168,7 @@ async def test_explicit_non_passive_source_is_scheduled_once(
             return set()
 
     if source == 'shodan':
+
         class FakeShodan:
             async def search_ip(self, _ip: str) -> dict:
                 nonlocal executions
@@ -202,11 +203,7 @@ async def test_all_schedules_each_passive_catalog_source_once_and_reports_result
     tmp_path: Path,
 ) -> None:
     executions: Counter[str] = Counter()
-    passive_sources = sorted(
-        source
-        for source, spec in SOURCE_SPECS.items()
-        if spec.activity is ActivityClass.PASSIVE
-    )
+    passive_sources = sorted(source for source, spec in SOURCE_SPECS.items() if spec.activity is ActivityClass.PASSIVE)
 
     class TestResultStore(theharvester_main.ResultStore):
         def __init__(self) -> None:
@@ -301,9 +298,10 @@ async def test_all_schedules_each_passive_catalog_source_once_and_reports_result
     assert 'user@example.test' in json_report['emails']
 
     jsonl_records = [json.loads(line) for line in report.with_suffix('.jsonl').read_text().splitlines()]
-    assert {'type': 'hostname', 'value': 'sub.example.test'} in jsonl_records
-    assert {'type': 'email', 'value': 'user@example.test'} in jsonl_records
-    assert {'type': 'url', 'value': 'https://gitlab.com/example/project'} in jsonl_records
+    findings = {(record['type'], record['value']): record for record in jsonl_records[1:]}
+    assert findings[('hostname', 'sub.example.test')]['sources']
+    assert findings[('email', 'user@example.test')]['sources']
+    assert findings[('url', 'https://gitlab.com/example/project')]['sources']
 
     completed = await TestResultStore().load_run(UUID(jsonl_records[0]['run_id']))
     assert completed.target == 'example.test'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from theHarvester import __main__ as theharvester_main
-from theHarvester.lib.completed_result import CompletedResult
+from theHarvester.lib.completed_result import CompletedResult, ResultObservation
 from theHarvester.lib.dns_consensus import Addressability
 from theHarvester.lib.enumeration import EnumerationOptions
 from theHarvester.lib.hostchecker import HostDnsRecords
@@ -49,7 +49,6 @@ def test_normalize_hosts_for_storage_uses_the_parser_scope(target: str) -> None:
 @pytest.mark.asyncio
 async def test_rapiddns_hostnames_honor_explicit_dns_resolution(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     completed: list[CompletedResult] = []
-    stored_observations: list[tuple[str, list[str], str, str]] = []
     output_directory = tmp_path / 'reports.v1'
     output_directory.mkdir()
     output_path = output_directory / 'rapiddns'
@@ -58,8 +57,8 @@ async def test_rapiddns_hostnames_honor_explicit_dns_resolution(monkeypatch: pyt
         async def initialize(self) -> None:
             return None
 
-        async def record_observations(self, domain: str, values: list[str] | set[str], kind: str, source: str) -> None:
-            stored_observations.append((domain, sorted(values), kind, source))
+        async def record_observations(self, *_args: object) -> None:
+            return None
 
         async def save_run(self, result: CompletedResult) -> None:
             completed.append(result)
@@ -81,6 +80,9 @@ async def test_rapiddns_hostnames_honor_explicit_dns_resolution(monkeypatch: pyt
             return {'192.0.2.20'}
 
     class FakeCrtsh:
+        execution_status = 'partial'
+        stop_reason = 'invalid-response'
+
         def __init__(self, _word: str) -> None:
             pass
 
@@ -138,9 +140,16 @@ async def test_rapiddns_hostnames_honor_explicit_dns_resolution(monkeypatch: pyt
     assert ('ip-address', '192.0.2.21') in completed[0].results
     assert ('ip-address', '192.0.2.30') in completed[0].results
     assert {execution.source for execution in completed[0].source_executions} == {'crtsh', 'rapiddns'}
-    assert ('example.com', ['crt.example.com'], 'hostname', 'crtsh') in stored_observations
-    assert ('example.com', ['api.example.com', 'reported.example.com'], 'hostname', 'rapiddns') in stored_observations
-    assert ('example.com', ['192.0.2.20'], 'ip-address', 'rapiddns') in stored_observations
+    crtsh_execution = next(execution for execution in completed[0].source_executions if execution.source == 'crtsh')
+    assert crtsh_execution.status == 'partial'
+    assert crtsh_execution.stop_reason == 'invalid-response'
+    assert completed[0].evidence_dict()['status'] == 'partial'
+    assert {(observation.source, observation.kind, observation.value) for observation in completed[0].observations} >= {
+        ('crtsh', 'hostname', 'crt.example.com'),
+        ('rapiddns', 'hostname', 'api.example.com'),
+        ('rapiddns', 'hostname', 'reported.example.com'),
+        ('rapiddns', 'ip-address', '192.0.2.20'),
+    }
     assert 'reported.example.com:192.0.2.21' in json.loads(output_path.with_suffix('.json').read_text())['hosts']
     assert output_path.with_suffix('.jsonl').is_file()
     xml_pairs = [
@@ -149,6 +158,160 @@ async def test_rapiddns_hostnames_honor_explicit_dns_resolution(monkeypatch: pyt
     ]
     assert xml_pairs.count(('reported.example.com', '192.0.2.20')) == 1
     assert xml_pairs.count(('reported.example.com', '192.0.2.21')) == 1
+
+
+@pytest.mark.asyncio
+async def test_source_failure_retains_normalized_partial_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    completed: list[CompletedResult] = []
+
+    class FakeResultStore:
+        async def initialize(self) -> None:
+            return None
+
+        async def save_run(self, result: CompletedResult) -> None:
+            completed.append(result)
+
+    class PartiallyFailingBuiltWith:
+        def __init__(self, _word: str) -> None:
+            pass
+
+        async def process(self, _proxy: bool) -> None:
+            return None
+
+        async def get_hostnames(self) -> list[str]:
+            return ['API.Example.COM.', 'api.example.com', 'outside.test']
+
+        async def get_interesting_urls(self) -> set[str]:
+            raise RuntimeError('provider page failed')
+
+    monkeypatch.setattr(theharvester_main, 'ResultStore', FakeResultStore)
+    monkeypatch.setattr(theharvester_main.builtwith, 'SearchBuiltWith', PartiallyFailingBuiltWith)
+    monkeypatch.setattr(sys, 'argv', ['theHarvester', '-d', 'example.com', '-b', 'builtwith'])
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    assert len(completed) == 1
+    execution = completed[0].source_executions[0]
+    assert execution.status == 'partial'
+    assert execution.result_count == 1
+    assert execution.error_type == 'RuntimeError'
+    assert completed[0].observations == (ResultObservation('builtwith', 'hostname', 'api.example.com'),)
+
+
+@pytest.mark.asyncio
+async def test_source_checkpoint_excludes_other_source_work_in_progress(monkeypatch: pytest.MonkeyPatch) -> None:
+    builtwith_collected = asyncio.Event()
+    release_builtwith = asyncio.Event()
+    checkpoints: list[CompletedResult] = []
+    completed: list[CompletedResult] = []
+
+    class FakeResultStore:
+        async def initialize(self) -> None:
+            return None
+
+        async def save_run(self, result: CompletedResult) -> None:
+            completed.append(result)
+
+    class PausedBuiltWith:
+        def __init__(self, _word: str) -> None:
+            pass
+
+        async def process(self, _proxy: bool) -> None:
+            return None
+
+        async def get_hostnames(self) -> set[str]:
+            builtwith_collected.set()
+            return {'early.example.com'}
+
+        async def get_interesting_urls(self) -> set[str]:
+            await release_builtwith.wait()
+            return set()
+
+        async def get_frameworks(self) -> set[str]:
+            return set()
+
+        async def get_languages(self) -> set[str]:
+            return set()
+
+        async def get_servers(self) -> set[str]:
+            return set()
+
+        async def get_cms(self) -> set[str]:
+            return set()
+
+        async def get_analytics(self) -> set[str]:
+            return set()
+
+    class FastCrtsh:
+        def __init__(self, _word: str) -> None:
+            pass
+
+        async def process(self, _proxy: bool) -> None:
+            await builtwith_collected.wait()
+
+        async def get_hostnames(self) -> set[str]:
+            return {'committed.example.com'}
+
+    async def capture_checkpoint(result: CompletedResult) -> None:
+        checkpoints.append(result)
+        if {execution.source for execution in result.source_executions} == {'crtsh'}:
+            release_builtwith.set()
+
+    monkeypatch.setattr(theharvester_main, 'ResultStore', FakeResultStore)
+    monkeypatch.setattr(theharvester_main.builtwith, 'SearchBuiltWith', PausedBuiltWith)
+    monkeypatch.setattr(theharvester_main.crtsh, 'SearchCrtsh', FastCrtsh)
+    monkeypatch.setattr(sys, 'argv', ['theHarvester', '-d', 'example.com', '-b', 'builtwith,crtsh'])
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start(completed_result_checkpoint=capture_checkpoint)
+
+    assert exit_info.value.code == 0
+    crtsh_checkpoint = next(
+        result for result in checkpoints if {execution.source for execution in result.source_executions} == {'crtsh'}
+    )
+    assert ('hostname', 'committed.example.com') in crtsh_checkpoint.results
+    assert ('hostname', 'early.example.com') not in crtsh_checkpoint.results
+    assert {value for kind, value in completed[0].results if kind == 'hostname'} == {
+        'committed.example.com',
+        'early.example.com',
+    }
+
+
+@pytest.mark.asyncio
+async def test_invalid_source_outcome_is_not_recorded_as_completed(monkeypatch: pytest.MonkeyPatch) -> None:
+    completed: list[CompletedResult] = []
+
+    class FakeResultStore:
+        async def initialize(self) -> None:
+            return None
+
+        async def save_run(self, result: CompletedResult) -> None:
+            completed.append(result)
+
+    class InvalidOutcomeCrtsh:
+        execution_status = 'typo'
+
+        def __init__(self, _word: str) -> None:
+            pass
+
+        async def process(self, _proxy: bool) -> None:
+            return None
+
+        async def get_hostnames(self) -> set[str]:
+            return set()
+
+    monkeypatch.setattr(theharvester_main, 'ResultStore', FakeResultStore)
+    monkeypatch.setattr(theharvester_main.crtsh, 'SearchCrtsh', InvalidOutcomeCrtsh)
+    monkeypatch.setattr(sys, 'argv', ['theHarvester', '-d', 'example.com', '-b', 'crtsh'])
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    assert completed[0].source_executions[0].status == 'failed'
+    assert completed[0].source_executions[0].error_type == 'ValueError'
 
 
 @pytest.mark.asyncio

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -131,8 +131,8 @@ def test_readme_preserves_project_social_attribution() -> None:
 def test_readme_explains_jsonl_record_and_structured_value_parsing() -> None:
     readme = Path('README.md').read_text()
 
-    assert '{"type":"hostname","value":"api.example.com"}' in readme
+    assert '{"sources":[],"type":"hostname","value":"api.example.com"}' in readme
     assert 'select(.type == "dns-recursive-finding") | .value | fromjson' in readme
-    assert 'JSONL v1 is easy to stream for simple findings, but it is not uniformly self-describing.' in readme
+    assert 'JSONL is easy to stream for simple findings, but it is not uniformly self-describing.' in readme
     assert '`person`, `infostealer`, `shodan`, and `takeover`' in readme
-    assert 'JSONL v1 does not include source execution records or source attribution.' in readme
+    assert 'JSONL does not include source execution records. Finding records include source attribution' in readme

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -13,7 +13,8 @@ from collections.abc import Awaitable, Callable, Iterable
 from contextlib import AsyncExitStack
 from datetime import UTC, datetime
 from ipaddress import ip_address
-from typing import Any
+from typing import Any, cast
+from uuid import uuid4
 
 import anyio
 import netaddr
@@ -83,7 +84,14 @@ from theHarvester.discovery import (
 )
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib import hostchecker
-from theHarvester.lib.completed_result import CompletedResult, ResultKind, SourceExecution
+from theHarvester.lib.completed_result import (
+    EXECUTION_STATUSES,
+    CompletedResult,
+    ExecutionStatus,
+    ResultKind,
+    ResultObservation,
+    SourceExecution,
+)
 from theHarvester.lib.core import DATA_DIR, Core, show_default_error_message
 from theHarvester.lib.database import ResultStore
 from theHarvester.lib.dns_consensus import AioDNSResolverVantage
@@ -337,6 +345,7 @@ async def start(
             # For relative paths, sanitize the entire filename
             filename = sanitize_filename(filename)
     run_started_at = datetime.now(UTC)
+    run_id = uuid4()
 
     all_emails: list = []
     all_hosts: list = []
@@ -432,9 +441,13 @@ async def start(
     interesting_urls = []
     total_asns = []
     source_executions: list[SourceExecution] = []
+    observations: set[ResultObservation] = set()
 
     def finish_completed_result(
-        *, extra_hostnames: Iterable[str] = (), virtual_hosts: Iterable[str] = ()
+        *,
+        extra_hostnames: Iterable[str] = (),
+        virtual_hosts: Iterable[str] = (),
+        committed_sources_only: bool = False,
     ) -> CompletedResult | None:
         groups: dict[ResultKind, Iterable[str]] = {
             'analytics': map(str, all_analytics),
@@ -517,40 +530,64 @@ async def start(
             'url': map(str, all_urls),
             'vhost': map(str, virtual_hosts),
         }
-        if extra_hostnames:
+        if committed_sources_only:
+            committed_groups: dict[ResultKind, list[str]] = {}
+            for observation in observations:
+                committed_groups.setdefault(observation.kind, []).append(observation.value)
+            groups = {kind: iter(values) for kind, values in committed_groups.items()}
+        elif extra_hostnames:
             groups['hostname'] = _normalize_hosts_for_storage((*all_hosts, *extra_hostnames), word)
         try:
             return CompletedResult.finish(
+                run_id=run_id,
                 target=word,
                 started_at=run_started_at,
                 completed_at=datetime.now(UTC),
                 groups=groups,
                 source_executions=source_executions,
+                observations=observations,
             )
         except (ValueError, TypeError) as error:
             output_logger.info(f'[!] An error occurred while completing the result: {error}')
             return None
 
-    async def checkpoint_completed_result(*, extra_hostnames: Iterable[str] = (), virtual_hosts: Iterable[str] = ()) -> None:
+    async def checkpoint_completed_result(
+        *,
+        extra_hostnames: Iterable[str] = (),
+        virtual_hosts: Iterable[str] = (),
+        committed_sources_only: bool = False,
+    ) -> None:
         if (
             completed_result_checkpoint is not None
-            and (result := finish_completed_result(extra_hostnames=extra_hostnames, virtual_hosts=virtual_hosts)) is not None
+            and (
+                result := finish_completed_result(
+                    extra_hostnames=extra_hostnames,
+                    virtual_hosts=virtual_hosts,
+                    committed_sources_only=committed_sources_only,
+                )
+            )
+            is not None
         ):
             await completed_result_checkpoint(result)
 
     async def collect_and_store(
         search_engine: Any,
         source_spec: SourceSpec,
-    ) -> int:
+        source_observations: set[ResultObservation],
+    ) -> None:
         """Process a source and persist its declared consolidated result routes.
 
         :param search_engine: search engine to fetch details from
         :param source_spec: canonical source identity and declared result routes
         """
         await search_engine.process(use_proxy)
-        result_count = 0
         source = source_spec.name
         routes = source_spec.routes
+
+        def record_source_observations(source_name: str, kind: ResultKind, values: Iterable[object]) -> None:
+            source_observations.update(
+                ResultObservation(source_name, kind, value) for item in values if (value := str(item).strip())
+            )
 
         if source:
             output_logger.info(f'[*] Searching {source[0].upper() + source[1:]}. ')
@@ -559,7 +596,6 @@ async def start(
             discovered_hosts = await search_engine.get_hostnames()
             host_names = list(_normalize_hosts_for_storage(discovered_hosts, word))
             paired_hosts: set[str] = set()
-            result_count += len(host_names)
             if source == 'rapiddns':
                 for host, address in await search_engine.get_host_ip_pairs():
                     normalized = normalize_scoped_hostname(host, word)
@@ -591,62 +627,51 @@ async def start(
             else:
                 full.extend(host_names)
             all_hosts.extend(host_names)
-            await db.record_observations(word, host_names, 'hostname', source)
+            record_source_observations(source, 'hostname', host_names)
 
         if ResultRoute.EMAILS in routes:
             email_list = await search_engine.get_emails()
-            result_count += len(email_list)
             all_emails.extend(email_list)
-            await db.record_observations(word, email_list, 'email', source)
+            record_source_observations(source, 'email', email_list)
 
         if ResultRoute.IPS in routes:
             ips_list = await search_engine.get_ips()
-            result_count += len(ips_list)
             all_ip.extend(ips_list)
-            await db.record_observations(word, ips_list, 'ip-address', source)
+            record_source_observations(source, 'ip-address', _normalize_ip_addresses(ips_list))
 
         if ResultRoute.PEOPLE in routes:
             people_list = await search_engine.get_people()
-            result_count += len(people_list)
             all_people.extend(people_list)
             people_evidence = (
                 json.dumps(person, ensure_ascii=False, separators=(',', ':'), sort_keys=True) for person in people_list
             )
-            await db.record_observations(word, people_evidence, 'person', source)
+            record_source_observations(source, 'person', people_evidence)
 
         if ResultRoute.LINKS in routes:
             links = await search_engine.get_links()
-            result_count += len(links)
             linkedin_links_tracker.extend(links)
-            if len(links) > 0:
-                await db.record_observations(word, links, 'linkedin-link', source)
+            record_source_observations(source, 'linkedin-link', links)
 
         if ResultRoute.URLS in routes:
             urls = await search_engine.get_urls()
-            result_count += len(urls)
             all_urls.extend(urls)
-            if len(urls) > 0:
-                await db.record_observations(word, urls, 'url', source)
+            record_source_observations(source, 'url', urls)
 
         if ResultRoute.INTERESTING_URLS in routes:
             get_interesting_urls = getattr(search_engine, 'get_interesting_urls', None)
             iurls = await get_interesting_urls() if get_interesting_urls else await search_engine.get_interestingurls()
-            result_count += len(iurls)
             interesting_urls.extend(iurls)
-            if len(iurls) > 0:
-                await db.record_observations(word, iurls, 'interesting-url', source)
+            record_source_observations(source, 'interesting-url', iurls)
 
         if ResultRoute.ASNS in routes:
             fasns = await search_engine.get_asns()
-            result_count += len(fasns)
             total_asns.extend(fasns)
-            if len(fasns) > 0:
-                await db.record_observations(word, fasns, 'asn', source)
+            record_source_observations(source, 'asn', fasns)
 
         if ResultRoute.BREACHES in routes:
             breach_names = await search_engine.get_breach_names()
-            result_count += len(breach_names)
             all_breaches.extend(breach_names)
+            record_source_observations(source, 'breach', breach_names)
         if source == 'builtwith':
             technology_results: tuple[tuple[str, list[Any], ResultKind], ...] = (
                 ('get_frameworks', all_frameworks, 'framework'),
@@ -657,39 +682,60 @@ async def start(
             )
             for getter_name, results, result_type in technology_results:
                 values = await getattr(search_engine, getter_name)()
-                result_count += len(values)
                 results.extend(values)
-                await db.record_observations(word, values, result_type, source)
+                record_source_observations(source, result_type, values)
         if source == 'hudsonrock':
             infostealers = await search_engine.get_infostealers()
-            result_count += len(infostealers)
             all_infostealers.extend(infostealers)
-
-        return result_count
+            record_source_observations(
+                source,
+                'infostealer',
+                (json.dumps(stealer, ensure_ascii=False, separators=(',', ':'), sort_keys=True) for stealer in infostealers),
+            )
 
     async def store(search_engine: Any, source: str) -> None:
         source_spec = get_source_spec(source)
         source_name = source_spec.name
+        source_observations: set[ResultObservation] = set()
         logger.info(f'Source {source_name} started')
         started = time.perf_counter()
         try:
-            result_count = await collect_and_store(search_engine, source_spec)
+            await collect_and_store(search_engine, source_spec, source_observations)
+            reported_status = getattr(search_engine, 'execution_status', None)
+            if reported_status is None:
+                execution_status: ExecutionStatus = 'completed'
+            elif isinstance(reported_status, str) and reported_status in EXECUTION_STATUSES:
+                execution_status = cast('ExecutionStatus', reported_status)
+            else:
+                raise ValueError(f'Source {source_name} reported invalid execution status: {reported_status!r}')
         except Exception as error:
             logger.exception(f'Source {source_name} failed')
+            result_count = len(source_observations)
             source_executions.append(
-                SourceExecution(source_name, 'failed', (time.perf_counter() - started) * 1000, 0, type(error).__name__)
+                SourceExecution(
+                    source_name,
+                    'partial' if result_count else 'failed',
+                    (time.perf_counter() - started) * 1000,
+                    result_count,
+                    type(error).__name__,
+                )
             )
-            await checkpoint_completed_result()
+            observations.update(source_observations)
+            await checkpoint_completed_result(committed_sources_only=True)
             raise
+        result_count = len(source_observations)
+        stop_reason = getattr(search_engine, 'stop_reason', None)
         source_executions.append(
             SourceExecution(
                 source_name,
-                'succeeded' if result_count else 'empty',
+                execution_status,
                 (time.perf_counter() - started) * 1000,
                 result_count,
+                stop_reason=stop_reason if isinstance(stop_reason, str) else None,
             )
         )
-        await checkpoint_completed_result()
+        observations.update(source_observations)
+        await checkpoint_completed_result(committed_sources_only=True)
         logger.info(f'Source {source_name} completed')
 
     stor_lst = []

--- a/theHarvester/discovery/certspottersearch.py
+++ b/theHarvester/discovery/certspottersearch.py
@@ -19,6 +19,12 @@ class SearchCertspoter:
         self.word = word.strip().lower().rstrip('.')
         self.totalhosts: set = set()
         self.proxy = False
+        self.execution_status: str | None = None
+        self.stop_reason: str | None = None
+
+    def _mark_incomplete(self, reason: str, *, rate_limited: bool = False) -> None:
+        self.execution_status = 'rate-limited' if rate_limited else 'partial'
+        self.stop_reason = reason
 
     async def do_search(self) -> None:
         base_url = 'https://api.certspotter.com/v1/issuances'
@@ -36,6 +42,7 @@ class SearchCertspoter:
 
                 responses = await AsyncFetcher.fetch_all([f'{base_url}?{urlencode(params)}'], json=True, proxy=self.proxy)
                 if not responses:
+                    self._mark_incomplete('no-response')
                     logger.warning('Cert Spotter stopped early; results may be incomplete.')
                     break
 
@@ -43,11 +50,14 @@ class SearchCertspoter:
                 if isinstance(page, dict):
                     code = page.get('code')
                     if isinstance(code, str):
+                        self._mark_incomplete(code, rate_limited=code == 'rate_limited')
                         logger.warning(f'Cert Spotter stopped early ({code}); results may be incomplete.')
                     else:
+                        self._mark_incomplete('invalid-response')
                         logger.warning('Cert Spotter stopped early; results may be incomplete.')
                     break
                 if not isinstance(page, list):
+                    self._mark_incomplete('invalid-response')
                     logger.warning('Cert Spotter stopped early; results may be incomplete.')
                     break
                 if not page:
@@ -86,6 +96,7 @@ class SearchCertspoter:
                         ):
                             self.totalhosts.add(name)
                 if malformed_issuance:
+                    self._mark_incomplete('malformed-issuance')
                     logger.warning('Cert Spotter ignored malformed issuance data; results may be incomplete.')
 
                 last_issuance = page[-1]
@@ -93,12 +104,14 @@ class SearchCertspoter:
                 if isinstance(next_cursor, str):
                     next_cursor = next_cursor.strip()
                 if not isinstance(next_cursor, str) or not next_cursor:
+                    self._mark_incomplete('invalid-cursor')
                     logger.warning(
                         'Cert Spotter stopped early because the response did not provide a valid cursor; '
                         'results may be incomplete.'
                     )
                     break
                 if next_cursor in seen_cursors:
+                    self._mark_incomplete('repeated-cursor')
                     logger.warning(
                         'Cert Spotter stopped early because the response repeated a cursor; results may be incomplete.'
                     )
@@ -106,10 +119,13 @@ class SearchCertspoter:
                 seen_cursors.add(next_cursor)
                 cursor = next_cursor
             else:
+                self._mark_incomplete('page-limit')
                 logger.warning('Cert Spotter page limit reached; results may be incomplete.')
         except ConnectionError:
+            self._mark_incomplete('connection-error')
             logger.warning('Cert Spotter network connection failed; results may be incomplete.')
         except Exception:
+            self._mark_incomplete('unexpected-error')
             logger.warning('Cert Spotter stopped after an unexpected error; results may be incomplete.')
 
     async def get_hostnames(self) -> set:

--- a/theHarvester/lib/completed_result.py
+++ b/theHarvester/lib/completed_result.py
@@ -35,7 +35,6 @@ ResultKind = Literal[
 ]
 ExecutionStatus = Literal['completed', 'partial', 'failed', 'rate-limited', 'skipped']
 
-SCHEMA_VERSION = 'theharvester-results-v1'
 RESULT_KINDS: frozenset[str] = frozenset(get_args(ResultKind))
 EXECUTION_STATUSES: frozenset[str] = frozenset(get_args(ExecutionStatus))
 
@@ -205,7 +204,6 @@ class CompletedResult:
                 'counts': dict(sorted(counts.items())),
                 'result_count': len(self.results),
                 'run_id': str(self.run_id),
-                'schema_version': SCHEMA_VERSION,
                 'started_at': _isoformat_utc(self.started_at),
                 'target': self.target,
                 'type': 'summary',

--- a/theHarvester/lib/completed_result.py
+++ b/theHarvester/lib/completed_result.py
@@ -33,7 +33,7 @@ ResultKind = Literal[
     'url',
     'vhost',
 ]
-ExecutionStatus = Literal['succeeded', 'empty', 'failed', 'rate-limited', 'skipped']
+ExecutionStatus = Literal['completed', 'partial', 'failed', 'rate-limited', 'skipped']
 
 SCHEMA_VERSION = 'theharvester-results-v1'
 RESULT_KINDS: frozenset[str] = frozenset(get_args(ResultKind))
@@ -44,8 +44,30 @@ def _isoformat_utc(value: datetime) -> str:
     return value.astimezone(UTC).isoformat().replace('+00:00', 'Z')
 
 
+@dataclass(frozen=True, order=True, slots=True)
+class ResultObservation:
+    source: str
+    kind: ResultKind
+    value: str
+
+    def __post_init__(self) -> None:
+        if not self.source.strip():
+            raise ValueError('observation source must not be empty')
+        if self.kind not in RESULT_KINDS:
+            raise ValueError(f'unknown observation kind: {self.kind}')
+        if not isinstance(self.value, str) or not self.value.strip():
+            raise ValueError('observation value must be a non-empty string')
+
+
 @dataclass(frozen=True, slots=True)
 class SourceExecution:
+    """Record one source invocation without overstating the provider outcome.
+
+    ``completed`` means the adapter returned normally. More precise statuses are
+    used only when the adapter reports them or raises an exception. ``result_count``
+    is the number of normalized, deduplicated observations attributed to the source.
+    """
+
     source: str
     status: ExecutionStatus
     duration_ms: float
@@ -73,6 +95,22 @@ class SourceExecution:
 
 
 @dataclass(frozen=True, slots=True)
+class SourceYield:
+    source: str
+    observed_result_count: int
+    unique_result_count: int
+    shared_result_count: int
+
+    def to_dict(self) -> dict[str, str | int]:
+        return {
+            'source': self.source,
+            'observed_result_count': self.observed_result_count,
+            'unique_result_count': self.unique_result_count,
+            'shared_result_count': self.shared_result_count,
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class CompletedResult:
     run_id: UUID
     target: str
@@ -80,6 +118,7 @@ class CompletedResult:
     completed_at: datetime
     results: tuple[tuple[ResultKind, str], ...]
     source_executions: tuple[SourceExecution, ...] = ()
+    observations: tuple[ResultObservation, ...] = ()
 
     def __post_init__(self) -> None:
         if not self.target.strip():
@@ -96,6 +135,20 @@ class CompletedResult:
             raise ValueError('results must contain known kinds and non-empty string values')
         if self.results != tuple(sorted(set(self.results))):
             raise ValueError('results must be deduplicated and sorted')
+        if self.observations != tuple(sorted(set(self.observations))):
+            raise ValueError('observations must be deduplicated and sorted')
+        result_set = set(self.results)
+        if any((observation.kind, observation.value) not in result_set for observation in self.observations):
+            raise ValueError('every observation must reference a completed result')
+        execution_sources = [execution.source for execution in self.source_executions]
+        execution_source_set = set(execution_sources)
+        if len(execution_sources) != len(execution_source_set):
+            raise ValueError('source executions must be unique')
+        if any(observation.source not in execution_source_set for observation in self.observations):
+            raise ValueError('every observation must reference a matching source execution')
+        observation_counts = Counter(observation.source for observation in self.observations)
+        if any(execution.result_count != observation_counts[execution.source] for execution in self.source_executions):
+            raise ValueError('source execution result count must match its attributed observations')
 
     @classmethod
     def finish(
@@ -107,6 +160,7 @@ class CompletedResult:
         completed_at: datetime,
         groups: Mapping[ResultKind, Iterable[str]],
         source_executions: Iterable[SourceExecution] = (),
+        observations: Iterable[ResultObservation] = (),
     ) -> Self:
         results: set[tuple[ResultKind, str]] = set()
         for kind, values in groups.items():
@@ -123,10 +177,11 @@ class CompletedResult:
             completed_at=completed_at,
             results=tuple(sorted(results)),
             source_executions=tuple(source_executions),
+            observations=tuple(sorted(set(observations))),
         )
 
     def evidence_dict(self) -> dict[str, object]:
-        incomplete = {'failed', 'rate-limited', 'skipped'}
+        incomplete = {'partial', 'failed', 'rate-limited', 'skipped'}
         status = 'complete'
         if self.source_executions and all(execution.status == 'failed' for execution in self.source_executions):
             status = 'failed'
@@ -138,7 +193,7 @@ class CompletedResult:
             'started_at': self.started_at.isoformat(),
             'completed_at': self.completed_at.isoformat(),
             'status': status,
-            'results': [{'type': kind, 'value': value, 'sources': []} for kind, value in self.results],
+            'results': self._result_records(),
             'source_executions': [execution.to_dict() for execution in self.source_executions],
         }
 
@@ -155,6 +210,14 @@ class CompletedResult:
                 'target': self.target,
                 'type': 'summary',
             },
-            *({'type': kind, 'value': value} for kind, value in self.results),
+            *self._result_records(),
         ]
         return ''.join(json.dumps(record, ensure_ascii=False, separators=(',', ':'), sort_keys=True) + '\n' for record in records)
+
+    def _result_records(self) -> list[dict[str, object]]:
+        sources_by_result: dict[tuple[ResultKind, str], list[str]] = {}
+        for observation in self.observations:
+            sources_by_result.setdefault((observation.kind, observation.value), []).append(observation.source)
+        return [
+            {'type': kind, 'value': value, 'sources': sources_by_result.get((kind, value), [])} for kind, value in self.results
+        ]

--- a/theHarvester/lib/database.py
+++ b/theHarvester/lib/database.py
@@ -409,6 +409,11 @@ class ResultStore:
             logger.info(f'Unexpected error while storing result: {error}')
 
     async def source_yields(self, run_id: UUID) -> list[SourceYield]:
+        """Count each source's observed, unique, and shared results for a run.
+
+        A result is unique when one source reported it and shared when more than one
+        source reported it. Sources that ran without results still appear with zero counts.
+        """
         async with self._session() as session:
             execution_rows = (
                 await session.scalars(

--- a/theHarvester/lib/database.py
+++ b/theHarvester/lib/database.py
@@ -2,6 +2,7 @@ import asyncio
 import datetime
 import logging
 import sqlite3
+from collections import Counter
 from collections.abc import AsyncIterator, Iterable
 from contextlib import asynccontextmanager
 from datetime import date
@@ -9,17 +10,24 @@ from pathlib import Path
 from typing import Any, cast
 from uuid import UUID
 
-from sqlalchemy import Date, ForeignKey, Text, UniqueConstraint, event, func, select
+from sqlalchemy import Date, Float, ForeignKey, ForeignKeyConstraint, Text, UniqueConstraint, event, func, select
 from sqlalchemy.engine import URL
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-from theHarvester.lib.completed_result import CompletedResult, ResultKind
+from theHarvester.lib.completed_result import (
+    CompletedResult,
+    ExecutionStatus,
+    ResultKind,
+    ResultObservation,
+    SourceExecution,
+    SourceYield,
+)
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 _DEFAULT_DATABASE = Path('~/.local/share/theHarvester/stash.sqlite').expanduser()
 
 
@@ -43,10 +51,10 @@ class _Base(DeclarativeBase):
     pass
 
 
-class _DiscoveryObservationRow(_Base):
+class _LegacyObservationRow(_Base):
     """A runless source observation, including incomplete rows from older databases."""
 
-    __tablename__ = 'discovery_observations'
+    __tablename__ = 'legacy_observations'
 
     id: Mapped[int] = mapped_column(primary_key=True)
     domain: Mapped[str | None] = mapped_column(Text, index=True)
@@ -81,6 +89,49 @@ class _ResultRow(_Base):
     position: Mapped[int] = mapped_column(primary_key=True)
     kind: Mapped[str] = mapped_column(Text)
     value: Mapped[str] = mapped_column(Text)
+
+
+class _ExecutionRow(_Base):
+    """One source or action that ran as part of an enumeration."""
+
+    __tablename__ = 'executions'
+    __table_args__ = (UniqueConstraint('run_id', 'producer_kind', 'name'),)
+
+    run_id: Mapped[str] = mapped_column(
+        Text,
+        ForeignKey('runs.run_id', ondelete='CASCADE'),
+        primary_key=True,
+    )
+    position: Mapped[int] = mapped_column(primary_key=True)
+    producer_kind: Mapped[str] = mapped_column(Text)
+    name: Mapped[str] = mapped_column(Text)
+    status: Mapped[str] = mapped_column(Text)
+    duration_ms: Mapped[float] = mapped_column(Float)
+    result_count: Mapped[int]
+    error_type: Mapped[str | None] = mapped_column(Text)
+    stop_reason: Mapped[str | None] = mapped_column(Text)
+
+
+class _ResultOriginRow(_Base):
+    """Link one persisted result to the execution that produced it."""
+
+    __tablename__ = 'result_origins'
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ('run_id', 'result_position'),
+            ('results.run_id', 'results.position'),
+            ondelete='CASCADE',
+        ),
+        ForeignKeyConstraint(
+            ('run_id', 'execution_position'),
+            ('executions.run_id', 'executions.position'),
+            ondelete='CASCADE',
+        ),
+    )
+
+    run_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    result_position: Mapped[int] = mapped_column(primary_key=True)
+    execution_position: Mapped[int] = mapped_column(primary_key=True)
 
 
 def _configure_sqlite_connection(dbapi_connection: Any, _connection_record: Any) -> None:
@@ -141,17 +192,22 @@ class _SQLiteDatabase:
                         if schema_version == 0:
                             table_rows = await connection.exec_driver_sql("SELECT name FROM sqlite_master WHERE type = 'table'")
                             tables = {row[0] for row in table_rows}
-                            has_legacy_results = 'results' in tables
+                            has_legacy_results = 'results' in tables and 'runs' not in tables
                             if has_legacy_results:
                                 await connection.exec_driver_sql('ALTER TABLE results RENAME TO legacy_results')
                             if 'completed_results' in tables:
                                 await connection.exec_driver_sql('ALTER TABLE completed_results RENAME TO runs')
                             if 'completed_result_items' in tables:
                                 await connection.exec_driver_sql('ALTER TABLE completed_result_items RENAME TO results')
+                        else:
+                            table_rows = await connection.exec_driver_sql("SELECT name FROM sqlite_master WHERE type = 'table'")
+                            tables = {row[0] for row in table_rows}
+                        if 'discovery_observations' in tables and 'legacy_observations' not in tables:
+                            await connection.exec_driver_sql('ALTER TABLE discovery_observations RENAME TO legacy_observations')
                         await connection.run_sync(_Base.metadata.create_all)
                         if has_legacy_results:
                             await connection.exec_driver_sql(
-                                'INSERT INTO discovery_observations (domain, resource, kind, discovered_on, source) '
+                                'INSERT INTO legacy_observations (domain, resource, kind, discovered_on, source) '
                                 'SELECT domain, resource, CASE type '
                                 "WHEN 'host' THEN 'hostname' "
                                 "WHEN 'ip' THEN 'ip-address' "
@@ -225,6 +281,31 @@ class ResultStore:
                     _ResultRow(run_id=run_id, position=position, kind=kind, value=value)
                     for position, (kind, value) in enumerate(result.results)
                 )
+                session.add_all(
+                    _ExecutionRow(
+                        run_id=run_id,
+                        position=position,
+                        producer_kind='source',
+                        name=execution.source,
+                        status=execution.status,
+                        duration_ms=execution.duration_ms,
+                        result_count=execution.result_count,
+                        error_type=execution.error_type,
+                        stop_reason=execution.stop_reason,
+                    )
+                    for position, execution in enumerate(result.source_executions)
+                )
+                await session.flush()
+                result_positions = {item: position for position, item in enumerate(result.results)}
+                execution_positions = {execution.source: position for position, execution in enumerate(result.source_executions)}
+                session.add_all(
+                    _ResultOriginRow(
+                        run_id=run_id,
+                        result_position=result_positions[(observation.kind, observation.value)],
+                        execution_position=execution_positions[observation.source],
+                    )
+                    for observation in result.observations
+                )
                 await session.commit()
             except IntegrityError as error:
                 duplicate_codes = {
@@ -243,12 +324,43 @@ class ResultStore:
             rows = (
                 await session.scalars(select(_ResultRow).where(_ResultRow.run_id == str(run_id)).order_by(_ResultRow.position))
             ).all()
+            execution_rows = (
+                await session.scalars(
+                    select(_ExecutionRow)
+                    .where(_ExecutionRow.run_id == str(run_id), _ExecutionRow.producer_kind == 'source')
+                    .order_by(_ExecutionRow.position)
+                )
+            ).all()
+            origin_rows = (await session.scalars(select(_ResultOriginRow).where(_ResultOriginRow.run_id == str(run_id)))).all()
+        results_by_position = {row.position: row for row in rows}
+        executions_by_position = {row.position: row for row in execution_rows}
         return CompletedResult(
             run_id=UUID(parent.run_id),
             target=parent.target,
             started_at=datetime.datetime.fromisoformat(parent.started_at),
             completed_at=datetime.datetime.fromisoformat(parent.completed_at),
             results=tuple((cast('ResultKind', row.kind), row.value) for row in rows),
+            source_executions=tuple(
+                SourceExecution(
+                    source=row.name,
+                    status=cast('ExecutionStatus', row.status),
+                    duration_ms=row.duration_ms,
+                    result_count=row.result_count,
+                    error_type=row.error_type,
+                    stop_reason=row.stop_reason,
+                )
+                for row in execution_rows
+            ),
+            observations=tuple(
+                sorted(
+                    ResultObservation(
+                        source=executions_by_position[row.execution_position].name,
+                        kind=cast('ResultKind', results_by_position[row.result_position].kind),
+                        value=results_by_position[row.result_position].value,
+                    )
+                    for row in origin_rows
+                )
+            ),
         )
 
     async def list_runs(self, *, limit: int = 50) -> list[dict[str, object]]:
@@ -283,7 +395,7 @@ class ResultStore:
         try:
             async with self._session() as session:
                 session.add_all(
-                    _DiscoveryObservationRow(
+                    _LegacyObservationRow(
                         domain=target,
                         resource=str(value),
                         kind=kind,
@@ -295,6 +407,43 @@ class ResultStore:
                 await session.commit()
         except Exception as error:
             logger.info(f'Unexpected error while storing result: {error}')
+
+    async def source_yields(self, run_id: UUID) -> list[SourceYield]:
+        async with self._session() as session:
+            execution_rows = (
+                await session.scalars(
+                    select(_ExecutionRow).where(
+                        _ExecutionRow.run_id == str(run_id),
+                        _ExecutionRow.producer_kind == 'source',
+                    )
+                )
+            ).all()
+            result_rows = (await session.scalars(select(_ResultRow).where(_ResultRow.run_id == str(run_id)))).all()
+            origin_rows = (await session.scalars(select(_ResultOriginRow).where(_ResultOriginRow.run_id == str(run_id)))).all()
+        source_by_position = {row.position: row.name for row in execution_rows}
+        result_by_position = {row.position: (row.kind, row.value) for row in result_rows}
+        sources_by_result: dict[tuple[str, str], set[str]] = {}
+        for origin in origin_rows:
+            source = source_by_position.get(origin.execution_position)
+            result = result_by_position.get(origin.result_position)
+            if source is not None and result is not None:
+                sources_by_result.setdefault(result, set()).add(source)
+        observed_counts: Counter[str] = Counter()
+        unique_counts: Counter[str] = Counter()
+        shared_counts: Counter[str] = Counter()
+        for sources in sources_by_result.values():
+            for source in sources:
+                observed_counts[source] += 1
+                (unique_counts if len(sources) == 1 else shared_counts)[source] += 1
+        return [
+            SourceYield(
+                source=source,
+                observed_result_count=observed_counts[source],
+                unique_result_count=unique_counts[source],
+                shared_result_count=shared_counts[source],
+            )
+            for source in sorted(source_by_position.values())
+        ]
 
     @asynccontextmanager
     async def _session(self) -> AsyncIterator[AsyncSession]:


### PR DESCRIPTION
## Summary

This adds the persistence layer needed to compare passive sources without changing CLI output formats or the REST API.

- keep one stable run ID across checkpoints and the terminal result
- store each passive source execution and link it to the normalized findings it produced
- preserve old runless observations in `legacy_observations` during the automatic SQLite `PRAGMA user_version` 1 to 2 migration
- include source attribution on JSONL findings while keeping the first JSONL contract unversioned
- expose observed, unique, and shared result counts, including sources that ran but yielded nothing
- retain partial findings when a later source getter fails
- record Cert Spotter pagination and rate-limit outcomes without retaining provider payloads

The run data stays deliberately small:

- `runs`: one scan
- `results`: deduplicated terminal findings
- `executions`: each source that ran
- `result_origins`: which execution produced each result
- `legacy_observations`: older rows that predate run identity

An execution status of `completed` means the adapter returned normally. It does not claim that every upstream request succeeded. Precise `partial` and `rate-limited` statuses are used only when the adapter can report them truthfully.

## Verification

- focused provenance and affected-source tests: 142 passed, 1 skipped
- full pytest: 616 passed, 6 skipped
- Ruff check and formatting check: passed
- mypy: passed for all 89 source files
- uv lock check: passed, 89 packages
- git diff check: passed
- zero em dashes in changed files
- parallel Standards review: no findings
- parallel Spec review: no findings

A bounded passive run against `mozilla.org` used crt.sh, Cert Spotter, and RapidDNS with a 100-result limit. JSONL contained 310 findings and SQLite contained the exact same 310 results. Cert Spotter contributed 241 observations, RapidDNS 90, and 21 findings were shared. crt.sh returned zero findings in that run and remains visible as a zero-yield execution. The database used SQLite `user_version` 2 and WAL mode.

## Scope

This PR covers passive-source provenance only. Active DNS, screenshots, takeover, Shodan, API-scan provenance, the REST refactor, SQLite upload, and HarvestView changes remain separate stacked slices.
