### PR TITLE
Add bounded virtual-host discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ api-keys.yaml
 .env.*
 .secrets/
 test-results/
+/testdata/
 
 # impeccable-ignore-start
 # Ephemeral output, runtime state, and per-dev overrides.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added bounded virtual host discovery over harvested or operator-supplied literal-IP endpoints, with aligned HTTP `Host` and TLS SNI, synthetic unknown-host controls, hard request and runtime limits, and structured observations on canonical hostname results in JSONL, SQLite, the API, and HarvestView.
 - Added HarvestView, an authenticated local browser workspace backed by a durable single-worker `/api/v1` run lifecycle with cancellation, deadlines, JSONL-only file interchange, retained partial evidence, and real-browser regression coverage.
 - Added a pinned, non-root Docker Compose deployment for HarvestView and the REST API with localhost-only publishing, file-secret authentication, private durable run storage, and an authenticated API health check.
 - Added bounded recursive DNS discovery with three-vantage consensus, closest-encloser wildcard controls, exact-address PTR evidence, and hard query, depth, runtime, and zero-yield limits.
@@ -23,11 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recorded takeover, Shodan, and API endpoint scan outcomes through the unified action model.
 - Added normalized BuiltWith framework, language, server, CMS, and analytics findings to JSONL and completed-result SQLite output.
 - Added DNSDB passive DNS discovery with API key configuration, shared transport handling, result parsing, and offline tests ([9b41b78e](https://github.com/laramies/theHarvester/commit/9b41b78e), [aba9fec6](https://github.com/laramies/theHarvester/commit/aba9fec6)).
-- Added `--verbose` diagnostic logging while keeping normal operator output available at the default log level ([8a7b8b71](https://github.com/laramies/theHarvester/commit/8a7b8b71)).
+- Added `-v` and `--verbose` diagnostic logging while keeping normal operator output available at the default log level ([8a7b8b71](https://github.com/laramies/theHarvester/commit/8a7b8b71)).
 - Added an opt-in passive-provider smoke workflow and a network guard that keeps routine tests offline by default ([72e5820f](https://github.com/laramies/theHarvester/commit/72e5820f)).
 - Added root contributor and security policies, structured issue forms, repository agent guidance, discovery terminology, and an operator-focused documentation wiki ([d090a29a](https://github.com/laramies/theHarvester/commit/d090a29a), [7c491ef5](https://github.com/laramies/theHarvester/commit/7c491ef5), [8b9d420b](https://github.com/laramies/theHarvester/commit/8b9d420b)).
 
 ### Changed
+- Removed the transport-wide delay before reading ready HTTP responses, bounded Wayback Archive and Common Crawl collection to 30 seconds, kept Wayback within the requested result limit, and made long-source progress visible in verbose mode.
+- Reported Baidu no-response and verification outcomes plus Common Crawl query failures as source evidence without aborting sibling sources.
 - Made `harvestview` the sole launcher for the local web application and REST API.
 - Standardized SQLite, JSONL, API, and HarvestView result names on `hostname` and `ip` without a presentation alias.
 - Standardized URL-producing adapters, JSON, JSONL, SQLite, and API evidence on one `url` result kind while preserving producer provenance.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -54,6 +54,10 @@ _Avoid_: Raw finding, source result
 One normalized DNS-name merged result. It can be the authorized target itself or a subordinate name and does not by itself imply current DNS addressability.
 _Avoid_: Subdomain result, live host, resolved host
 
+**Virtual-host observation**:
+Structured differential endpoint evidence attached to a canonical hostname result. Several endpoint observations can enrich one hostname without creating another result or count.
+_Avoid_: Virtual-host result, vhost result
+
 **IP result**:
 One canonical IPv4 or IPv6 address merged result.
 _Avoid_: IP-address result, resolved host

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Never commit populated configuration files, API keys, account details, or provid
 - Host, email, IP, and related scan records are stored in `~/.local/share/theHarvester/stash.sqlite`.
 - Full CLI pipeline runs are also stored transactionally by run UUID with their completed, deduplicated findings.
 - API executions use the same SQLite database as CLI results. Durable lifecycle rows stay separate from terminal evidence, while typed results and source or action origins remain queryable. JSONL handles individual run interchange, and the API can import completed runs from another theHarvester SQLite database.
+- Bounded [virtual host discovery](docs/wiki/Virtual-Host-Discovery.md) enriches each confirmed `hostname` result with structured endpoint observations and `vhost` action provenance.
 
 Treat collected OSINT as potentially sensitive. Keep report files, screenshots, and the local database out of source control and share them only within the authorized engagement.
 
@@ -272,10 +273,18 @@ The JSONL report is finalized after the selected one-shot actions finish. The fi
 
 JSONL is easy to stream one record at a time. The summary preserves the evidence status, source and action outcomes, and screenshot artifact metadata. Finding lines carry `sources` and, when applicable, `actions`; they inherit their run ID and target from the preceding summary. Hostnames, IP addresses, and URLs use the same `hostname`, `ip`, and `url` result kinds in JSONL, SQLite, the API, and HarvestView. Provenance identifies which source or action produced each finding. Structured result types, including recursive DNS records plus `person`, `infostealer`, `shodan`, and `takeover`, store a JSON object inside the string `value`. Parse those values a second time with `fromjson`.
 
+Virtual-host observations do not use that string encoding. Each confirmed name remains one `hostname` finding with `actions: ["vhost"]` and a native `observations` array. Several endpoint observations can enrich the same hostname without creating another result kind or count.
+
 Parse recursive DNS findings as JSON objects:
 
 ```bash
 jq -c 'select(.type == "dns-recursive-finding") | .value | fromjson' report.jsonl
+```
+
+List the endpoint observations for each confirmed virtual host:
+
+```bash
+jq -c 'select(.type == "hostname" and .observations) | {hostname: .value, observations}' report.jsonl
 ```
 
 Stable Have I Been Pwned breach names use `breach` records. Normalized BuiltWith findings use `framework`, `language`, `server`, `cms`, or `analytics` records. Recursive runs also include classifications and one summary containing query cost, reached depth, zero-yield batches, and the stop reason.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -4,7 +4,7 @@ theHarvester gathers open-source intelligence about a domain or organization. It
 
 Use it during the early reconnaissance stage of an authorized security assessment. Passive providers still receive the search target.
 
-DNS brute force, DNS resolution, takeover checks, screenshots, and API-path scanning create additional network activity. Use these features only on systems you own or are explicitly authorized to test.
+DNS brute force, DNS resolution, virtual host discovery, takeover checks, screenshots, and API-path scanning create additional network activity. Use these features only on systems you own or are explicitly authorized to test.
 
 ## Start here
 

--- a/docs/wiki/Responsible-Use-and-Scope.md
+++ b/docs/wiki/Responsible-Use-and-Scope.md
@@ -19,6 +19,7 @@ The following options require additional care:
 | `-c`, `--dns-brute` | Tries candidate subdomains against DNS. |
 | `-t`, `--take-over` | Checks discovered hosts for takeover indicators. |
 | `-s`, `--shodan` | Enriches discovered hosts through Shodan. |
+| `--vhost`, `--vhost-*` | Probes literal IP endpoints with candidate SNI and HTTP `Host` values. |
 | `--screenshot DIR` | Opens discovered web services in a browser. |
 | `-a`, `--api-scan` | Requests common API paths from the target. |
 

--- a/docs/wiki/Rest-API.md
+++ b/docs/wiki/Rest-API.md
@@ -111,6 +111,19 @@ The action catalog and run request use the same names. For example, set `takeove
 
 Every custom API scan entry must be a URL path beginning with `/`. The API does not accept a server-side file path.
 
+Virtual host discovery is the `vhost` action. An action-only run must provide both a literal-IP endpoint and at least one in-scope hostname candidate:
+
+```json
+{
+  "target": "authorized.example",
+  "sources": [],
+  "vhost_endpoint": "https://192.0.2.10:443/",
+  "vhost_candidates": ["admin.authorized.example"]
+}
+```
+
+Supplying either virtual host field enables the action, but a missing endpoint or candidate set must then come from selected-source results. Candidate names are sent as HTTP `Host` values and HTTPS SNI; this action never resolves them. It uses direct transport, does not follow redirects, rejects proxy settings, and applies request, runtime, timeout, and concurrency bounds. See [Virtual Host Discovery](Virtual-Host-Discovery) for the exact scope and evidence model.
+
 HarvestView's subdomain action buttons call this route and create a separate run without changing the completed parent run.
 
 ## Import and export
@@ -149,7 +162,7 @@ curl -s "http://127.0.0.1:5000/api/v1/runs/$run_id/export" \
   -o results.jsonl
 ```
 
-The first line is the `summary` record, including evidence status, source and action outcomes, and artifacts. Each remaining line is one normalized finding with `type`, `value`, `sources`, and optional `actions`. This keeps the file easy to stream with `jq -c` and makes API exports importable again without a format conversion. Lifecycle details and the submitted request remain available from `GET /api/v1/runs/{run_id}`.
+The first line is the `summary` record, including evidence status, source and action outcomes, and artifacts. Each remaining line is one normalized finding with `type`, `value`, `sources`, and optional `actions`. A hostname confirmed by the `vhost` action adds a native `observations` array; it remains one `hostname` finding. This keeps the file easy to stream with `jq -c` and makes API exports importable again without a format conversion. Lifecycle details and the submitted request remain available from `GET /api/v1/runs/{run_id}`.
 
 ## Security boundary
 

--- a/docs/wiki/Results-and-Local-Data.md
+++ b/docs/wiki/Results-and-Local-Data.md
@@ -20,6 +20,8 @@ This creates `report.json` and `report.xml`.
 - **XML** contains the command, emails, hosts, and virtual hosts. Use JSON for other result types.
 - Current JSON and XML reports do not record which source found each item.
 
+When virtual host discovery runs, JSON's `vhosts` array and XML's `<vhost>` entries contain confirmed hostnames only. They do not include endpoint or baseline evidence; use JSONL or API run details for that structured data.
+
 Host values may be plain hostnames. When DNS resolution is enabled, they can also use the `hostname:IP` form.
 
 The repository [README output section](https://github.com/laramies/theHarvester/blob/dev/README.md#report-formats) documents the current fields and provides copyable `jq` examples.
@@ -44,6 +46,8 @@ The normalized persistence model can represent active-action provenance and arti
 - `result_origins`: which execution produced each result; and
 - `artifacts`: files such as screenshots, linked to their creating action and subject result.
 
+Virtual-host evidence stays inside this model. `results` holds one `hostname` row, `result_origins` links it to the `vhost` action execution, and the result's `details_json` contains the canonical endpoint observation array. If one hostname is distinct on several IP endpoints, it remains one result with several observations.
+
 Current runtime collection populates passive source executions plus DNS, takeover, Shodan, and API endpoint scan executions and origins. Screenshot actions attach file metadata to their captured hostname or URL without creating fake screenshot findings.
 
 Every discovered URL is stored as the `url` result kind. Its source or action origins identify whether it came from BuiltWith, GitLab, RocketReach, API scanning, or another producer; provider-specific URL kinds are not stored.
@@ -58,7 +62,7 @@ Two operational tables support the API without changing those five evidence conc
 
 ## API results
 
-`GET /api/v1/runs/{run_id}` returns lifecycle state plus a normalized `results` array. Each result has `type`, `value`, `sources`, and `actions`. Run-level source and action outcomes remain available in `source_executions` and `action_executions`, while file metadata is returned through `artifacts`. JSONL imports or exports one run, and SQLite import loads completed runs in bulk. Treat runtime `/docs`, `/redoc`, and OpenAPI as the exact request and response reference.
+`GET /api/v1/runs/{run_id}` returns lifecycle state plus a normalized `results` array. Each result has `type`, `value`, `sources`, and `actions`. A `hostname` found through the `vhost` action also has a native `observations` array with its endpoint, literal-IP context, unknown-host control, and optional body-confirmation evidence. Run-level source and action outcomes remain available in `source_executions` and `action_executions`, while file metadata is returned through `artifacts`. JSONL imports or exports one run, and SQLite import loads completed runs in bulk. Treat runtime `/docs`, `/redoc`, and OpenAPI as the exact request and response reference.
 
 ## Handling and sharing
 

--- a/docs/wiki/Virtual-Host-Discovery.md
+++ b/docs/wiki/Virtual-Host-Discovery.md
@@ -1,0 +1,292 @@
+# Virtual host discovery
+
+A web server can host several sites on one IP address. The site selected by the server depends on the HTTP `Host` header and, for HTTPS, the TLS Server Name Indication (SNI). Virtual host discovery checks whether an in-scope hostname produces a response that differs from the endpoint's default or wildcard response.
+
+This is a P2 direct action. It sends requests to harvested IP addresses or to one literal-IP endpoint supplied by the operator. Use it only when the target, addresses, ports, and technique are covered by the assessment authorization.
+
+## What gets probed
+
+`--vhost` uses the run's collected evidence:
+
+- Literal IP addresses become endpoints. The sweep tries HTTPS port 443 across the address set before HTTP port 80.
+- Harvested hostnames inside the exact target boundary become candidates.
+- DNS brute-force IPs and names are included because virtual host discovery runs after DNS brute force.
+- In-scope names found by reverse DNS become candidates. The reverse-DNS `/24` range does not become a new set of virtual host endpoints.
+
+This is harvested-candidate testing, not wordlist-based virtual host brute forcing. Repeat `--vhost-candidate` to add a small authorized list that the selected sources did not return.
+
+For a normal harvested run, `--vhost` is the only virtual-host option you need. The request, runtime, timeout, and concurrency options are advanced safety overrides; bounded defaults apply when you omit them.
+
+The shared request cap may stop the sweep before it reaches every endpoint. When that happens, the `vhost` action is `partial` with the stop reason `request-limit`; it does not claim complete coverage.
+
+An explicit endpoint replaces the harvested endpoint set:
+
+```bash
+AUTHORIZED_DOMAIN='replace-with-a-domain-you-control'
+AUTHORIZED_IP='replace-with-an-authorized-ip'
+
+uv run theHarvester \
+  -d "$AUTHORIZED_DOMAIN" \
+  --vhost-endpoint "https://${AUTHORIZED_IP}:443/" \
+  --vhost-candidate "admin.${AUTHORIZED_DOMAIN}" \
+  -f report
+```
+
+The endpoint must use `http` or `https`, a literal IPv4 or IPv6 address, and an optional port. Paths, query strings, fragments, credentials, hostnames, and CIDR ranges are rejected.
+
+Candidate names are never resolved by this feature. Each candidate must be the target hostname or a descendant of it. The boundary is exact: authorization for `www.example.com` does not authorize `admin.example.com`.
+
+## How the classifier works
+
+For each endpoint, theHarvester makes a literal-IP context request and at least three synthetic unknown-host control requests. Controls match the label shape of the candidate being tested. This matters on servers whose wildcard behavior changes with label depth.
+
+HTTPS candidate and control requests send the same hostname in TLS SNI and the HTTP `Host` header. HTTP requests send the hostname only in `Host`. Redirects are recorded as evidence but are not followed.
+
+```mermaid
+flowchart TD
+    A[Collect hostnames and literal IPs] --> B[Keep candidates inside the exact target scope]
+    A --> C[Build HTTPS endpoints, then HTTP endpoints]
+    B --> D[Select the next endpoint and candidates that fit the shared cap]
+    C --> D
+    D --> E[Request the literal-IP context]
+    D --> F[Request three unknown controls for each candidate shape]
+    D --> G[Request the candidate with aligned SNI and Host]
+    E --> H{Are both baselines usable and controls stable?}
+    F --> H
+    G --> H
+    H -->|No| I[Indeterminate]
+    H -->|Yes| J{Does the candidate match either baseline?}
+    J -->|Yes| K[Default]
+    J -->|No, status or redirect differs| L[Distinct]
+    J -->|Only the body differs| M[Repeat the candidate request]
+    M --> N{Does the body difference repeat?}
+    N -->|Yes| L
+    N -->|No| I
+    L --> O[Store structured virtual host evidence]
+```
+
+Before comparison, the classifier replaces an exact reflection of the current authority in the response body or `Location` header. A generic error page that merely repeats the requested hostname should not become a discovery.
+
+The comparison can use these signals:
+
+| Signal | Meaning |
+| --- | --- |
+| `status` | The HTTP status differs from both baselines. |
+| `location` | The normalized redirect location differs. |
+| `body_size` | The bounded response body has a different size. |
+| `body_sha256` | The bounded response body has different content. |
+
+The classifier returns one of three states:
+
+| Classification | Meaning |
+| --- | --- |
+| `default` | The candidate matches either the literal-IP context response or a stable unknown-host control. |
+| `distinct` | The candidate differs from both baselines. Body-only differences require a matching second candidate response. |
+| `indeterminate` | A baseline is unusable, the controls disagree, the candidate matches only one baseline, body evidence is incomplete, or a required confirmation did not repeat. |
+
+Completed results retain only confirmed `distinct` observations. Default and indeterminate responses still consume budget, but they are not reported as discoveries.
+
+## Request and runtime limits
+
+The defaults are:
+
+| Control | CLI option | Default |
+| --- | --- | ---: |
+| Requests across the whole sweep | `--vhost-request-limit` | 100 |
+| Runtime across the whole sweep | `--vhost-runtime-seconds` | 30 seconds |
+| Timeout for one request | `--vhost-timeout-seconds` | 5 seconds |
+| Concurrent candidate requests | `--vhost-concurrency` | 5 |
+
+The request limit covers the context request, unknown controls, candidate requests, and any confirmation request. Unused requests and time from an early endpoint carry forward to later endpoints. A low cap favors breadth: HTTPS is attempted across harvested IPs before the sweep starts HTTP.
+
+The `vhost` entry in `action_executions` records one of these action statuses:
+
+| Action status | Meaning |
+| --- | --- |
+| `completed` | Every selected endpoint and candidate completed within the limits. |
+| `partial` | A request or runtime limit stopped coverage, or a request, scan, or cancellation error occurred after a confirmed hostname was retained. |
+| `skipped` | No candidate names or literal-IP endpoints were available. |
+| `failed` | A request, scan, or cancellation error ended the action before it retained a confirmed hostname. |
+
+Its `stop_reason` explains the outcome in more detail:
+
+| Stop reason | Meaning |
+| --- | --- |
+| `completed` | Every selected endpoint and candidate completed within the limits. |
+| `no-candidates` | The run had no in-scope hostnames to test. |
+| `no-endpoints` | The run had no harvested literal IP and no endpoint override. |
+| `request-limit` | The cap omitted an endpoint or candidate, or stopped before confirmation finished. |
+| `request-errors` | Every candidate was attempted, but one or more requests failed. |
+| `runtime-limit` | The shared wall-clock deadline expired. Completed partial evidence is retained. |
+| `scan-error` | An unexpected probing error stopped the action. |
+| `cancelled` | The operator cancelled the run. |
+
+Cancellation requested by the operator is different from a runtime limit. It propagates through the worker lifecycle and closes active connections.
+
+## Basic CLI use
+
+Harvest hostnames and IP addresses, then run the bounded sweep:
+
+```bash
+AUTHORIZED_DOMAIN='replace-with-a-domain-you-control'
+
+uv run theHarvester \
+  -d "$AUTHORIZED_DOMAIN" \
+  -b rapiddns \
+  --vhost \
+  -f report
+```
+
+`rapiddns` is used here because it can return both hostnames and literal IP addresses. If the selected sources return only hostnames, enable a DNS action that contributes IP evidence or supply `--vhost-endpoint`.
+
+Repeat `--vhost-candidate` to add names that are already authorized but were not returned by the selected sources:
+
+```bash
+uv run theHarvester \
+  -d "$AUTHORIZED_DOMAIN" \
+  -b rapiddns \
+  --vhost \
+  --vhost-candidate "admin.${AUTHORIZED_DOMAIN}" \
+  --vhost-candidate "preview.${AUTHORIZED_DOMAIN}"
+```
+
+Virtual host discovery uses direct transport. It rejects `--proxies`. HTTPS certificate verification is enabled by default. `--vhost-insecure` disables verification and records `tls_verified: false` in the evidence. Use that option only when the engagement requires it and the endpoint is authorized.
+
+### Reading terminal output
+
+The summary reports confirmed endpoint observations and coverage:
+
+```text
+[*] Virtual hosts: confirmed=1; candidate-endpoints=18/48; endpoints=4/8; requests=100
+[!] Coverage stopped at the request limit; raise --vhost-request-limit or narrow the scan.
+admin.authorized.example at https://192.0.2.10:443/: status=401; signals=status
+```
+
+A candidate-endpoint is one hostname tested against one IP endpoint. This pair count avoids implying that a hostname tested against one IP was also tested against every other IP. When coverage stops early, the next line explains which limit was reached and which option controls it.
+
+## HarvestView and REST API
+
+HarvestView exposes a virtual host discovery checkbox plus optional endpoint and candidate inputs. Advanced safety controls contain the request, runtime, timeout, concurrency, and certificate-verification overrides. Leaving the endpoint blank uses harvested IPs.
+
+The same run can be submitted to `POST /api/v1/runs`:
+
+```json
+{
+  "target": "authorized.example",
+  "sources": ["rapiddns"],
+  "vhost": true
+}
+```
+
+Add `vhost_endpoint` or `vhost_candidates` only when harvested evidence does not supply them. The request, runtime, timeout, concurrency, and insecure-TLS fields override the same bounded defaults shown above.
+
+Supplying `vhost_endpoint` or `vhost_candidates` enables the action even when `vhost` is omitted. A run with `sources: []` must supply both an endpoint and at least one candidate; otherwise the missing side must come from harvested results. The API rejects proxy use, hostname endpoints, out-of-scope candidates, and IP targets before it queues a run.
+
+## One finding, multiple endpoint observations
+
+JSONL is unversioned. After the summary line, it stores one canonical finding for each confirmed hostname. The normal `value` field contains the hostname, `actions` records `vhost` provenance, and `observations` is a native array rather than JSON hidden inside a string.
+
+If a hostname is distinct on two endpoints, both endpoint records stay under that one hostname finding:
+
+```json
+{
+  "type": "hostname",
+  "value": "admin.authorized.example",
+  "sources": [],
+  "actions": ["vhost"],
+  "observations": [
+    {
+      "endpoint": "https://192.0.2.10:443/",
+      "http_host": "admin.authorized.example",
+      "tls_server_name": "admin.authorized.example",
+      "classification": "distinct",
+      "phase": "body",
+      "status": 401,
+      "location": null,
+      "body_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "body_size": 123,
+      "body_truncated": false,
+      "context_phase": "body",
+      "context_status": 200,
+      "context_location": null,
+      "context_body_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "context_body_size": 123,
+      "context_body_truncated": false,
+      "control_phase": "body",
+      "control_status": 200,
+      "control_location": null,
+      "control_body_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "control_body_size": 123,
+      "control_body_truncated": false,
+      "confirmation_body_sha256": null,
+      "tls_verified": true,
+      "distinct_signals": ["status"],
+      "reflection_normalized": false
+    },
+    {
+      "endpoint": "https://192.0.2.11:443/",
+      "http_host": "admin.authorized.example",
+      "tls_server_name": "admin.authorized.example",
+      "classification": "distinct",
+      "phase": "body",
+      "status": 403,
+      "location": null,
+      "body_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "body_size": 87,
+      "body_truncated": false,
+      "context_phase": "body",
+      "context_status": 404,
+      "context_location": null,
+      "context_body_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "context_body_size": 87,
+      "context_body_truncated": false,
+      "control_phase": "body",
+      "control_status": 404,
+      "control_location": null,
+      "control_body_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "control_body_size": 87,
+      "control_body_truncated": false,
+      "confirmation_body_sha256": null,
+      "tls_verified": true,
+      "distinct_signals": ["status"],
+      "reflection_normalized": false
+    }
+  ]
+}
+```
+
+The `context_*` fields contain the literal-IP response, while `control_*` contains the stable unknown-host response. A distinct candidate must differ from both. `confirmation_body_sha256` is present only when a repeated response confirmed a body-only difference. These fields let a reviewer verify the recorded `distinct_signals` without retaining every synthetic control request. The source list is empty because virtual host discovery is an action, not a passive source.
+
+SQLite uses the same shape without inventing another evidence concept: `results` holds one `hostname` row, `result_origins` links it to the `vhost` execution, and that result's details hold the endpoint observation array. JSONL export and API run details expose the array as native JSON. `vhost` is an action name, not a result kind.
+
+Legacy JSON and XML keep their existing virtual host name lists. They do not carry the endpoint and response evidence. Use JSONL or `GET /api/v1/runs/{run_id}` when automation needs the structured observations.
+
+## Troubleshooting
+
+### The run says `no-candidates`
+
+Select a source that returns hostnames or add an authorized name with `--vhost-candidate`. Check the exact target boundary if the run targets a hostname such as `www.example.com`.
+
+### The run says `no-endpoints`
+
+Select sources that can return IP addresses, enable a DNS action that contributes literal IP evidence, or supply `--vhost-endpoint`.
+
+### The run says `request-limit`
+
+The cap was too small for every endpoint, candidate shape, and confirmation request. Narrow the source set or candidate list before raising the cap. The terminal summary shows attempted endpoints as `attempted/total`.
+
+### A candidate is missing from the results
+
+Only confirmed `distinct` observations are retained. A candidate may have matched the default response, produced unstable controls, failed during transport, returned a truncated body, or failed a body-only confirmation.
+
+### HTTPS results are indeterminate
+
+Certificate verification or TLS negotiation may have failed before the server returned HTTP evidence. Check whether the certificate is valid for the candidate SNI. If the assessment permits unverified TLS, rerun the bounded test with `--vhost-insecure` and keep the recorded verification state with the result.
+
+## Related pages
+
+- [Responsible Use and Scope](Responsible-Use-and-Scope)
+- [Operator Workflows](Operator-Workflows)
+- [Results and Local Data](Results-and-Local-Data)
+- [REST API](Rest-API)
+- [Troubleshooting](Troubleshooting)

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -10,6 +10,7 @@
 
 - [Configuration and API Keys](Configuration-and-API-Keys)
 - [Operator Workflows](Operator-Workflows)
+- [Virtual Host Discovery](Virtual-Host-Discovery)
 - [Results and Local Data](Results-and-Local-Data)
 - [REST API](Rest-API)
 - [Troubleshooting](Troubleshooting)

--- a/tests/discovery/test_baidusearch.py
+++ b/tests/discovery/test_baidusearch.py
@@ -25,8 +25,10 @@ class TestBaiduSearch:
         monkeypatch.setattr(baidusearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
         search = baidusearch.SearchBaidu(word='example.com', limit=10)
 
-        with pytest.raises(RuntimeError, match='empty response'):
-            await search.process()
+        await search.process()
+
+        assert search.execution_status == 'failed'
+        assert search.stop_reason == 'no-response'
 
     @pytest.mark.asyncio
     async def test_partial_empty_fetch_response_is_ignored(self, monkeypatch):
@@ -48,8 +50,10 @@ class TestBaiduSearch:
         monkeypatch.setattr(baidusearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
         search = baidusearch.SearchBaidu(word='example.com', limit=10)
 
-        with pytest.raises(RuntimeError, match='security verification'):
-            await search.process()
+        await search.process()
+
+        assert search.execution_status == 'rate-limited'
+        assert search.stop_reason == 'security-verification'
 
     @pytest.mark.asyncio
     async def test_process_and_parsing(self, monkeypatch):

--- a/tests/discovery/test_commoncrawl.py
+++ b/tests/discovery/test_commoncrawl.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from urllib.parse import parse_qs, urlsplit
 
@@ -185,11 +186,14 @@ async def test_process_caps_provider_page_counts_and_reports_truncation(
     monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
     monkeypatch.setattr(commoncrawl.SearchCommoncrawl, 'MAX_PAGES_PER_QUERY', 2)
 
+    search = commoncrawl.SearchCommoncrawl('example.com', limit=50)
     with caplog.at_level(logging.WARNING, logger=commoncrawl.__name__):
-        await commoncrawl.SearchCommoncrawl('example.com', limit=50).process()
+        await search.process()
 
     assert requested_pages == [0, 1, 0, 1]
     assert 'Common Crawl page limit reached for index CC-MAIN-2026-30; results may be incomplete' in caplog.text
+    assert search.execution_status == 'partial'
+    assert search.stop_reason == 'page-limit'
 
 
 @pytest.mark.asyncio
@@ -289,13 +293,119 @@ async def test_process_reports_non_json_upstream_response(
 
     monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
 
-    with (
-        caplog.at_level(logging.WARNING, logger=commoncrawl.__name__),
-        pytest.raises(RuntimeError, match='all Common Crawl queries failed'),
-    ):
-        await commoncrawl.SearchCommoncrawl('example.com').process()
+    search = commoncrawl.SearchCommoncrawl('example.com')
+    with caplog.at_level(logging.WARNING, logger=commoncrawl.__name__):
+        await search.process()
 
     assert 'unexpected non-JSON response' in caplog.text
+    assert search.execution_status == 'failed'
+    assert search.stop_reason == 'all-queries-failed'
+
+
+@pytest.mark.asyncio
+async def test_process_stops_a_query_after_one_entirely_unusable_page_batch(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    catalog = [
+        {
+            'id': 'CC-MAIN-2026-30',
+            'cdx-api': 'https://index.commoncrawl.org/CC-MAIN-2026-30-index',
+            'to': '2026-07-12T00:00:00',
+        }
+    ]
+    page_batches = 0
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        nonlocal page_batches
+        if urls == ['https://index.commoncrawl.org/collinfo.json']:
+            return [catalog]
+        query = parse_qs(urlsplit(urls[0]).query)
+        if query.get('showNumPages') == ['true']:
+            return ['{"pages": 100, "pageSize": 5, "blocks": 500}']
+        page_batches += 1
+        return [''] * len(urls)
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = commoncrawl.SearchCommoncrawl('example.com')
+    with caplog.at_level(logging.INFO, logger=commoncrawl.__name__):
+        await search.process()
+
+    assert page_batches == 2
+    assert 'Common Crawl selected 1 index and 2 queries' in caplog.text
+    assert 'example.com' not in caplog.text
+    assert search.execution_status == 'failed'
+    assert search.stop_reason == 'all-queries-failed'
+
+
+@pytest.mark.asyncio
+async def test_process_retains_partial_results_at_the_runtime_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    catalog = [
+        {
+            'id': 'CC-MAIN-2026-30',
+            'cdx-api': 'https://index.commoncrawl.org/CC-MAIN-2026-30-index',
+            'to': '2026-07-12T00:00:00',
+        }
+    ]
+    count_requests = 0
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        nonlocal count_requests
+        if urls == ['https://index.commoncrawl.org/collinfo.json']:
+            return [catalog]
+        query = parse_qs(urlsplit(urls[0]).query)
+        if query.get('showNumPages') == ['true']:
+            count_requests += 1
+            if count_requests > 1:
+                await asyncio.Event().wait()
+            return ['{"pages": 1, "pageSize": 5, "blocks": 1}']
+        return ['{"url":"https://api.example.com/"}']
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(commoncrawl.SearchCommoncrawl, 'RUNTIME_SECONDS', 0.01)
+    search = commoncrawl.SearchCommoncrawl('example.com')
+
+    await asyncio.wait_for(search.process(), timeout=0.1)
+
+    assert await search.get_hostnames() == {'api.example.com'}
+    assert search.execution_status == 'partial'
+    assert search.stop_reason == 'runtime-limit'
+
+
+@pytest.mark.asyncio
+async def test_process_reports_a_runtime_limit_before_collecting_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch_all(_urls: list[str], **_kwargs: object) -> list[object]:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(commoncrawl.SearchCommoncrawl, 'RUNTIME_SECONDS', 0.01)
+    search = commoncrawl.SearchCommoncrawl('example.com')
+
+    await asyncio.wait_for(search.process(), timeout=0.1)
+
+    assert await search.get_hostnames() == set()
+    assert search.execution_status == 'failed'
+    assert search.stop_reason == 'runtime-limit'
+
+
+@pytest.mark.asyncio
+async def test_process_propagates_external_cancellation(monkeypatch: pytest.MonkeyPatch) -> None:
+    started = asyncio.Event()
+
+    async def fake_fetch_all(_urls: list[str], **_kwargs: object) -> list[object]:
+        started.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = commoncrawl.SearchCommoncrawl('example.com')
+    task = asyncio.create_task(search.process())
+    await started.wait()
+
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
 
 @pytest.mark.asyncio
@@ -333,6 +443,8 @@ async def test_process_keeps_later_valid_page_after_malformed_page(
 
     assert await search.get_hostnames() == {'api.example.com'}
     assert 'malformed JSON line' in caplog.text
+    assert search.execution_status == 'partial'
+    assert search.stop_reason == 'query-errors'
 
 
 @pytest.mark.asyncio

--- a/tests/discovery/test_waybackarchive.py
+++ b/tests/discovery/test_waybackarchive.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from urllib.parse import parse_qs, urlparse
 
@@ -121,15 +122,17 @@ async def test_process_keeps_partial_results_when_a_later_page_times_out(
 
     assert await search.get_hostnames() == {'api.example.com', 'example.com'}
     assert 'Wayback Archive API error for pattern *.example.com' in caplog.text
+    assert search.execution_status == 'partial'
+    assert search.stop_reason == 'request-error'
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ('payload', 'expected_log'),
+    ('payload', 'expected_log', 'expected_status', 'expected_stop_reason'),
     [
-        ('', 'returned no page data'),
-        ('<html>provider error</html>', 'returned invalid page data'),
-        ({'unexpected': 'shape'}, 'returned invalid page data'),
+        ('', 'returned no page data', None, None),
+        ('<html>provider error</html>', 'returned invalid page data', 'failed', 'invalid-response'),
+        ({'unexpected': 'shape'}, 'returned invalid page data', 'failed', 'invalid-response'),
     ],
 )
 async def test_process_ignores_empty_html_and_non_text_responses(
@@ -137,6 +140,8 @@ async def test_process_ignores_empty_html_and_non_text_responses(
     caplog: pytest.LogCaptureFixture,
     payload: object,
     expected_log: str,
+    expected_status: str | None,
+    expected_stop_reason: str | None,
 ) -> None:
     async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
         return [payload]
@@ -149,6 +154,8 @@ async def test_process_ignores_empty_html_and_non_text_responses(
 
     assert await search.get_hostnames() == set()
     assert expected_log in caplog.text
+    assert search.execution_status == expected_status
+    assert search.stop_reason == expected_stop_reason
 
 
 @pytest.mark.asyncio
@@ -176,3 +183,70 @@ async def test_process_respects_the_per_query_page_bound(
     assert wildcard_requests == 2
     assert await search.get_hostnames() == {'host-1.example.com', 'host-2.example.com'}
     assert 'Wayback Archive page limit reached for pattern *.example.com; results may be incomplete' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_process_retains_partial_results_at_the_runtime_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    requests = 0
+
+    async def fake_fetch_all(_urls: list[str], **_kwargs: object) -> list[str]:
+        nonlocal requests
+        requests += 1
+        if requests == 1:
+            return ['https://api.example.com/path\n\nnext-page']
+        await asyncio.Event().wait()
+        raise AssertionError('unreachable')
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(waybackarchive.SearchWaybackarchive, 'RUNTIME_SECONDS', 0.01)
+    search = waybackarchive.SearchWaybackarchive('example.com')
+
+    with caplog.at_level(logging.INFO, logger=waybackarchive.__name__):
+        await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com'}
+    assert search.execution_status == 'partial'
+    assert search.stop_reason == 'runtime-limit'
+    assert 'Wayback Archive page 1: hosts=1' in caplog.text
+    assert 'example.com' not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_process_stops_at_the_requested_result_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    requested_urls: list[str] = []
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
+        requested_urls.extend(urls)
+        return ['https://one.example.com/path\nhttps://two.example.com/path\nhttps://three.example.com/path\n\nnext-page']
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = waybackarchive.SearchWaybackarchive('example.com', limit=2)
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'one.example.com', 'two.example.com'}
+    assert search.stop_reason == 'result-limit'
+    assert len(requested_urls) == 1
+
+
+@pytest.mark.asyncio
+async def test_process_keeps_an_earlier_failure_when_a_later_pattern_reaches_the_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
+        query = parse_qs(urlparse(urls[0]).query)
+        if query['url'] == ['*.example.com']:
+            return ['<html>provider error</html>']
+        return ['https://example.com/path']
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = waybackarchive.SearchWaybackarchive('example.com', limit=1)
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'example.com'}
+    assert search.execution_status == 'partial'
+    assert search.stop_reason == 'invalid-response'

--- a/tests/e2e/test_harvestview.py
+++ b/tests/e2e/test_harvestview.py
@@ -164,8 +164,10 @@ def test_harvestview_can_submit_overridable_execution_controls(
 
     page.route(f'{harvestview_server_url}/api/v1/runs', capture_submission)
     page.goto(f'{harvestview_server_url}/')
+    start_button = page.get_by_role('button', name='Start enumeration').first
+    expect(start_button).to_be_enabled()
     page.set_default_timeout(2_000)
-    page.get_by_role('button', name='Start enumeration').first.click()
+    start_button.click()
     page.get_by_role('button', name='Clear', exact=True).click()
     page.locator('#run-target').fill('example.com')
     page.get_by_text('Advanced execution controls', exact=True).click()
@@ -209,7 +211,66 @@ def test_harvestview_can_submit_overridable_execution_controls(
         'takeover': True,
         'api_scan': True,
         'api_scan_paths': ['/api/v2', '/health'],
+        'vhost': False,
+        'vhost_endpoint': '',
+        'vhost_candidates': [],
+        'vhost_request_limit': 100,
+        'vhost_runtime_seconds': 30,
+        'vhost_timeout_seconds': 5,
+        'vhost_concurrency': 5,
+        'vhost_insecure': False,
     }
+
+
+def test_harvestview_requires_complete_inputs_for_a_vhost_only_run(
+    harvestview_server_url: str,
+    page: Page,
+    browser_failures,
+) -> None:
+    browser_failures.allow_response('POST', 503, '/api/v1/runs')
+    browser_failures.allow_console_error(
+        'Failed to load resource: the server responded with a status of 503 (Service Unavailable)'
+    )
+    captured: dict[str, object] = {}
+
+    def capture_submission(route: Route) -> None:
+        if route.request.method != 'POST':
+            route.continue_()
+            return
+        captured.update(route.request.post_data_json)
+        route.fulfill(status=503, json={'detail': 'Virtual-host controls captured'})
+
+    page.route(f'{harvestview_server_url}/api/v1/runs', capture_submission)
+    page.goto(f'{harvestview_server_url}/')
+    page.get_by_role('button', name='Start enumeration').first.click()
+    page.get_by_role('button', name='Clear', exact=True).click()
+    page.locator('#run-target').fill('example.com')
+    page.get_by_text('P2 · Virtual-host discovery', exact=True).click()
+    page.locator('#vhost-endpoint').fill('https://192.0.2.10:443/')
+
+    expect(page.locator('#activity-summary')).to_have_text('P0 off · P1 off · P2 selected')
+    page.locator('#submit-run-button').click()
+    expect(page.locator('#new-run-error')).to_have_text(
+        'Virtual-host discovery without sources requires both a literal-IP endpoint and at least one candidate hostname.'
+    )
+    assert captured == {}
+
+    page.locator('#vhost-candidates').fill('admin.example.com\npreview.example.com')
+    page.locator('#submit-run-button').click()
+    expect(page.locator('#new-run-error')).to_have_text('Virtual-host controls captured')
+
+    assert captured['sources'] == []
+    assert captured['dns_resolvers']
+    assert captured['takeover'] is False
+    assert captured['api_scan_paths'] == []
+    assert captured['vhost'] is True
+    assert captured['vhost_endpoint'] == 'https://192.0.2.10:443/'
+    assert captured['vhost_candidates'] == ['admin.example.com', 'preview.example.com']
+    assert captured['vhost_request_limit'] == 100
+    assert captured['vhost_runtime_seconds'] == 30
+    assert captured['vhost_timeout_seconds'] == 5
+    assert captured['vhost_concurrency'] == 5
+    assert captured['vhost_insecure'] is False
 
 
 def test_harvestview_submits_a_target_only_api_scan(
@@ -236,7 +297,7 @@ def test_harvestview_submits_a_target_only_api_scan(
     page.get_by_role('button', name='Clear', exact=True).click()
     page.locator('#run-target').fill('api.example.test')
     page.locator('[name="api_scan"]').check()
-    page.locator('details.advanced-execution summary').click()
+    page.get_by_text('Advanced execution controls', exact=True).click()
     page.locator('#api-scan-paths').fill('/api/v2\n/health')
     page.locator('#submit-run-button').click()
 
@@ -244,6 +305,104 @@ def test_harvestview_submits_a_target_only_api_scan(
     assert captured['sources'] == []
     assert captured['api_scan'] is True
     assert captured['api_scan_paths'] == ['/api/v2', '/health']
+
+
+def test_harvestview_renders_grouped_virtual_host_observations(
+    harvestview_server_url: str,
+    page: Page,
+) -> None:
+    run = {
+        'run_id': 'vhost-run',
+        'target': 'example.com',
+        'status': 'completed',
+        'origin': 'local',
+        'created_at': '2026-08-05T12:00:00+00:00',
+        'started_at': '2026-08-05T12:00:01+00:00',
+        'completed_at': '2026-08-05T12:00:05+00:00',
+        'cancellation_requested_at': None,
+        'evidence_status': 'complete',
+        'result_count': 2,
+        'activities': ['P0', 'P2'],
+        'sources': ['crtsh'],
+        'request': {
+            'sources': ['crtsh'],
+            'limit': 25,
+            'deadline_seconds': 300,
+            'vhost': True,
+            'vhost_endpoint': '',
+            'vhost_candidates': [],
+            'vhost_request_limit': 100,
+            'vhost_runtime_seconds': 30,
+            'vhost_timeout_seconds': 5,
+            'vhost_concurrency': 5,
+            'vhost_insecure': False,
+        },
+        'source_executions': [],
+        'action_executions': [
+            {'action': 'vhost', 'status': 'completed', 'result_count': 1, 'duration_ms': 125},
+        ],
+        'results': [
+            {
+                'type': 'hostname',
+                'value': 'admin.example.com',
+                'sources': [],
+                'actions': ['vhost'],
+                'observations': [
+                    {
+                        'endpoint': 'https://192.0.2.10:443/',
+                        'phase': 'body',
+                        'status': 200,
+                        'location': None,
+                        'context_status': 200,
+                        'control_status': 200,
+                        'confirmation_body_sha256': 'a' * 64,
+                        'tls_verified': True,
+                        'distinct_signals': ['body_sha256'],
+                    },
+                    {
+                        'endpoint': 'http://198.51.100.20:80/',
+                        'phase': 'body',
+                        'status': 302,
+                        'location': '/login',
+                        'context_status': 404,
+                        'control_status': 404,
+                        'confirmation_body_sha256': None,
+                        'tls_verified': None,
+                        'distinct_signals': ['status', 'location'],
+                    },
+                ],
+            },
+            {
+                'type': 'hostname',
+                'value': 'www.example.com',
+                'sources': ['crtsh'],
+                'actions': [],
+            },
+        ],
+        'screenshots': [],
+        'log': '',
+        'error': None,
+    }
+
+    page.route(f'{harvestview_server_url}/api/v1/runs', lambda route: route.fulfill(json=[run]))
+    page.route(f'{harvestview_server_url}/api/v1/runs/vhost-run', lambda route: route.fulfill(json=run))
+    page.goto(f'{harvestview_server_url}/')
+
+    expect(page.get_by_role('button', name='Hostnames 2')).to_be_enabled()
+    expect(page.get_by_role('button', name='Virtual hosts 1')).to_have_count(0)
+    expect(page.locator('#route-count')).to_have_text('2')
+    expect(page.locator('#results-summary')).to_have_text('2 normalized results across 1 route.')
+    result_row = page.locator('.tabulator-row').first
+    expect(result_row).to_contain_text('admin.example.com')
+    expect(result_row).to_contain_text(
+        'https://192.0.2.10:443/ · HTTP 200 · body_sha256 · IP HTTP 200 · unknown HTTP 200 · body confirmed · TLS verified'
+    )
+    expect(result_row).to_contain_text(
+        'http://198.51.100.20:80/ · HTTP 302 → /login · status, location · IP HTTP 404 · unknown HTTP 404'
+    )
+    expect(result_row).to_contain_text('vhost')
+    expect(page.get_by_role('button', name='Take screenshot of admin.example.com (P2)')).to_be_visible()
+    expect(page.get_by_role('button', name='DNS brute force admin.example.com (P1)')).to_be_visible()
 
 
 def test_hostname_actions_queue_isolated_runs(

--- a/tests/lib/test_api_v1.py
+++ b/tests/lib/test_api_v1.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sqlite3
 
 import pytest
 from fastapi.testclient import TestClient
@@ -35,6 +36,64 @@ def _jsonl_result(
     )
 
 
+def _vhost_observation(endpoint: str, hostname: str = 'admin.example.test') -> dict[str, object]:
+    return {
+        'endpoint': endpoint,
+        'http_host': hostname,
+        'tls_server_name': hostname,
+        'classification': 'distinct',
+        'phase': 'body',
+        'status': 401,
+        'location': None,
+        'body_sha256': 'a' * 64,
+        'body_size': 12,
+        'body_truncated': False,
+        'context_phase': 'body',
+        'context_status': 200,
+        'context_location': None,
+        'context_body_sha256': 'a' * 64,
+        'context_body_size': 12,
+        'context_body_truncated': False,
+        'control_phase': 'body',
+        'control_status': 200,
+        'control_location': None,
+        'control_body_sha256': 'a' * 64,
+        'control_body_size': 12,
+        'control_body_truncated': False,
+        'confirmation_body_sha256': None,
+        'tls_verified': True,
+        'distinct_signals': ['status'],
+        'reflection_normalized': False,
+    }
+
+
+def _vhost_jsonl_result(*, target: str = 'example.test', value: str = 'admin.example.test') -> str:
+    return _jsonl_result(
+        target=target,
+        finding_type='hostname',
+        value=value,
+        finding_fields={
+            'actions': ['vhost'],
+            'observations': [
+                _vhost_observation('https://192.0.2.8:443/', value),
+                _vhost_observation('https://192.0.2.9:443/', value),
+            ],
+        },
+        summary_fields={
+            'action_executions': [
+                {
+                    'action': 'vhost',
+                    'status': 'completed',
+                    'duration_ms': 1,
+                    'result_count': 1,
+                    'error_type': None,
+                    'stop_reason': None,
+                }
+            ]
+        },
+    )
+
+
 @pytest.mark.parametrize(
     ('finding_type', 'finding_fields'),
     [
@@ -44,6 +103,7 @@ def _jsonl_result(
         ('ip-address', {}),
         ('linkedin-link', {}),
         ('subdomain', {}),
+        ('vhost', {}),
         ('hostname', {'dns_status': 'made-up-status'}),
     ],
 )
@@ -218,6 +278,7 @@ def test_source_catalog_exposes_shared_action_activities(tmp_path, monkeypatch) 
         {'name': 'screenshot', 'activity': 'P2'},
         {'name': 'shodan', 'activity': 'P0'},
         {'name': 'takeover', 'activity': 'P2'},
+        {'name': 'vhost', 'activity': 'P2'},
     ]
 
 
@@ -253,7 +314,9 @@ def test_openapi_explains_scope_and_execution_controls(tmp_path, monkeypatch) ->
         'value',
         'sources',
         'actions',
+        'observations',
     }
+    assert 'VirtualHostResult' not in schema['components']['schemas']
     assert export_content['application/x-ndjson']['schema']['description'] == (
         'UTF-8 JSONL with one summary followed by normalized findings.'
     )
@@ -714,6 +777,215 @@ def test_api_jsonl_round_trip_uses_canonical_hostname_and_ip_kinds(tmp_path, mon
         assert imported.json()['results'] == [{'type': finding_type, 'value': value, 'sources': [], 'actions': []}]
         assert json.loads(exported.text.splitlines()[1]) == {'sources': [], 'type': finding_type, 'value': value}
         assert reimported.json()['results'] == [{'type': finding_type, 'value': value, 'sources': [], 'actions': []}]
+
+
+def test_api_jsonl_round_trip_preserves_grouped_virtual_host_observations(tmp_path, monkeypatch) -> None:
+    from theHarvester.lib.api import api
+
+    monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
+    monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
+    monkeypatch.setenv('THEHARVESTER_RUN_WORKER', 'disabled')
+    headers = {'X-API-Key': 'test-key'}
+
+    with TestClient(api.app, client=('127.0.0.18', 50000)) as client:
+        imported = client.post(
+            '/api/v1/runs/import',
+            params={'filename': 'vhost.jsonl'},
+            headers=headers,
+            content=_vhost_jsonl_result(),
+        )
+        exported = client.get(f'/api/v1/runs/{imported.json()["run_id"]}/export', headers=headers)
+        reimported = client.post(
+            '/api/v1/runs/import',
+            params={'filename': 'vhost-round-trip.jsonl'},
+            headers=headers,
+            content=exported.content,
+        )
+
+    expected = {
+        'type': 'hostname',
+        'value': 'admin.example.test',
+        'sources': [],
+        'actions': ['vhost'],
+        'observations': [
+            _vhost_observation('https://192.0.2.8:443/'),
+            _vhost_observation('https://192.0.2.9:443/'),
+        ],
+    }
+    assert imported.status_code == 201
+    assert imported.json()['results'] == [expected]
+    assert imported.json()['result_count'] == 1
+    assert json.loads(exported.text.splitlines()[1]) == expected
+    assert reimported.status_code == 201
+    assert reimported.json()['results'] == [expected]
+
+
+@pytest.mark.parametrize(
+    ('target', 'hostname'),
+    [
+        ('example.test', 'example.test'),
+        ('example.test', 'admin.other.test'),
+        ('192.0.2.8', 'admin.192.0.2.8'),
+    ],
+)
+def test_api_rejects_virtual_host_evidence_outside_the_run_scope(
+    tmp_path,
+    monkeypatch,
+    target: str,
+    hostname: str,
+) -> None:
+    from theHarvester.lib.api import api
+
+    monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
+    monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
+    monkeypatch.setenv('THEHARVESTER_RUN_WORKER', 'disabled')
+
+    with TestClient(api.app) as client:
+        response = client.post(
+            '/api/v1/runs/import',
+            params={'filename': 'out-of-scope-vhost.jsonl'},
+            headers={'X-API-Key': 'test-key'},
+            content=_vhost_jsonl_result(target=target, value=hostname),
+        )
+
+    assert response.status_code == 400
+
+
+def test_api_rejects_partial_virtual_host_observation(tmp_path, monkeypatch) -> None:
+    from theHarvester.lib.api import api
+
+    records = [json.loads(line) for line in _vhost_jsonl_result().splitlines()]
+    records[1]['observations'][0].pop('control_body_sha256')
+    monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
+    monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
+    monkeypatch.setenv('THEHARVESTER_RUN_WORKER', 'disabled')
+
+    with TestClient(api.app) as client:
+        response = client.post(
+            '/api/v1/runs/import',
+            params={'filename': 'partial-vhost.jsonl'},
+            headers={'X-API-Key': 'test-key'},
+            content=''.join(json.dumps(record) + '\n' for record in records),
+        )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize(
+    'mutation',
+    ['impossible-phase', 'serialized-error', 'missing-confirmation', 'mismatched-confirmation'],
+)
+def test_api_rejects_unproven_virtual_host_observation(tmp_path, monkeypatch, mutation: str) -> None:
+    from theHarvester.lib.api import api
+
+    records = [json.loads(line) for line in _vhost_jsonl_result().splitlines()]
+    observation = records[1]['observations'][0]
+    if mutation == 'impossible-phase':
+        observation['phase'] = 'connect'
+    elif mutation == 'serialized-error':
+        observation['error_type'] = None
+    else:
+        observation.update(
+            status=200,
+            context_body_sha256='b' * 64,
+            control_body_sha256='b' * 64,
+            distinct_signals=['body_sha256'],
+        )
+        if mutation == 'missing-confirmation':
+            observation.pop('confirmation_body_sha256')
+        else:
+            observation['confirmation_body_sha256'] = 'b' * 64
+    monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
+    monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
+    monkeypatch.setenv('THEHARVESTER_RUN_WORKER', 'disabled')
+
+    with TestClient(api.app) as client:
+        response = client.post(
+            '/api/v1/runs/import',
+            params={'filename': f'{mutation}.jsonl'},
+            headers={'X-API-Key': 'test-key'},
+            content=''.join(json.dumps(record) + '\n' for record in records),
+        )
+
+    assert response.status_code == 400
+
+
+def test_api_database_upload_preserves_grouped_virtual_host_observations(tmp_path, monkeypatch) -> None:
+    from theHarvester.lib.api import api
+    from theHarvester.lib.api.run_evidence import parse_jsonl_import
+    from theHarvester.lib.api.run_store import RunStore
+    from theHarvester.lib.database import dispose_sqlite_databases
+
+    source_database = tmp_path / 'source.sqlite'
+
+    async def build_source_database() -> None:
+        await RunStore(source_database).import_evidence(
+            parse_jsonl_import(_vhost_jsonl_result().encode()),
+            'vhost.jsonl',
+        )
+        await dispose_sqlite_databases()
+
+    asyncio.run(build_source_database())
+    monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
+    monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'destination.sqlite'))
+    monkeypatch.setenv('THEHARVESTER_RUN_WORKER', 'disabled')
+    headers = {'X-API-Key': 'test-key'}
+
+    with TestClient(api.app) as client:
+        uploaded = client.post(
+            '/api/v1/runs/import-database',
+            params={'filename': 'source.sqlite'},
+            headers=headers,
+            content=source_database.read_bytes(),
+        )
+        run_id = uploaded.json()['imported_run_ids'][0]
+        detail = client.get(f'/api/v1/runs/{run_id}', headers=headers)
+        exported = client.get(f'/api/v1/runs/{run_id}/export', headers=headers)
+
+    assert uploaded.status_code == 201
+    assert detail.status_code == 200
+    assert detail.json()['results'][0]['observations'] == [
+        _vhost_observation('https://192.0.2.8:443/'),
+        _vhost_observation('https://192.0.2.9:443/'),
+    ]
+    assert json.loads(exported.text.splitlines()[1]) == detail.json()['results'][0]
+
+
+def test_api_database_upload_rejects_vhost_evidence_outside_its_stored_target(tmp_path, monkeypatch) -> None:
+    from theHarvester.lib.api import api
+    from theHarvester.lib.api.run_evidence import parse_jsonl_import
+    from theHarvester.lib.api.run_store import RunStore
+    from theHarvester.lib.database import dispose_sqlite_databases
+
+    source_database = tmp_path / 'source.sqlite'
+
+    async def build_source_database() -> None:
+        await RunStore(source_database).import_evidence(
+            parse_jsonl_import(_vhost_jsonl_result().encode()),
+            'vhost.jsonl',
+        )
+        await dispose_sqlite_databases()
+
+    asyncio.run(build_source_database())
+    with sqlite3.connect(source_database) as database:
+        database.execute("UPDATE runs SET target = 'other.test'")
+        database.commit()
+        database.execute('PRAGMA wal_checkpoint(TRUNCATE)')
+
+    monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
+    monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'destination.sqlite'))
+    monkeypatch.setenv('THEHARVESTER_RUN_WORKER', 'disabled')
+
+    with TestClient(api.app) as client:
+        response = client.post(
+            '/api/v1/runs/import-database',
+            params={'filename': 'out-of-scope.sqlite'},
+            headers={'X-API-Key': 'test-key'},
+            content=source_database.read_bytes(),
+        )
+
+    assert response.status_code == 400
+    assert 'run target scope' in response.json()['detail']
 
 
 def test_api_jsonl_round_trip_preserves_execution_outcomes_and_action_origins(tmp_path, monkeypatch) -> None:

--- a/tests/lib/test_completed_persistence.py
+++ b/tests/lib/test_completed_persistence.py
@@ -17,6 +17,7 @@ from theHarvester.lib.database import (
     _sqlite_has_wal_reset_fix,
     dispose_sqlite_databases,
 )
+from theHarvester.lib.virtual_host import VirtualHostObservation
 
 RELEASED_COMPLETED_SCHEMA = """
 CREATE TABLE completed_results (
@@ -128,6 +129,13 @@ PRAGMA user_version = 4;
 
 SCHEMA_V5_RESULT_KINDS = SCHEMA_V4_URL_KINDS + 'PRAGMA user_version = 5;'
 SCHEMA_V6_RESULT_KINDS = SCHEMA_V5_RESULT_KINDS + 'PRAGMA user_version = 6;'
+SCHEMA_V7_EVIDENCE_STATUS = (
+    SCHEMA_V6_RESULT_KINDS
+    + """
+ALTER TABLE runs ADD COLUMN evidence_status TEXT;
+PRAGMA user_version = 7;
+"""
+)
 
 
 def completed_result(run_id: str = 'f047261c-0afb-4e18-89d5-28a7d977f51f') -> CompletedResult:
@@ -168,6 +176,41 @@ def screenshot_execution(completed_at: datetime) -> ActionExecution:
                 created_at=completed_at,
             ),
         ),
+    )
+
+
+def vhost_observation(endpoint: str, *, status: int, control_status: int) -> VirtualHostObservation:
+    return VirtualHostObservation.from_record(
+        {
+            'type': 'vhost',
+            'endpoint': endpoint,
+            'hostname': 'admin.example.com',
+            'http_host': 'admin.example.com',
+            'tls_server_name': None,
+            'classification': 'distinct',
+            'phase': 'body',
+            'status': status,
+            'location': None,
+            'body_sha256': 'a' * 64,
+            'body_size': 5,
+            'body_truncated': False,
+            'context_phase': 'body',
+            'context_status': control_status,
+            'context_location': None,
+            'context_body_sha256': 'a' * 64,
+            'context_body_size': 5,
+            'context_body_truncated': False,
+            'control_phase': 'body',
+            'control_status': control_status,
+            'control_location': None,
+            'control_body_sha256': 'a' * 64,
+            'control_body_size': 5,
+            'control_body_truncated': False,
+            'confirmation_body_sha256': None,
+            'tls_verified': None,
+            'distinct_signals': ['status'],
+            'reflection_normalized': False,
+        }
     )
 
 
@@ -218,10 +261,10 @@ async def test_newer_schema_is_rejected_without_changing_journal_mode(tmp_path) 
     database = tmp_path / 'stash.sqlite'
     store = ResultStore(database)
     with sqlite3.connect(database) as db:
-        db.execute('PRAGMA user_version = 8')
+        db.execute('PRAGMA user_version = 9')
         original_journal_mode = db.execute('PRAGMA journal_mode').fetchone()[0]
 
-    with pytest.raises(RuntimeError, match='schema version 8 is newer than supported version 7'):
+    with pytest.raises(RuntimeError, match='schema version 9 is newer than supported version 8'):
         await store.initialize()
 
     with sqlite3.connect(database) as db:
@@ -303,7 +346,192 @@ async def test_completed_result_round_trip_preserves_legacy_observations(tmp_pat
         'position': 'INTEGER',
         'kind': 'TEXT',
         'value': 'TEXT',
+        'details_json': 'TEXT',
     }
+
+
+@pytest.mark.asyncio
+async def test_structured_vhost_evidence_round_trips_in_the_results_table(tmp_path) -> None:
+    database = tmp_path / 'stash.sqlite'
+    store = ResultStore(database)
+    await store.initialize()
+    completed_at = datetime(2026, 8, 9, 12, 1, tzinfo=UTC)
+    first = vhost_observation('http://192.0.2.10', status=200, control_status=404)
+    second = vhost_observation('http://192.0.2.11', status=201, control_status=404)
+    result = CompletedResult.finish(
+        run_id=UUID('3ac7bba2-45da-4cdd-96a4-019a4d42bca4'),
+        target='example.com',
+        started_at=completed_at,
+        completed_at=completed_at,
+        groups={},
+        source_executions=(SourceExecution('crtsh', 'completed', 4.0, 1),),
+        observations=(ResultObservation('crtsh', 'hostname', 'admin.example.com'),),
+        active_evidence=ActiveEvidence(
+            executions=(
+                ActionExecution.finish(
+                    action='vhost',
+                    status='completed',
+                    duration_ms=12.5,
+                    groups={'hostname': ['admin.example.com']},
+                ),
+            )
+        ),
+        virtual_hosts=(second, first),
+    )
+
+    await store.save_run(result)
+
+    assert await store.load_run(result.run_id) == result
+    with sqlite3.connect(database) as db:
+        schema_version = db.execute('PRAGMA user_version').fetchone()[0]
+        stored_result = db.execute(
+            'SELECT kind, value, details_json FROM results WHERE run_id = ?',
+            (str(result.run_id),),
+        ).fetchone()
+        executions = db.execute(
+            'SELECT producer_kind, name, result_count FROM executions WHERE run_id = ? ORDER BY producer_kind',
+            (str(result.run_id),),
+        ).fetchall()
+        origin_count = db.execute(
+            'SELECT COUNT(*) FROM result_origins WHERE run_id = ?',
+            (str(result.run_id),),
+        ).fetchone()[0]
+    assert schema_version == 8
+    assert stored_result[:2] == ('hostname', 'admin.example.com')
+    assert json.loads(stored_result[2]) == [
+        {key: value for key, value in observation.to_record().items() if key not in {'type', 'hostname'}}
+        for observation in (first, second)
+    ]
+    assert executions == [('action', 'vhost', 1), ('source', 'crtsh', 1)]
+    assert origin_count == 2
+
+
+@pytest.mark.asyncio
+async def test_schema_v7_migrates_vhost_collision_without_losing_references(tmp_path) -> None:
+    database = tmp_path / 'stash.sqlite'
+    run_id = UUID('750ab571-778d-490e-b760-70394d936eb4')
+    with sqlite3.connect(database) as db:
+        db.executescript(SCHEMA_V7_EVIDENCE_STATUS)
+        db.execute(
+            'INSERT INTO runs (run_id, target, started_at, completed_at) VALUES (?, ?, ?, ?)',
+            (str(run_id), 'example.com', '2026-08-09T12:00:00+00:00', '2026-08-09T12:01:00+00:00'),
+        )
+        db.execute(
+            'INSERT INTO results (run_id, position, kind, value) VALUES (?, ?, ?, ?)',
+            (str(run_id), 0, 'hostname', 'admin.example.com'),
+        )
+        db.execute(
+            'INSERT INTO results (run_id, position, kind, value) VALUES (?, ?, ?, ?)',
+            (str(run_id), 1, 'vhost', 'admin.example.com'),
+        )
+        db.execute(
+            'INSERT INTO executions '
+            '(run_id, position, producer_kind, name, status, duration_ms, result_count) '
+            'VALUES (?, ?, ?, ?, ?, ?, ?)',
+            (str(run_id), 0, 'action', 'vhost', 'completed', 1.0, 2),
+        )
+        db.executemany(
+            'INSERT INTO result_origins (run_id, result_position, execution_position) VALUES (?, ?, ?)',
+            [(str(run_id), position, 0) for position in (0, 1)],
+        )
+        db.execute(
+            'INSERT INTO artifacts '
+            '(run_id, position, result_position, execution_position, kind, path, media_type, size_bytes, sha256, created_at) '
+            'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            (
+                str(run_id),
+                0,
+                1,
+                0,
+                'screenshot',
+                'screenshots/admin.example.com.png',
+                'image/png',
+                3,
+                '0' * 64,
+                '2026-08-09T12:01:00+00:00',
+            ),
+        )
+
+    store = ResultStore(database)
+    await store.initialize()
+    await store.dispose()
+    store = ResultStore(database)
+    await store.initialize()
+
+    with pytest.raises(ResultStoreError, match='virtual-host details'):
+        await store.load_run(run_id)
+    with sqlite3.connect(database) as db:
+        result_columns = [row[1] for row in db.execute('PRAGMA table_info(results)')]
+        stored = db.execute('SELECT kind, value, details_json FROM results').fetchall()
+        execution = db.execute('SELECT name, result_count FROM executions').fetchone()
+        origins = db.execute('SELECT result_position, execution_position FROM result_origins').fetchall()
+        artifacts = db.execute('SELECT result_position, execution_position, path FROM artifacts').fetchall()
+        schema_version = db.execute('PRAGMA user_version').fetchone()[0]
+    assert result_columns == ['run_id', 'position', 'kind', 'value', 'details_json']
+    assert stored == [('hostname', 'admin.example.com', None)]
+    assert execution == ('vhost', 1)
+    assert origins == [(0, 0)]
+    assert artifacts == [(0, 0, 'screenshots/admin.example.com.png')]
+    assert schema_version == 8
+
+
+@pytest.mark.asyncio
+async def test_schema_v7_migrates_unstructured_vhost_without_action_origin_to_hostname(tmp_path) -> None:
+    database = tmp_path / 'stash.sqlite'
+    run_id = UUID('20f4b762-e9cb-4e10-96c6-85f982af50b3')
+    with sqlite3.connect(database) as db:
+        db.executescript(SCHEMA_V7_EVIDENCE_STATUS)
+        db.execute(
+            'INSERT INTO runs (run_id, target, started_at, completed_at) VALUES (?, ?, ?, ?)',
+            (str(run_id), 'example.com', '2026-08-09T12:00:00+00:00', '2026-08-09T12:01:00+00:00'),
+        )
+        db.execute(
+            'INSERT INTO results (run_id, position, kind, value) VALUES (?, ?, ?, ?)',
+            (str(run_id), 0, 'vhost', 'admin.example.com'),
+        )
+
+    store = ResultStore(database)
+    await store.initialize()
+
+    loaded = await store.load_run(run_id)
+
+    assert loaded.results == (('hostname', 'admin.example.com'),)
+    assert loaded.virtual_hosts == ()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('details_json', [None, 'not-json', '[]', '[{"endpoint":"http://192.0.2.10:80/"}]'])
+async def test_loading_malformed_vhost_details_fails_closed(tmp_path, details_json: str | None) -> None:
+    database = tmp_path / 'stash.sqlite'
+    store = ResultStore(database)
+    await store.initialize()
+    result = CompletedResult.finish(
+        target='example.com',
+        started_at=datetime(2026, 8, 9, 12, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 8, 9, 12, 1, tzinfo=UTC),
+        groups={},
+        active_evidence=ActiveEvidence(
+            executions=(
+                ActionExecution.finish(
+                    action='vhost',
+                    status='completed',
+                    duration_ms=1,
+                    groups={'hostname': ['admin.example.com']},
+                ),
+            )
+        ),
+        virtual_hosts=(vhost_observation('http://192.0.2.10', status=200, control_status=404),),
+    )
+    await store.save_run(result)
+    with sqlite3.connect(database) as db:
+        db.execute(
+            'UPDATE results SET details_json = ? WHERE run_id = ?',
+            (details_json, str(result.run_id)),
+        )
+        db.commit()
+
+    with pytest.raises(ResultStoreError, match='virtual-host details'):
+        await store.load_run(result.run_id)
 
 
 @pytest.mark.asyncio
@@ -585,7 +813,7 @@ async def test_current_schema_reopens_without_running_legacy_migration(tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_schema_v2_upgrades_to_v7_without_rewriting_existing_rows(tmp_path) -> None:
+async def test_schema_v2_upgrades_to_v8_without_rewriting_existing_rows(tmp_path) -> None:
     database = tmp_path / 'stash.sqlite'
     run_id = UUID('251d4047-190b-4a4d-9c4e-9eed3f23c8c7')
     with sqlite3.connect(database) as db:
@@ -629,7 +857,7 @@ async def test_schema_v2_upgrades_to_v7_without_rewriting_existing_rows(tmp_path
         observations=(ResultObservation('crtsh', 'hostname', 'api.example.com'),),
     )
     with sqlite3.connect(database) as db:
-        assert db.execute('PRAGMA user_version').fetchone()[0] == 7
+        assert db.execute('PRAGMA user_version').fetchone()[0] == 8
         assert db.execute('SELECT COUNT(*) FROM artifacts').fetchone()[0] == 0
 
 
@@ -666,7 +894,7 @@ async def test_schema_v6_adds_nullable_evidence_status_without_rewriting_executi
     assert loaded.status == 'partial'
     assert stored_status is None
     assert 'evidence_status' in run_columns
-    assert schema_version == 7
+    assert schema_version == 8
 
 
 @pytest.mark.asyncio
@@ -755,7 +983,7 @@ async def test_schema_v4_merges_deprecated_url_kinds_without_losing_origins(tmp_
     assert screenshot.artifacts[0].subject_kind == 'url'
     assert screenshot.artifacts[0].subject_value == target_url
     with sqlite3.connect(database) as db:
-        assert db.execute('PRAGMA user_version').fetchone()[0] == 7
+        assert db.execute('PRAGMA user_version').fetchone()[0] == 8
         assert db.execute('SELECT DISTINCT kind FROM legacy_observations').fetchall() == [('url',)]
         assert db.execute('SELECT result_count FROM executions WHERE name = ?', ('api-scan',)).fetchone()[0] == 1
 
@@ -833,7 +1061,7 @@ async def test_schema_v5_merges_ip_address_into_ip_without_losing_provenance_or_
     assert screenshot.artifacts[0].subject_kind == 'ip'
     assert screenshot.artifacts[0].subject_value == address
     with sqlite3.connect(database) as db:
-        assert db.execute('PRAGMA user_version').fetchone()[0] == 7
+        assert db.execute('PRAGMA user_version').fetchone()[0] == 8
         assert db.execute('SELECT kind, value FROM results').fetchall() == [('ip', address)]
         assert db.execute('SELECT execution_position FROM result_origins ORDER BY execution_position').fetchall() == [
             (0,),
@@ -870,7 +1098,7 @@ async def test_released_results_migrate_to_legacy_observations(tmp_path) -> None
         result_columns = [row[1] for row in db.execute('PRAGMA table_info(results)')]
         schema_version = db.execute('PRAGMA user_version').fetchone()[0]
     assert 'legacy_results' not in tables
-    assert result_columns == ['run_id', 'position', 'kind', 'value']
+    assert result_columns == ['run_id', 'position', 'kind', 'value', 'details_json']
     assert observations == [
         ('api.example.com', 'hostname'),
         ('192.0.2.1', 'ip'),
@@ -881,7 +1109,7 @@ async def test_released_results_migrate_to_legacy_observations(tmp_path) -> None
         ('/api/v1', 'url'),
         ('admin@example.com', 'email'),
     ]
-    assert schema_version == 7
+    assert schema_version == 8
 
 
 @pytest.mark.asyncio
@@ -992,7 +1220,7 @@ async def test_legacy_observations_keep_the_released_normalized_schema(tmp_path)
     await store.record_observations('example.com', ['admin@example.com'], 'email', 'hunter')
     await store.record_observations('example.com', ['192.0.2.1'], 'ip', 'dns')
     await store.record_observations('example.com', ['{"firstname":"Ada","lastname":"Lovelace"}'], 'person', 'hunter')
-    await store.record_observations('example.com', ['vhost.example.com'], 'vhost', 'virtual-host')
+    await store.record_observations('example.com', ['vhost.example.com'], 'hostname', 'virtual-host')
     await store.record_observations('example.com', ['443'], 'shodan', 'shodan')
 
     with sqlite3.connect(database) as db:
@@ -1006,7 +1234,7 @@ async def test_legacy_observations_keep_the_released_normalized_schema(tmp_path)
         ('example.com', 'admin@example.com', 'email', 'hunter'),
         ('example.com', '192.0.2.1', 'ip', 'dns'),
         ('example.com', '{"firstname":"Ada","lastname":"Lovelace"}', 'person', 'hunter'),
-        ('example.com', 'vhost.example.com', 'vhost', 'virtual-host'),
+        ('example.com', 'vhost.example.com', 'hostname', 'virtual-host'),
         ('example.com', '443', 'shodan', 'shodan'),
     ]
 
@@ -1030,7 +1258,7 @@ async def test_schema_v1_observations_upgrade_without_losing_rows(tmp_path) -> N
         schema_version = db.execute('PRAGMA user_version').fetchone()[0]
     assert 'discovery_observations' not in tables
     assert rows == [('example.com', 'api.example.com', 'hostname', 'crtsh')]
-    assert schema_version == 7
+    assert schema_version == 8
 
 
 @pytest.mark.asyncio

--- a/tests/lib/test_completed_result.py
+++ b/tests/lib/test_completed_result.py
@@ -6,7 +6,49 @@ from uuid import UUID
 import pytest
 
 from theHarvester.lib.active_evidence import ActionExecution, ActionObservation, ActiveEvidence, ArtifactReference
-from theHarvester.lib.completed_result import CompletedResult, ResultObservation, SourceExecution
+from theHarvester.lib.completed_result import CompletedResult, ResultObservation, SourceExecution, parse_result_jsonl
+from theHarvester.lib.virtual_host import VirtualHostObservation
+
+
+def vhost_observation(
+    endpoint: str,
+    *,
+    status: int,
+    control_status: int,
+    hostname: str = 'admin.example.com',
+) -> VirtualHostObservation:
+    return VirtualHostObservation.from_record(
+        {
+            'type': 'vhost',
+            'endpoint': endpoint,
+            'hostname': hostname,
+            'http_host': hostname,
+            'tls_server_name': None,
+            'classification': 'distinct',
+            'phase': 'body',
+            'status': status,
+            'location': None,
+            'body_sha256': 'a' * 64,
+            'body_size': 5,
+            'body_truncated': False,
+            'context_phase': 'body',
+            'context_status': control_status,
+            'context_location': None,
+            'context_body_sha256': 'a' * 64,
+            'context_body_size': 5,
+            'context_body_truncated': False,
+            'control_phase': 'body',
+            'control_status': control_status,
+            'control_location': None,
+            'control_body_sha256': 'a' * 64,
+            'control_body_size': 5,
+            'control_body_truncated': False,
+            'confirmation_body_sha256': None,
+            'tls_verified': None,
+            'distinct_signals': ['status'],
+            'reflection_normalized': False,
+        }
+    )
 
 
 @pytest.mark.parametrize('evidence_status', ['partial', 'failed'])
@@ -234,6 +276,165 @@ def test_completed_result_merges_active_results_and_keeps_screenshot_as_an_artif
         {'type': 'hostname', 'value': 'api.example.com', 'sources': []},
         {'type': 'ip', 'value': '192.0.2.10', 'sources': [], 'actions': ['dns-resolve']},
     ]
+
+
+def test_completed_result_groups_structured_vhost_evidence_by_hostname() -> None:
+    completed_at = datetime(2026, 8, 5, 12, 1, tzinfo=UTC)
+    first = vhost_observation('http://192.0.2.10', status=200, control_status=404)
+    second = vhost_observation('http://192.0.2.11', status=201, control_status=404)
+    result = CompletedResult.finish(
+        target='example.com',
+        started_at=completed_at,
+        completed_at=completed_at,
+        groups={'hostname': ['admin.example.com']},
+        source_executions=(SourceExecution('crtsh', 'completed', 4.0, 1),),
+        observations=(ResultObservation('crtsh', 'hostname', 'admin.example.com'),),
+        active_evidence=ActiveEvidence(
+            executions=(
+                ActionExecution.finish(
+                    action='vhost',
+                    status='completed',
+                    duration_ms=12.5,
+                    groups={'hostname': ['admin.example.com', 'admin.example.com']},
+                ),
+            )
+        ),
+        virtual_hosts=(second, first, first),
+    )
+
+    records = [json.loads(line) for line in result.jsonl().splitlines()]
+    _summary, parsed_findings = parse_result_jsonl(result.jsonl())
+
+    assert result.virtual_hosts == (first, second)
+    assert result.results == (('hostname', 'admin.example.com'),)
+    assert result.active_evidence.executions[0].result_count == 1
+    assert records[0]['counts'] == {'hostname': 1}
+    assert records[0]['result_count'] == 1
+    assert records[1] == {
+        'type': 'hostname',
+        'value': 'admin.example.com',
+        'sources': ['crtsh'],
+        'actions': ['vhost'],
+        'observations': [
+            {key: value for key, value in observation.to_record().items() if key not in {'type', 'hostname'}}
+            for observation in (first, second)
+        ],
+    }
+    assert parsed_findings == records[1:]
+
+
+def test_completed_result_rejects_structured_vhost_without_vhost_action_provenance() -> None:
+    completed_at = datetime(2026, 8, 5, 12, 1, tzinfo=UTC)
+
+    with pytest.raises(ValueError, match='vhost action'):
+        CompletedResult.finish(
+            target='example.com',
+            started_at=completed_at,
+            completed_at=completed_at,
+            groups={'hostname': ['admin.example.com']},
+            virtual_hosts=(vhost_observation('http://192.0.2.10', status=200, control_status=404),),
+        )
+
+
+def test_completed_result_rejects_unstructured_vhost_action_result() -> None:
+    completed_at = datetime(2026, 8, 5, 12, 1, tzinfo=UTC)
+
+    with pytest.raises(ValueError, match='structured virtual-host evidence'):
+        CompletedResult.finish(
+            target='example.com',
+            started_at=completed_at,
+            completed_at=completed_at,
+            groups={},
+            active_evidence=ActiveEvidence(
+                executions=(
+                    ActionExecution.finish(
+                        action='vhost',
+                        status='completed',
+                        duration_ms=1,
+                        groups={'hostname': ['admin.example.com']},
+                    ),
+                )
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ('target', 'hostname'),
+    [
+        ('example.com', 'example.com'),
+        ('example.com', 'admin.other.test'),
+        ('192.0.2.8', 'admin.192.0.2.8'),
+    ],
+)
+def test_completed_result_rejects_structured_vhost_outside_the_run_scope(target: str, hostname: str) -> None:
+    completed_at = datetime(2026, 8, 5, 12, 1, tzinfo=UTC)
+
+    with pytest.raises(ValueError, match='run target scope'):
+        CompletedResult.finish(
+            target=target,
+            started_at=completed_at,
+            completed_at=completed_at,
+            groups={},
+            active_evidence=ActiveEvidence(
+                executions=(
+                    ActionExecution.finish(
+                        action='vhost',
+                        status='completed',
+                        duration_ms=1,
+                        groups={'hostname': [hostname]},
+                    ),
+                )
+            ),
+            virtual_hosts=(
+                vhost_observation(
+                    'http://192.0.2.10',
+                    status=200,
+                    control_status=404,
+                    hostname=hostname,
+                ),
+            ),
+        )
+
+
+def test_jsonl_rejects_noncanonical_structured_vhost_hostname() -> None:
+    observation = vhost_observation('http://192.0.2.10', status=200, control_status=404)
+    details = {key: value for key, value in observation.to_record().items() if key not in {'type', 'hostname'}}
+    payload = '\n'.join(
+        (
+            json.dumps({'type': 'summary'}),
+            json.dumps(
+                {
+                    'type': 'hostname',
+                    'value': 'Admin.Example.com',
+                    'sources': [],
+                    'actions': ['vhost'],
+                    'observations': [details],
+                }
+            ),
+        )
+    )
+
+    with pytest.raises(ValueError, match='canonical hostname'):
+        parse_result_jsonl(payload)
+
+
+def test_jsonl_rejects_legacy_vhost_result_kind() -> None:
+    payload = '\n'.join(
+        (
+            json.dumps({'type': 'summary'}),
+            json.dumps(
+                {
+                    'type': 'vhost',
+                    'value': 'admin.example.com',
+                    'sources': [],
+                    'actions': ['vhost'],
+                }
+            ),
+        )
+    )
+
+    with pytest.raises(ValueError, match='known type'):
+        parse_result_jsonl(payload)
 
 
 def test_completed_result_rejects_artifact_without_a_real_subject_result() -> None:

--- a/tests/lib/test_core.py
+++ b/tests/lib/test_core.py
@@ -283,11 +283,14 @@ def test_api_key_accessors_delegate_to_shared_mapping(monkeypatch, accessor_name
 
 @pytest.mark.asyncio
 async def test_fetch_creates_session_with_default_headers(monkeypatch) -> None:
+    async def fail_if_fetch_sleeps(seconds: float) -> None:
+        raise AssertionError(f'fetch delayed reading a ready response by {seconds} seconds')
+
     reset_dummy_sessions()
     monkeypatch.setattr(core_module.aiohttp, 'ClientSession', DummySession)
     monkeypatch.setattr(core_module.ssl, 'create_default_context', lambda cafile=None: 'ssl-context')
     monkeypatch.setattr(core_module.certifi, 'where', lambda: '/tmp/cacert.pem')
-    monkeypatch.setattr(core_module.asyncio, 'sleep', fake_sleep)
+    monkeypatch.setattr(core_module.asyncio, 'sleep', fail_if_fetch_sleeps)
     monkeypatch.setattr(Core, 'get_user_agent', staticmethod(lambda: 'test-agent'))
 
     result = await AsyncFetcher.fetch(url='https://example.com', follow_redirects=False)

--- a/tests/lib/test_enumeration.py
+++ b/tests/lib/test_enumeration.py
@@ -1,11 +1,14 @@
 from argparse import Namespace
 
+import pytest
+
 from theHarvester.lib.enumeration import (
     DEFAULT_DNS_RECURSIVE_QUERY_LIMIT,
     DEFAULT_DNS_RECURSIVE_RUNTIME_SECONDS,
     DEFAULT_RESULT_LIMIT,
     EnumerationOptions,
 )
+from theHarvester.lib.source_catalog import selected_action_names
 
 
 def test_enumeration_options_fill_the_shared_execution_defaults() -> None:
@@ -36,3 +39,40 @@ def test_enumeration_options_preserve_explicit_transport_values() -> None:
     assert options.proxies is True
     assert options.quiet is True
     assert options.screenshot == '/tmp/managed-screenshots'
+
+
+def test_enumeration_options_preserve_virtual_host_inputs() -> None:
+    options = EnumerationOptions.from_namespace(
+        Namespace(
+            domain='example.com',
+            vhost=True,
+            vhost_endpoint='https://192.0.2.10/',
+            vhost_candidates=['admin.example.com', 'portal.example.com'],
+            vhost_request_limit=25,
+            vhost_runtime_seconds=10.0,
+            vhost_timeout_seconds=2.0,
+            vhost_concurrency=3,
+            vhost_insecure=True,
+        )
+    )
+
+    assert options.vhost is True
+    assert options.vhost_endpoint == 'https://192.0.2.10/'
+    assert options.vhost_candidates == ('admin.example.com', 'portal.example.com')
+    assert options.vhost_request_limit == 25
+    assert options.vhost_runtime_seconds == 10.0
+    assert options.vhost_timeout_seconds == 2.0
+    assert options.vhost_concurrency == 3
+    assert options.vhost_insecure is True
+
+
+@pytest.mark.parametrize(
+    'selection',
+    [
+        {'vhost': True},
+        {'vhost_endpoint': 'https://192.0.2.10/'},
+        {'vhost_candidates': ['admin.example.com']},
+    ],
+)
+def test_virtual_host_inputs_select_the_direct_action(selection: dict[str, object]) -> None:
+    assert selected_action_names(selection) == ('vhost',)

--- a/tests/lib/test_harvestview_ui.py
+++ b/tests/lib/test_harvestview_ui.py
@@ -20,6 +20,7 @@ def test_harvestview_owns_root_and_issues_an_http_only_session(tmp_path, monkeyp
 
     assert root.status_code == 200
     assert '<title>HarvestView</title>' in root.text
+    assert '<summary>Advanced safety controls</summary>' in root.text
     assert f'value="{",".join(DEFAULT_DNS_RESOLVERS)}"' in root.text
     assert 'Resolve with the configured resolver addresses.' in root.text
     assert legacy.status_code == 404

--- a/tests/lib/test_run_backend.py
+++ b/tests/lib/test_run_backend.py
@@ -215,7 +215,7 @@ def test_api_lifecycle_and_terminal_evidence_share_the_sqlalchemy_database(tmp_p
         schema_version = db.execute('PRAGMA user_version').fetchone()[0]
     assert evidence_run_id == lifecycle_run_id
     assert stored_target == 'example.test'
-    assert schema_version == 7
+    assert schema_version == 8
     assert 'import aiosqlite' not in inspect.getsource(run_store_module)
 
 
@@ -797,6 +797,112 @@ def test_dns_brute_child_uses_operator_resolver_list(tmp_path, monkeypatch) -> N
     assert received_options[0].dns_brute is True
     assert received_options[0].dns_resolve == ''
     assert received_options[0].dns_resolvers == ('192.0.2.53',)
+
+
+def test_virtual_host_request_normalizes_a_self_contained_target_action() -> None:
+    from pydantic import ValidationError
+
+    from theHarvester.lib.api.run_models import RunRequest
+
+    request = RunRequest(
+        target='Example.Test.',
+        sources=[],
+        vhost_endpoint='https://192.0.2.8',
+        vhost_candidates=['ADMIN.Example.Test.'],
+    )
+
+    assert request.vhost is True
+    assert request.vhost_endpoint == 'https://192.0.2.8:443/'
+    assert request.vhost_candidates == ['admin.example.test']
+    assert (
+        RunRequest(
+            target='example.test',
+            sources=['crtsh'],
+            vhost_endpoint='http://192.0.2.9',
+        ).vhost
+        is True
+    )
+    assert (
+        RunRequest(
+            target='example.test',
+            sources=['crtsh'],
+            vhost_candidates=['admin.example.test'],
+        ).vhost
+        is True
+    )
+    with pytest.raises(ValidationError, match='discovery source'):
+        RunRequest(target='example.test', sources=[], vhost_endpoint='https://192.0.2.8')
+    with pytest.raises(ValidationError, match='discovery source'):
+        RunRequest(target='example.test', sources=[], vhost_candidates=['admin.example.test'])
+    with pytest.raises(ValidationError, match='discovery source'):
+        RunRequest(target='example.test', sources=[], vhost=True)
+    with pytest.raises(ValidationError, match='hostname target'):
+        RunRequest(target='192.0.2.8', sources=['crtsh'], vhost=True)
+    with pytest.raises(ValidationError, match='direct transport'):
+        RunRequest(target='example.test', sources=['crtsh'], vhost=True, proxies=True)
+
+
+def test_virtual_host_child_receives_bounded_controls_and_persistence_identity(tmp_path, monkeypatch) -> None:
+    from theHarvester import __main__ as main_module
+    from theHarvester.lib.api import run_worker
+    from theHarvester.lib.api.run_models import RunRequest
+    from theHarvester.lib.api.run_store import RunStore
+    from theHarvester.lib.completed_result import CompletedResult
+
+    captured = None
+    captured_database = None
+    captured_run_id = None
+
+    async def fake_start(options, **kwargs):
+        nonlocal captured, captured_database, captured_run_id
+        captured = options
+        captured_database = kwargs.get('result_database')
+        captured_run_id = kwargs.get('completed_run_id')
+        now = datetime.now(UTC)
+        return (
+            CompletedResult.finish(
+                run_id=captured_run_id,
+                target=options.domain,
+                started_at=now,
+                completed_at=now,
+                groups={},
+            ),
+        )
+
+    monkeypatch.setattr(main_module, 'start', fake_start)
+
+    async def scenario() -> tuple[Path, str]:
+        store = RunStore(tmp_path / 'runs.sqlite')
+        created = await store.create(
+            RunRequest(
+                target='example.test',
+                sources=[],
+                vhost_endpoint='https://192.0.2.8',
+                vhost_candidates=['admin.example.test'],
+                vhost_request_limit=12,
+                vhost_runtime_seconds=9,
+                vhost_timeout_seconds=2,
+                vhost_concurrency=1,
+                vhost_insecure=True,
+            )
+        )
+        assert await store.claim_next() is not None
+        await run_worker._child_execute(created['run_id'], store.database)
+        return store.database, created['run_id']
+
+    database, run_id = asyncio.run(scenario())
+
+    assert captured is not None
+    assert captured.vhost is True
+    assert captured.vhost_endpoint == 'https://192.0.2.8:443/'
+    assert captured.vhost_candidates == ('admin.example.test',)
+    assert captured.vhost_request_limit == 12
+    assert captured.vhost_runtime_seconds == 9
+    assert captured.vhost_timeout_seconds == 2
+    assert captured.vhost_concurrency == 1
+    assert captured.vhost_insecure is True
+    assert captured_database == database
+    assert str(captured_run_id) == run_id
 
 
 def test_api_scan_child_uses_operator_endpoint_paths(tmp_path, monkeypatch) -> None:

--- a/tests/lib/test_virtual_host.py
+++ b/tests/lib/test_virtual_host.py
@@ -1,0 +1,1234 @@
+import asyncio
+import logging
+import math
+import ssl
+import subprocess
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+from theHarvester.lib import virtual_host as virtual_host_module
+from theHarvester.lib.virtual_host import (
+    VHOST_BODY_LIMIT,
+    ProbeObservation,
+    VirtualHostDiscoveryCancelled,
+    VirtualHostDiscoveryResult,
+    VirtualHostLimits,
+    VirtualHostObservation,
+    VirtualHostRequest,
+    classify_virtual_host,
+    discover_harvested_virtual_hosts,
+    discover_virtual_hosts,
+)
+
+
+async def read_host(reader: asyncio.StreamReader) -> str:
+    request = await reader.readuntil(b'\r\n\r\n')
+    host_line = next(line for line in request.split(b'\r\n') if line.lower().startswith(b'host:'))
+    return host_line.split(b':', 1)[1].strip().decode()
+
+
+async def write_response(
+    writer: asyncio.StreamWriter,
+    *,
+    status: bytes = b'200 OK',
+    body: bytes = b'default page',
+    headers: tuple[bytes, ...] = (),
+    content_length: int | None = None,
+) -> None:
+    header_bytes = b''.join(header + b'\r\n' for header in headers)
+    length = len(body) if content_length is None else content_length
+    writer.write(
+        b'HTTP/1.1 '
+        + status
+        + b'\r\n'
+        + header_bytes
+        + b'Content-Length: '
+        + str(length).encode()
+        + b'\r\nConnection: close\r\n\r\n'
+        + body
+    )
+    await writer.drain()
+    writer.close()
+    await writer.wait_closed()
+
+
+@asynccontextmanager
+async def local_server(
+    handler: Callable[[asyncio.StreamReader, asyncio.StreamWriter], Awaitable[None]],
+    *,
+    host: str = '127.0.0.1',
+    ssl_context: ssl.SSLContext | None = None,
+) -> AsyncIterator[int]:
+    server = await asyncio.start_server(handler, host, 0, ssl=ssl_context)
+    try:
+        yield server.sockets[0].getsockname()[1]
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.fixture(scope='module')
+def tls_cert_chain(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, Path]:
+    tls_directory = tmp_path_factory.mktemp('vhost-tls')
+    certificate = tls_directory / 'certificate.pem'
+    private_key = tls_directory / 'private-key.pem'
+    subprocess.run(
+        [
+            'openssl',
+            'req',
+            '-x509',
+            '-newkey',
+            'rsa:2048',
+            '-nodes',
+            '-sha256',
+            '-days',
+            '1',
+            '-subj',
+            '/CN=example.com',
+            '-keyout',
+            str(private_key),
+            '-out',
+            str(certificate),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return certificate, private_key
+
+
+def response(
+    hostname: str,
+    *,
+    status: int = 200,
+    body: bytes = b'default page',
+    location: str | None = None,
+) -> ProbeObservation:
+    return ProbeObservation(
+        hostname=hostname,
+        http_host=hostname,
+        tls_server_name=hostname,
+        phase='body',
+        status=status,
+        location=location,
+        body=body,
+    )
+
+
+def discovery_result(
+    *,
+    observations: tuple[VirtualHostObservation, ...] = (),
+    request_count: int,
+    attempted_candidate_count: int,
+    stop_reason: str = 'completed',
+    request_error_count: int = 0,
+    request_error_types: tuple[str, ...] = (),
+    scan_error_type: str | None = None,
+) -> VirtualHostDiscoveryResult:
+    return VirtualHostDiscoveryResult(
+        context=response('192.0.2.20'),
+        controls=(),
+        observations=observations,
+        request_count=request_count,
+        attempted_candidate_count=attempted_candidate_count,
+        stop_reason=stop_reason,
+        request_error_count=request_error_count,
+        request_error_types=request_error_types,
+        scan_error_type=scan_error_type,
+    )
+
+
+def distinct_observation(endpoint: str, *, hostname: str = 'admin.example.com') -> VirtualHostObservation:
+    controls = tuple(response(f'unknown-{index}.example.com') for index in range(3))
+    return classify_virtual_host(
+        endpoint,
+        response('192.0.2.20'),
+        response(hostname, status=401),
+        controls,
+    )
+
+
+async def test_harvested_virtual_host_sweep_carries_unused_budget_forward(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    requests: list[VirtualHostRequest] = []
+
+    async def fake_discover(request: VirtualHostRequest, **_kwargs):
+        requests.append(request)
+        return discovery_result(
+            request_count=8,
+            attempted_candidate_count=len(request.candidates),
+        )
+
+    monkeypatch.setattr(virtual_host_module, 'discover_virtual_hosts', fake_discover)
+
+    with caplog.at_level(logging.INFO, logger=virtual_host_module.__name__):
+        result = await discover_harvested_virtual_hosts(
+            scope='Example.COM.',
+            addresses=('2001:db8::20', '192.0.2.20'),
+            candidates=('admin.example.com', 'panel.example.com'),
+            limits=VirtualHostLimits(request_limit=40, runtime_seconds=20),
+        )
+
+    assert [request.endpoint for request in requests] == [
+        'https://192.0.2.20:443/',
+        'https://[2001:db8::20]:443/',
+        'http://192.0.2.20:80/',
+        'http://[2001:db8::20]:80/',
+    ]
+    assert [request.limits.request_limit for request in requests] == [10, 10, 12, 16]
+    assert all(request.scope == 'example.com' for request in requests)
+    assert all(request.candidates == ('admin.example.com', 'panel.example.com') for request in requests)
+    assert result.request_count == 32
+    assert result.endpoint_count == 4
+    assert result.total_endpoint_count == 4
+    assert result.candidate_endpoint_count == 8
+    assert result.total_candidate_endpoint_count == 8
+    assert result.stop_reason == 'completed'
+    assert 'Virtual-host endpoint 1/4 started: candidates=2; request-limit=10' in caplog.text
+    assert 'Virtual-host endpoint 4/4 finished: stop=completed; requests=8; candidates=2/2; errors=0' in caplog.text
+
+
+async def test_harvested_virtual_host_sweep_reports_every_budget_truncation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[VirtualHostRequest] = []
+
+    async def fake_discover(request: VirtualHostRequest, **_kwargs):
+        requests.append(request)
+        return discovery_result(
+            request_count=5,
+            attempted_candidate_count=len(request.candidates),
+        )
+
+    monkeypatch.setattr(virtual_host_module, 'discover_virtual_hosts', fake_discover)
+
+    result = await discover_harvested_virtual_hosts(
+        scope='Example.COM.',
+        addresses=('192.0.2.20', '2001:db8::20'),
+        candidates=('a.example.com', 'preview.example.com'),
+        limits=VirtualHostLimits(request_limit=10, runtime_seconds=20),
+    )
+
+    assert [request.endpoint for request in requests] == [
+        'https://192.0.2.20:443/',
+        'https://[2001:db8::20]:443/',
+    ]
+    assert all(request.candidates == ('a.example.com',) for request in requests)
+    assert result.request_count == 10
+    assert result.endpoint_count == 2
+    assert result.total_endpoint_count == 4
+    assert result.candidate_endpoint_count == 2
+    assert result.total_candidate_endpoint_count == 8
+    assert result.stop_reason == 'request-limit'
+
+
+async def test_harvested_virtual_host_sweep_has_one_hard_runtime_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_discover(
+        request: VirtualHostRequest,
+        *,
+        _preserve_partial_on_cancel: bool = False,
+    ):
+        assert _preserve_partial_on_cancel is True
+        try:
+            await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            partial = classify_virtual_host(
+                request.endpoint,
+                response('192.0.2.20'),
+                response('admin.example.com', status=401),
+                tuple(response(f'unknown-{index}.example.com') for index in range(3)),
+            )
+            return discovery_result(
+                observations=(partial,),
+                request_count=5,
+                attempted_candidate_count=1,
+                stop_reason='runtime-limit',
+            )
+
+    monkeypatch.setattr(virtual_host_module, 'discover_virtual_hosts', fake_discover)
+    started = time.perf_counter()
+
+    result = await discover_harvested_virtual_hosts(
+        scope='example.com',
+        addresses=('192.0.2.20',),
+        candidates=('admin.example.com',),
+        limits=VirtualHostLimits(request_limit=10, runtime_seconds=0.02),
+    )
+
+    assert time.perf_counter() - started < 0.2
+    assert tuple(observation.hostname for observation in result.observations) == ('admin.example.com',)
+    assert result.request_count == 5
+    assert result.candidate_endpoint_count == 1
+    assert result.total_candidate_endpoint_count == 2
+    assert result.stop_reason == 'runtime-limit'
+
+
+async def test_harvested_virtual_host_sweep_retains_completed_endpoints_after_a_later_scan_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    call_count = 0
+
+    async def fake_discover(
+        request: VirtualHostRequest,
+        *,
+        _preserve_partial_on_cancel: bool = False,
+    ):
+        nonlocal call_count
+        assert _preserve_partial_on_cancel is True
+        call_count += 1
+        if call_count == 2:
+            raise RuntimeError('endpoint failed')
+        return discovery_result(
+            observations=(distinct_observation(request.endpoint),),
+            request_count=5,
+            attempted_candidate_count=1,
+        )
+
+    monkeypatch.setattr(virtual_host_module, 'discover_virtual_hosts', fake_discover)
+    result = await discover_harvested_virtual_hosts(
+        scope='example.com',
+        addresses=('192.0.2.20',),
+        candidates=('admin.example.com',),
+        limits=VirtualHostLimits(request_limit=10, runtime_seconds=10),
+    )
+
+    assert tuple(observation.endpoint for observation in result.observations) == ('https://192.0.2.20:443/',)
+    assert result.request_count == 5
+    assert result.candidate_endpoint_count == 1
+    assert result.stop_reason == 'scan-error'
+    assert result.scan_error_type == 'RuntimeError'
+
+
+async def test_discovery_returns_an_earlier_batch_when_a_later_probe_crashes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_probe(
+        _session: object,
+        _request: VirtualHostRequest,
+        hostname: str | None,
+    ) -> ProbeObservation:
+        if hostname == 'login.example.com':
+            raise RuntimeError('probe crashed')
+        if hostname == 'admin.example.com':
+            return response(hostname, status=401)
+        return response(hostname or '192.0.2.20')
+
+    monkeypatch.setattr(virtual_host_module, '_probe', fake_probe)
+
+    result = await discover_virtual_hosts(
+        VirtualHostRequest(
+            endpoint='http://192.0.2.20/',
+            scope='example.com',
+            candidates=('admin.example.com', 'login.example.com'),
+            limits=VirtualHostLimits(concurrency=1),
+        )
+    )
+
+    assert tuple(observation.hostname for observation in result.observations) == ('admin.example.com',)
+    assert result.observations[0].classification == 'distinct'
+    assert result.request_count == 6
+    assert result.attempted_candidate_count == 1
+    assert result.stop_reason == 'scan-error'
+    assert result.scan_error_type == 'RuntimeError'
+
+
+async def test_harvested_virtual_host_sweep_keeps_same_endpoint_evidence_after_a_scan_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    async def fake_discover(request: VirtualHostRequest, **_kwargs: object) -> VirtualHostDiscoveryResult:
+        calls.append(request.endpoint)
+        return discovery_result(
+            observations=(distinct_observation(request.endpoint),),
+            request_count=6,
+            attempted_candidate_count=1,
+            stop_reason='scan-error',
+            scan_error_type='RuntimeError',
+        )
+
+    monkeypatch.setattr(virtual_host_module, 'discover_virtual_hosts', fake_discover)
+
+    result = await discover_harvested_virtual_hosts(
+        scope='example.com',
+        addresses=('192.0.2.20',),
+        candidates=('admin.example.com', 'portal.example.com'),
+        limits=VirtualHostLimits(request_limit=20, runtime_seconds=10),
+    )
+
+    assert calls == ['https://192.0.2.20:443/']
+    assert tuple(observation.hostname for observation in result.observations) == ('admin.example.com',)
+    assert result.request_count == 6
+    assert result.candidate_endpoint_count == 1
+    assert result.stop_reason == 'scan-error'
+    assert result.scan_error_type == 'RuntimeError'
+
+
+async def test_harvested_virtual_host_sweep_cancellation_carries_partial_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    second_endpoint_started = asyncio.Event()
+    call_count = 0
+
+    async def fake_discover(
+        request: VirtualHostRequest,
+        *,
+        _preserve_partial_on_cancel: bool = False,
+    ):
+        nonlocal call_count
+        assert _preserve_partial_on_cancel is True
+        call_count += 1
+        if call_count == 1:
+            return discovery_result(
+                observations=(distinct_observation(request.endpoint),),
+                request_count=5,
+                attempted_candidate_count=1,
+            )
+        second_endpoint_started.set()
+        try:
+            await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            return discovery_result(
+                observations=(distinct_observation(request.endpoint),),
+                request_count=5,
+                attempted_candidate_count=1,
+                stop_reason='runtime-limit',
+            )
+
+    monkeypatch.setattr(virtual_host_module, 'discover_virtual_hosts', fake_discover)
+    task = asyncio.create_task(
+        discover_harvested_virtual_hosts(
+            scope='example.com',
+            addresses=('192.0.2.20',),
+            candidates=('admin.example.com',),
+            limits=VirtualHostLimits(request_limit=10, runtime_seconds=10),
+        )
+    )
+    await second_endpoint_started.wait()
+    task.cancel()
+
+    with pytest.raises(VirtualHostDiscoveryCancelled) as cancelled:
+        await task
+
+    result = cancelled.value.result
+    assert tuple(observation.endpoint for observation in result.observations) == (
+        'https://192.0.2.20:443/',
+        'http://192.0.2.20:80/',
+    )
+    assert result.request_count == 10
+    assert result.candidate_endpoint_count == 2
+    assert result.stop_reason == 'cancelled'
+    assert result.scan_error_type == 'CancelledError'
+
+
+async def test_harvested_virtual_host_sweep_propagates_cancellation_during_deadline_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deadline_cancelled = asyncio.Event()
+
+    async def fake_discover(
+        _request: VirtualHostRequest,
+        *,
+        _preserve_partial_on_cancel: bool = False,
+    ):
+        assert _preserve_partial_on_cancel is True
+        try:
+            await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            deadline_cancelled.set()
+            try:
+                await asyncio.sleep(1)
+            except asyncio.CancelledError:
+                return discovery_result(
+                    request_count=1,
+                    attempted_candidate_count=0,
+                    stop_reason='runtime-limit',
+                )
+
+    monkeypatch.setattr(virtual_host_module, 'discover_virtual_hosts', fake_discover)
+    task = asyncio.create_task(
+        discover_harvested_virtual_hosts(
+            scope='example.com',
+            addresses=('192.0.2.20',),
+            candidates=('admin.example.com',),
+            limits=VirtualHostLimits(request_limit=10, runtime_seconds=0.02),
+        )
+    )
+    await deadline_cancelled.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+def test_classifier_marks_a_candidate_matching_stable_controls_as_default() -> None:
+    controls = tuple(response(f'unknown-{index}.example.com') for index in range(3))
+
+    observation = classify_virtual_host(
+        'https://192.0.2.10:443/',
+        response('192.0.2.10'),
+        response('admin.example.com'),
+        controls,
+    )
+
+    assert observation.classification == 'default'
+    assert observation.distinct_signals == ()
+
+
+def test_classifier_marks_a_candidate_matching_the_raw_ip_context_as_default() -> None:
+    controls = tuple(response(f'unknown-{index}.example.com') for index in range(3))
+
+    observation = classify_virtual_host(
+        'https://192.0.2.10:443/',
+        response('192.0.2.10', status=401, body=b'raw endpoint'),
+        response('admin.example.com', status=401, body=b'raw endpoint'),
+        controls,
+    )
+
+    assert observation.classification == 'default'
+    assert observation.distinct_signals == ()
+
+
+def test_classifier_keeps_a_candidate_indeterminate_when_the_raw_ip_context_fails() -> None:
+    context = ProbeObservation(
+        hostname='192.0.2.10',
+        http_host='192.0.2.10',
+        tls_server_name=None,
+        phase='connect',
+        error_type='TimeoutError',
+    )
+    controls = tuple(response(f'unknown-{index}.example.com') for index in range(3))
+
+    observation = classify_virtual_host(
+        'https://192.0.2.10:443/',
+        context,
+        response('admin.example.com', status=401),
+        controls,
+    )
+
+    assert observation.classification == 'indeterminate'
+    assert observation.distinct_signals == ()
+
+
+def test_classifier_marks_a_stable_status_difference_as_distinct() -> None:
+    controls = tuple(response(f'unknown-{index}.example.com') for index in range(3))
+
+    observation = classify_virtual_host(
+        'https://192.0.2.10:443/',
+        response('192.0.2.10'),
+        response('admin.example.com', status=401),
+        controls,
+    )
+
+    assert observation.classification == 'distinct'
+    assert observation.distinct_signals == ('status',)
+    assert observation.control_phase == 'body'
+    assert observation.control_status == 200
+    assert observation.control_location is None
+    assert observation.control_body_sha256 == 'de9adea2908417ad2b86d8812b598c24c80c3faf4b0bfa304c5530f391805894'
+    assert observation.control_body_size == 12
+    assert observation.control_body_truncated is False
+
+
+def test_classifier_ignores_exact_candidate_reflection() -> None:
+    controls = tuple(
+        response(
+            hostname,
+            body=f'unknown host: {hostname}'.encode(),
+            location=f'https://errors.example.test/?host={hostname}',
+        )
+        for hostname in (f'unknown-{index}.example.com' for index in range(3))
+    )
+    candidate = response(
+        'admin.example.com',
+        body=b'unknown host: admin.example.com',
+        location='https://errors.example.test/?host=admin.example.com',
+    )
+
+    observation = classify_virtual_host(
+        'https://192.0.2.10:443/',
+        response('192.0.2.10'),
+        candidate,
+        controls,
+    )
+
+    assert observation.classification == 'default'
+    assert observation.reflection_normalized is True
+
+
+def test_classifier_does_not_normalize_an_authority_inside_a_larger_hostname() -> None:
+    controls = tuple(
+        response(hostname, body=f'unknown host: not{hostname}'.encode())
+        for hostname in (f'unknown-{index}.example.com' for index in range(3))
+    )
+
+    observation = classify_virtual_host(
+        'https://192.0.2.10:443/',
+        response('192.0.2.10'),
+        response('admin.example.com', body=b'unknown host: notadmin.example.com'),
+        controls,
+    )
+
+    assert observation.classification == 'indeterminate'
+    assert observation.reflection_normalized is False
+
+
+def test_classifier_keeps_inconsistent_controls_indeterminate() -> None:
+    controls = (
+        response('unknown-0.example.com', body=b'first default'),
+        response('unknown-1.example.com', body=b'second default'),
+        response('unknown-2.example.com', body=b'third default'),
+    )
+
+    observation = classify_virtual_host(
+        'https://192.0.2.10:443/',
+        response('192.0.2.10'),
+        response('admin.example.com', status=401, body=b'candidate'),
+        controls,
+    )
+
+    assert observation.classification == 'indeterminate'
+
+
+def test_classifier_keeps_a_candidate_indeterminate_when_all_controls_fail() -> None:
+    controls = tuple(
+        ProbeObservation(
+            hostname=f'unknown-{index}.example.com',
+            http_host=f'unknown-{index}.example.com',
+            tls_server_name=f'unknown-{index}.example.com',
+            phase='connect',
+            error_type='TimeoutError',
+        )
+        for index in range(3)
+    )
+
+    observation = classify_virtual_host(
+        'https://192.0.2.10:443/',
+        response('192.0.2.10'),
+        response('admin.example.com', status=401),
+        controls,
+    )
+
+    assert observation.classification == 'indeterminate'
+    assert observation.distinct_signals == ()
+
+
+def test_classifier_keeps_an_ambiguous_candidate_failure_indeterminate() -> None:
+    controls = tuple(response(f'unknown-{index}.example.com') for index in range(3))
+    candidate = ProbeObservation(
+        hostname='admin.example.com',
+        http_host='admin.example.com',
+        tls_server_name='admin.example.com',
+        phase='connect',
+        error_type='TimeoutError',
+    )
+
+    observation = classify_virtual_host(
+        'https://192.0.2.10:443/',
+        response('192.0.2.10'),
+        candidate,
+        controls,
+    )
+
+    assert observation.classification == 'indeterminate'
+
+
+def test_classifier_requires_confirmation_for_a_body_only_difference() -> None:
+    controls = tuple(response(f'unknown-{index}.example.com') for index in range(3))
+
+    observation = classify_virtual_host(
+        'https://192.0.2.10:443/',
+        response('192.0.2.10'),
+        response('admin.example.com', body=b'private page'),
+        controls,
+    )
+
+    assert observation.classification == 'indeterminate'
+    assert observation.distinct_signals == ('body_sha256',)
+    assert observation.needs_confirmation is True
+
+
+def test_classifier_accepts_a_repeatable_body_only_difference() -> None:
+    controls = tuple(response(f'unknown-{index}.example.com') for index in range(3))
+    candidate = response('admin.example.com', body=b'private page')
+
+    observation = classify_virtual_host(
+        'https://192.0.2.10:443/',
+        response('192.0.2.10'),
+        candidate,
+        controls,
+        confirmation=candidate,
+    )
+
+    assert observation.classification == 'distinct'
+    assert observation.distinct_signals == ('body_sha256',)
+    assert observation.needs_confirmation is False
+
+
+def test_classifier_keeps_a_truncated_body_comparison_indeterminate() -> None:
+    controls = tuple(response(f'unknown-{index}.example.com') for index in range(3))
+    candidate = ProbeObservation(
+        hostname='admin.example.com',
+        http_host='admin.example.com',
+        tls_server_name='admin.example.com',
+        phase='body',
+        status=200,
+        body=b'default page',
+        body_truncated=True,
+    )
+
+    observation = classify_virtual_host(
+        'https://192.0.2.10:443/',
+        response('192.0.2.10'),
+        candidate,
+        controls,
+    )
+
+    assert observation.classification == 'indeterminate'
+    assert observation.body_truncated is True
+
+
+def test_direct_request_construction_enforces_scope_and_literal_ip() -> None:
+    with pytest.raises(ValueError, match='literal IP'):
+        VirtualHostRequest(
+            endpoint='https://edge.example.com/',
+            scope='example.com',
+            candidates=('admin.example.com',),
+        )
+    with pytest.raises(ValueError, match='outside authorized scope'):
+        VirtualHostRequest(
+            endpoint='https://192.0.2.10/',
+            scope='example.com',
+            candidates=('admin.attacker.test',),
+        )
+
+
+def test_request_rejects_explicit_port_zero() -> None:
+    with pytest.raises(ValueError, match='port must be between 1 and 65535'):
+        VirtualHostRequest(
+            endpoint='http://192.0.2.10:0/',
+            scope='example.com',
+            candidates=('admin.example.com',),
+        )
+
+
+def test_request_accepts_the_authorized_scope_apex_for_conservative_classification() -> None:
+    request = VirtualHostRequest(
+        endpoint='http://192.0.2.10/',
+        scope='example.com',
+        candidates=('example.com',),
+    )
+
+    assert request.candidates == ('example.com',)
+
+
+def test_request_rejects_a_shape_without_three_available_unknown_controls() -> None:
+    alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789'
+
+    with pytest.raises(ValueError, match='fewer than three available unknown controls'):
+        VirtualHostRequest(
+            endpoint='http://192.0.2.10/',
+            scope='example.com',
+            candidates=tuple(f'{character}.example.com' for character in alphabet[:-2]),
+        )
+
+
+@pytest.mark.parametrize('invalid_value', [math.inf, math.nan])
+def test_limits_reject_non_finite_time_bounds(invalid_value: float) -> None:
+    with pytest.raises(ValueError, match='runtime seconds must be positive and finite'):
+        VirtualHostLimits(runtime_seconds=invalid_value)
+    with pytest.raises(ValueError, match='timeout seconds must be positive and finite'):
+        VirtualHostLimits(timeout_seconds=invalid_value)
+
+
+@pytest.mark.parametrize(
+    ('field', 'invalid_value'),
+    [('request_limit', math.inf), ('request_limit', True), ('concurrency', math.inf), ('concurrency', True)],
+)
+def test_limits_require_finite_integer_counts(field: str, invalid_value: float) -> None:
+    with pytest.raises(ValueError, match='must be an integer'):
+        VirtualHostLimits(**{field: invalid_value})  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_discovery_connects_to_the_literal_ip_and_sends_the_candidate_host() -> None:
+    seen_hosts: list[str] = []
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        host = await read_host(reader)
+        seen_hosts.append(host)
+        status = b'401 Unauthorized' if host == f'admin.example.com:{port}' else b'200 OK'
+        await write_response(writer, status=status)
+
+    async with local_server(handle) as port:
+        request = VirtualHostRequest(
+            endpoint=f'http://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=('admin.example.com',),
+        )
+        result = await discover_virtual_hosts(request)
+
+    assert result.request_count == 5
+    assert seen_hosts[0] == f'127.0.0.1:{port}'
+    assert f'admin.example.com:{port}' in seen_hosts
+    assert result.context.tls_verified is None
+    assert result.observations[0].tls_verified is None
+    assert result.observations[0].classification == 'distinct'
+
+
+@pytest.mark.asyncio
+async def test_discovery_keeps_the_authorized_scope_apex_indeterminate() -> None:
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        host = await read_host(reader)
+        status = b'401 Unauthorized' if host.startswith('example.com:') else b'200 OK'
+        await write_response(writer, status=status)
+
+    async with local_server(handle) as port:
+        request = VirtualHostRequest(
+            endpoint=f'http://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=('example.com',),
+        )
+        result = await discover_virtual_hosts(request)
+
+    assert result.observations[0].status == 401
+    assert result.observations[0].classification == 'indeterminate'
+    assert result.observations[0].distinct_signals == ()
+
+
+@pytest.mark.asyncio
+async def test_discovery_records_the_ipv6_context_authority_exactly() -> None:
+    seen_hosts: list[str] = []
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        host = await read_host(reader)
+        seen_hosts.append(host)
+        status = b'401 Unauthorized' if host.startswith('admin.') else b'200 OK'
+        await write_response(writer, status=status)
+
+    try:
+        async with local_server(handle, host='::1') as port:
+            request = VirtualHostRequest(
+                endpoint=f'http://[::1]:{port}/',
+                scope='example.com',
+                candidates=('admin.example.com',),
+            )
+            result = await discover_virtual_hosts(request)
+    except OSError:
+        pytest.skip('IPv6 loopback is unavailable')
+
+    assert seen_hosts[0] == f'[::1]:{port}'
+    assert result.context.http_host == seen_hosts[0]
+    assert result.observations[0].classification == 'distinct'
+
+
+@pytest.mark.asyncio
+async def test_discovery_charges_body_confirmation_to_the_hard_request_budget() -> None:
+    request_count = 0
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        nonlocal request_count
+        host = await read_host(reader)
+        request_count += 1
+        body = b'private page' if host.startswith('one.') or host.startswith('two.') else b'default page'
+        await write_response(writer, body=body)
+
+    async with local_server(handle) as port:
+        request = VirtualHostRequest(
+            endpoint=f'http://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=('one.example.com', 'two.example.com'),
+            limits=VirtualHostLimits(request_limit=6),
+        )
+        result = await discover_virtual_hosts(request)
+
+    assert request_count == result.request_count == 6
+    assert len(result.observations) == 1
+    assert result.observations[0].classification == 'distinct'
+    assert result.stop_reason == 'request-limit'
+
+
+@pytest.mark.asyncio
+async def test_discovery_reports_the_budget_stop_when_confirmation_cannot_run() -> None:
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        host = await read_host(reader)
+        body = b'private page' if host.startswith('admin.') else b'default page'
+        await write_response(writer, body=body)
+
+    async with local_server(handle) as port:
+        request = VirtualHostRequest(
+            endpoint=f'http://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=('admin.example.com',),
+            limits=VirtualHostLimits(request_limit=5),
+        )
+        result = await discover_virtual_hosts(request)
+
+    assert result.request_count == 5
+    assert result.observations[0].needs_confirmation is True
+    assert result.stop_reason == 'request-limit'
+
+
+@pytest.mark.asyncio
+async def test_discovery_respects_the_candidate_concurrency_limit() -> None:
+    active_candidates = 0
+    maximum_active_candidates = 0
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        nonlocal active_candidates, maximum_active_candidates
+        host = await read_host(reader)
+        is_candidate = host.startswith('candidate-')
+        if is_candidate:
+            active_candidates += 1
+            maximum_active_candidates = max(maximum_active_candidates, active_candidates)
+            await asyncio.sleep(0.02)
+            active_candidates -= 1
+        status = b'401 Unauthorized' if is_candidate else b'200 OK'
+        await write_response(writer, status=status)
+
+    async with local_server(handle) as port:
+        request = VirtualHostRequest(
+            endpoint=f'http://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=tuple(f'candidate-{index}.example.com' for index in range(4)),
+            limits=VirtualHostLimits(concurrency=2),
+        )
+        result = await discover_virtual_hosts(request)
+
+    assert maximum_active_candidates == 2
+    assert len(result.observations) == 4
+
+
+@pytest.mark.asyncio
+async def test_discovery_stops_at_the_shared_runtime_limit() -> None:
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        host = await read_host(reader)
+        if host.startswith('slow.'):
+            await asyncio.sleep(0.2)
+        await write_response(writer)
+
+    async with local_server(handle) as port:
+        request = VirtualHostRequest(
+            endpoint=f'http://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=('slow.example.com',),
+            limits=VirtualHostLimits(runtime_seconds=0.05, timeout_seconds=1),
+        )
+        started = time.monotonic()
+        result = await discover_virtual_hosts(request)
+        elapsed = time.monotonic() - started
+
+    assert elapsed < 0.15
+    assert result.request_count == 5
+    assert result.observations == ()
+    assert result.stop_reason == 'runtime-limit'
+
+
+@pytest.mark.asyncio
+async def test_discovery_retains_controls_completed_before_the_runtime_limit() -> None:
+    request_count = 0
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        nonlocal request_count
+        await read_host(reader)
+        request_count += 1
+        if request_count == 3:
+            await asyncio.sleep(0.2)
+        await write_response(writer)
+
+    async with local_server(handle) as port:
+        request = VirtualHostRequest(
+            endpoint=f'http://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=('admin.example.com',),
+            limits=VirtualHostLimits(runtime_seconds=0.05, timeout_seconds=1),
+        )
+        result = await discover_virtual_hosts(request)
+
+    assert result.request_count == 3
+    assert len(result.controls) == 1
+    assert result.stop_reason == 'runtime-limit'
+
+
+@pytest.mark.asyncio
+async def test_discovery_retains_completed_evidence_at_the_runtime_limit() -> None:
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        host = await read_host(reader)
+        if host.startswith('slow.'):
+            await asyncio.sleep(1)
+        status = b'401 Unauthorized' if host.startswith('fast.') else b'200 OK'
+        await write_response(writer, status=status)
+
+    async with local_server(handle) as port:
+        request = VirtualHostRequest(
+            endpoint=f'http://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=('fast.example.com', 'slow.example.com'),
+            limits=VirtualHostLimits(runtime_seconds=0.5, timeout_seconds=2, concurrency=1),
+        )
+        result = await discover_virtual_hosts(request)
+
+    assert tuple(observation.hostname for observation in result.observations) == ('fast.example.com',)
+    assert result.attempted_candidate_count == 1
+    assert result.observations[0].classification == 'distinct'
+    assert result.stop_reason == 'runtime-limit'
+
+
+@pytest.mark.asyncio
+async def test_discovery_retains_a_completed_probe_from_a_timed_out_concurrent_batch() -> None:
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        host = await read_host(reader)
+        if host.startswith('slow.'):
+            await asyncio.sleep(1)
+        status = b'401 Unauthorized' if host.startswith('fast.') else b'200 OK'
+        await write_response(writer, status=status)
+
+    async with local_server(handle) as port:
+        request = VirtualHostRequest(
+            endpoint=f'http://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=('fast.example.com', 'slow.example.com'),
+            limits=VirtualHostLimits(runtime_seconds=0.5, timeout_seconds=2, concurrency=2),
+        )
+        result = await discover_virtual_hosts(request)
+
+    assert tuple(observation.hostname for observation in result.observations) == ('fast.example.com',)
+    assert result.attempted_candidate_count == 1
+    assert result.observations[0].classification == 'distinct'
+    assert result.stop_reason == 'runtime-limit'
+
+
+@pytest.mark.asyncio
+async def test_discovery_uses_controls_matching_each_candidate_name_shape() -> None:
+    seen_hosts: list[str] = []
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        host = (await read_host(reader)).split(':', 1)[0]
+        seen_hosts.append(host)
+        relative_depth = len(host.removesuffix('.example.com').rstrip('.').split('.'))
+        status = b'404 Not Found' if relative_depth == 2 else b'200 OK'
+        await write_response(writer, status=status)
+
+    async with local_server(handle) as port:
+        request = VirtualHostRequest(
+            endpoint=f'http://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=('admin.example.com', 'admin.dev.example.com'),
+        )
+        result = await discover_virtual_hosts(request)
+
+    control_depths = {len(control.hostname.removesuffix('.example.com').rstrip('.').split('.')) for control in result.controls}
+    assert control_depths == {1, 2}
+    assert len(result.controls) == 6
+    assert tuple(observation.classification for observation in result.observations) == ('default', 'default')
+    assert set(request.candidates) <= set(seen_hosts)
+
+
+@pytest.mark.asyncio
+async def test_discovery_records_a_per_request_timeout_as_bounded_evidence() -> None:
+    request_count = 0
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        nonlocal request_count
+        await read_host(reader)
+        request_count += 1
+        if request_count == 2:
+            await asyncio.sleep(0.1)
+        await write_response(writer)
+
+    async with local_server(handle) as port:
+        request = VirtualHostRequest(
+            endpoint=f'http://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=('admin.example.com',),
+            limits=VirtualHostLimits(runtime_seconds=1, timeout_seconds=0.02),
+        )
+        result = await discover_virtual_hosts(request)
+
+    assert request_count == result.request_count == 5
+    assert result.controls[0].error_type == 'TimeoutError'
+    assert result.observations[0].classification == 'indeterminate'
+    assert result.request_error_count == 1
+    assert result.request_error_types == ('TimeoutError',)
+    assert result.stop_reason == 'request-errors'
+
+
+@pytest.mark.asyncio
+async def test_discovery_preserves_headers_when_the_body_read_fails() -> None:
+    request_count = 0
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        nonlocal request_count
+        await read_host(reader)
+        request_count += 1
+        if request_count == 5:
+            await write_response(writer, body=b'short', content_length=20)
+        else:
+            await write_response(writer)
+
+    async with local_server(handle) as port:
+        request = VirtualHostRequest(
+            endpoint=f'http://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=('admin.example.com',),
+        )
+        result = await discover_virtual_hosts(request)
+
+    observation = result.observations[0]
+    assert observation.phase == 'headers'
+    assert observation.status == 200
+    assert observation.error_type == 'ClientPayloadError'
+    assert observation.classification == 'indeterminate'
+
+
+@pytest.mark.asyncio
+async def test_discovery_caps_large_bodies_and_keeps_them_indeterminate() -> None:
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        host = await read_host(reader)
+        body = b'x' * (VHOST_BODY_LIMIT + 100) if host.startswith('admin.') else b'default page'
+        await write_response(writer, body=body)
+
+    async with local_server(handle) as port:
+        request = VirtualHostRequest(
+            endpoint=f'http://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=('admin.example.com',),
+        )
+        result = await discover_virtual_hosts(request)
+
+    observation = result.observations[0]
+    assert observation.body_size == VHOST_BODY_LIMIT
+    assert observation.body_truncated is True
+    assert observation.classification == 'indeterminate'
+
+
+@pytest.mark.asyncio
+async def test_discovery_preserves_cancellation_and_closes_the_connection() -> None:
+    accepted = asyncio.Event()
+    connection_closed = asyncio.Event()
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        await reader.readuntil(b'\r\n\r\n')
+        accepted.set()
+        await reader.read()
+        connection_closed.set()
+        writer.close()
+        await writer.wait_closed()
+
+    async with local_server(handle) as port:
+        request = VirtualHostRequest(
+            endpoint=f'http://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=('admin.example.com',),
+        )
+        task = asyncio.create_task(discover_virtual_hosts(request))
+        await asyncio.wait_for(accepted.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await asyncio.wait_for(connection_closed.wait(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_discovery_records_redirects_without_following_them() -> None:
+    paths: list[str] = []
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        request = await reader.readuntil(b'\r\n\r\n')
+        request_line = request.split(b'\r\n', 1)[0].decode()
+        paths.append(request_line.split()[1])
+        host_line = next(line for line in request.split(b'\r\n') if line.lower().startswith(b'host:'))
+        host = host_line.split(b':', 1)[1].strip().decode()
+        if host.startswith('admin.'):
+            await write_response(writer, status=b'302 Found', body=b'', headers=(b'Location: /followed',))
+        else:
+            await write_response(writer)
+
+    async with local_server(handle) as port:
+        request = VirtualHostRequest(
+            endpoint=f'http://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=('admin.example.com',),
+        )
+        result = await discover_virtual_hosts(request)
+
+    assert paths == ['/'] * 5
+    assert result.observations[0].status == 302
+    assert result.observations[0].location == '/followed'
+
+
+@pytest.mark.asyncio
+async def test_https_discovery_does_not_retry_with_verification_disabled(
+    tls_cert_chain: tuple[Path, Path],
+) -> None:
+    server_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    server_context.load_cert_chain(*tls_cert_chain)
+    received_requests = 0
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        nonlocal received_requests
+        await read_host(reader)
+        received_requests += 1
+        writer.close()
+        await writer.wait_closed()
+
+    async with local_server(handle, ssl_context=server_context) as port:
+        request = VirtualHostRequest(
+            endpoint=f'https://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=('admin.example.com',),
+        )
+        result = await discover_virtual_hosts(request)
+
+    assert received_requests == 0
+    assert result.request_count == 5
+    assert result.context.phase == 'tls'
+    assert all(control.phase == 'tls' for control in result.controls)
+    assert result.observations[0].phase == 'tls'
+    assert result.observations[0].tls_verified is True
+    assert result.observations[0].classification == 'indeterminate'
+
+
+@pytest.mark.asyncio
+async def test_https_discovery_aligns_each_candidate_sni_and_host(
+    tls_cert_chain: tuple[Path, Path],
+) -> None:
+    server_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    server_context.load_cert_chain(*tls_cert_chain)
+    server_names: dict[int, str | None] = {}
+    received: list[tuple[str, str | None]] = []
+
+    def record_server_name(ssl_object: ssl.SSLObject, server_name: str | None, _context: ssl.SSLContext) -> None:
+        server_names[id(ssl_object)] = server_name
+
+    server_context.sni_callback = record_server_name
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        host = await read_host(reader)
+        ssl_object = writer.get_extra_info('ssl_object')
+        received.append((host, server_names[id(ssl_object)]))
+        status = b'401 Unauthorized' if host.startswith('admin.') or host.startswith('portal.') else b'200 OK'
+        await write_response(writer, status=status)
+
+    async with local_server(handle, ssl_context=server_context) as port:
+        request = VirtualHostRequest(
+            endpoint=f'https://127.0.0.1:{port}/',
+            scope='example.com',
+            candidates=('admin.example.com', 'portal.example.com'),
+            insecure=True,
+        )
+        result = await discover_virtual_hosts(request)
+
+    candidate_pairs = [(host, sni) for host, sni in received if host.startswith(('admin.', 'portal.'))]
+    assert candidate_pairs == [
+        (f'admin.example.com:{port}', 'admin.example.com'),
+        (f'portal.example.com:{port}', 'portal.example.com'),
+    ]
+    assert all(observation.tls_verified is False for observation in result.observations)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import logging
 import os
 import subprocess
@@ -135,12 +136,34 @@ except SystemExit:
     environment = {**os.environ, 'HOME': str(tmp_path)}
 
     normal = subprocess.run(command, capture_output=True, text=True, env=environment)
+    short_verbose = subprocess.run([*command, '-v'], capture_output=True, text=True, env=environment)
     verbose = subprocess.run([*command, '--verbose'], capture_output=True, text=True, env=environment)
 
-    assert normal.returncode == verbose.returncode == 1
+    assert normal.returncode == short_verbose.returncode == verbose.returncode == 1
     assert 'INFO theHarvester.__main__: Verbose logging enabled' not in normal.stderr
+    assert 'INFO theHarvester.__main__: Verbose logging enabled' in short_verbose.stderr
     assert 'INFO theHarvester.__main__: Verbose logging enabled' in verbose.stderr
     assert 'third-party info' not in verbose.stderr
+
+
+def test_operator_output_flushes_the_current_stdout(monkeypatch) -> None:
+    from theHarvester.lib.output import configure_logging, output_logger
+
+    class RecordingStdout(io.StringIO):
+        flushed = False
+
+        def flush(self) -> None:
+            self.flushed = True
+            super().flush()
+
+    stream = RecordingStdout()
+    monkeypatch.setattr(sys, 'stdout', stream)
+    configure_logging(verbose=False)
+
+    output_logger.info('operator progress')
+
+    assert stream.getvalue() == 'operator progress\n'
+    assert stream.flushed is True
 
 
 def test_cli_preserves_host_logging_unless_verbose_is_requested(tmp_path: Path) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,11 @@ from theHarvester.lib.dns_consensus import Addressability
 from theHarvester.lib.enumeration import EnumerationOptions
 from theHarvester.lib.hostchecker import HostDnsRecords
 from theHarvester.lib.recursive_dns import RecursiveDNSClassification, RecursiveDNSFinding, RecursiveDNSResult
+from theHarvester.lib.virtual_host import (
+    HarvestedVirtualHostResult,
+    VirtualHostDiscoveryCancelled,
+    VirtualHostObservation,
+)
 
 
 @pytest.mark.asyncio
@@ -35,6 +40,462 @@ async def test_cli_help_explains_proxy_and_direct_action_scope(
     assert 'Multiple capabilities select the union of matching sources; they do not filter returned fields.' in help_text
     assert 'Check common API paths with GET, HEAD, and OPTIONS.' in help_text
     assert 'Requests follow redirects.' in help_text
+    assert 'virtual host discovery' in help_text
+    assert 'P2 direct interaction (active reconnaissance): sends direct HTTP and TLS requests.' in help_text
+    assert 'For normal use, pass only --vhost; bounded safety defaults apply automatically.' in help_text
+    assert 'virtual host advanced controls' in help_text
+    assert 'Candidate names are never resolved through DNS.' in help_text
+
+
+def _confirmed_vhost(endpoint: str = 'http://192.0.2.10:80/') -> VirtualHostObservation:
+    return VirtualHostObservation(
+        endpoint=endpoint,
+        hostname='admin.example.com',
+        http_host='admin.example.com',
+        tls_server_name=None,
+        classification='distinct',
+        phase='body',
+        status=200,
+        location=None,
+        body_sha256='a' * 64,
+        body_size=5,
+        body_truncated=False,
+        tls_verified=None,
+        error_type=None,
+        distinct_signals=('body_sha256',),
+        reflection_normalized=False,
+        needs_confirmation=False,
+        context_phase='body',
+        context_status=200,
+        context_location=None,
+        context_body_sha256='b' * 64,
+        context_body_size=5,
+        context_body_truncated=False,
+        control_phase='body',
+        control_status=200,
+        control_location=None,
+        control_body_sha256='b' * 64,
+        control_body_size=5,
+        control_body_truncated=False,
+        confirmation_body_sha256='a' * 64,
+    )
+
+
+@pytest.mark.asyncio
+async def test_virtual_host_action_reaches_completed_evidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    async def fake_discover(**kwargs: object) -> HarvestedVirtualHostResult:
+        calls.append(kwargs)
+        return HarvestedVirtualHostResult((_confirmed_vhost(),), 5, 1, 1, 1, 1, 'completed')
+
+    monkeypatch.setattr(theharvester_main, 'ResultStore', _NoopResultStore)
+    monkeypatch.setattr(theharvester_main, 'discover_harvested_virtual_hosts', fake_discover, raising=False)
+
+    response = await theharvester_main.start(
+        EnumerationOptions(
+            domain='example.com',
+            quiet=True,
+            vhost_endpoint='http://192.0.2.10/',
+            vhost_candidates=('admin.example.com',),
+        ),
+        return_completed_result=True,
+    )
+
+    completed = response[-1]
+    assert isinstance(completed, CompletedResult)
+    assert calls[0]['scope'] == 'example.com'
+    assert calls[0]['addresses'] == ()
+    assert calls[0]['candidates'] == ('admin.example.com',)
+    assert calls[0]['endpoint_override'] == 'http://192.0.2.10:80/'
+    execution = next(item for item in completed.active_evidence.executions if item.action == 'vhost')
+    assert execution.status == 'completed'
+    assert {(item.kind, item.value) for item in execution.observations} == {('hostname', 'admin.example.com')}
+    assert completed.virtual_hosts == (_confirmed_vhost(),)
+
+
+@pytest.mark.asyncio
+async def test_virtual_host_inputs_fail_before_result_store_initialization(monkeypatch: pytest.MonkeyPatch) -> None:
+    class UnexpectedResultStore:
+        def __init__(self, *_args: object) -> None:
+            raise AssertionError('result store initialization must follow virtual-host validation')
+
+    monkeypatch.setattr(theharvester_main, 'ResultStore', UnexpectedResultStore)
+
+    with pytest.raises(ValueError, match='outside authorized scope'):
+        await theharvester_main.start(
+            EnumerationOptions(
+                domain='example.com',
+                vhost_endpoint='https://192.0.2.10/',
+                vhost_candidates=('admin.attacker.test',),
+            )
+        )
+
+    with pytest.raises(ValueError, match='direct transport only'):
+        await theharvester_main.start(
+            EnumerationOptions(
+                domain='example.com',
+                proxies=True,
+                vhost_endpoint='https://192.0.2.10/',
+                vhost_candidates=('admin.example.com',),
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_virtual_host_action_uses_harvested_hostnames_and_ips(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    class FakeRapidDNS:
+        def __init__(self, _word: str) -> None:
+            pass
+
+        async def process(self, _proxy: bool) -> None:
+            return None
+
+        async def get_hostnames(self) -> set[str]:
+            return {'admin.example.com'}
+
+        async def get_host_ip_pairs(self) -> set[tuple[str, str]]:
+            return {('admin.example.com', '192.0.2.10')}
+
+        async def get_ips(self) -> set[str]:
+            return {'192.0.2.10'}
+
+    async def fake_discover(**kwargs: object) -> HarvestedVirtualHostResult:
+        calls.append(kwargs)
+        return HarvestedVirtualHostResult((), 5, 1, 1, 1, 1, 'completed')
+
+    monkeypatch.setattr(theharvester_main, 'ResultStore', _NoopResultStore)
+    monkeypatch.setattr(theharvester_main.rapiddns, 'SearchRapidDns', FakeRapidDNS)
+    monkeypatch.setattr(theharvester_main, 'discover_harvested_virtual_hosts', fake_discover)
+
+    response = await theharvester_main.start(
+        EnumerationOptions(domain='example.com', quiet=True, source='rapiddns', vhost=True),
+        return_completed_result=True,
+    )
+
+    assert calls[0]['addresses'] == ('192.0.2.10',)
+    assert calls[0]['candidates'] == ('admin.example.com',)
+    execution = next(item for item in response[-1].active_evidence.executions if item.action == 'vhost')
+    assert execution.status == 'completed'
+    assert execution.result_count == 0
+
+
+@pytest.mark.asyncio
+async def test_virtual_host_action_explains_missing_harvested_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(theharvester_main, 'ResultStore', _NoopResultStore)
+
+    response = await theharvester_main.start(
+        EnumerationOptions(domain='example.com', quiet=True, vhost_candidates=('admin.example.com',)),
+        return_completed_result=True,
+    )
+
+    execution = next(item for item in response[-1].active_evidence.executions if item.action == 'vhost')
+    assert execution.status == 'skipped'
+    assert execution.stop_reason == 'no-endpoints'
+
+
+@pytest.mark.asyncio
+async def test_virtual_host_action_reports_all_request_errors_as_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def failed_discovery(**_kwargs: object) -> HarvestedVirtualHostResult:
+        return HarvestedVirtualHostResult(
+            observations=(),
+            request_count=5,
+            endpoint_count=1,
+            total_endpoint_count=1,
+            candidate_endpoint_count=1,
+            total_candidate_endpoint_count=1,
+            stop_reason='request-errors',
+            request_error_count=5,
+            request_error_types=('TimeoutError',),
+        )
+
+    monkeypatch.setattr(theharvester_main, 'ResultStore', _NoopResultStore)
+    monkeypatch.setattr(theharvester_main, 'discover_harvested_virtual_hosts', failed_discovery)
+
+    response = await theharvester_main.start(
+        EnumerationOptions(
+            domain='example.com',
+            quiet=True,
+            vhost_endpoint='http://192.0.2.10/',
+            vhost_candidates=('admin.example.com',),
+        ),
+        return_completed_result=True,
+    )
+
+    execution = next(item for item in response[-1].active_evidence.executions if item.action == 'vhost')
+    assert execution.status == 'failed'
+    assert execution.error_type == 'TimeoutError'
+    assert execution.stop_reason == 'request-errors'
+
+
+@pytest.mark.asyncio
+async def test_virtual_host_action_reports_mixed_request_errors_without_a_finding_as_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def failed_discovery(**_kwargs: object) -> HarvestedVirtualHostResult:
+        return HarvestedVirtualHostResult(
+            observations=(),
+            request_count=5,
+            endpoint_count=1,
+            total_endpoint_count=1,
+            candidate_endpoint_count=1,
+            total_candidate_endpoint_count=1,
+            stop_reason='request-errors',
+            request_error_count=1,
+            request_error_types=('TimeoutError',),
+        )
+
+    monkeypatch.setattr(theharvester_main, 'ResultStore', _NoopResultStore)
+    monkeypatch.setattr(theharvester_main, 'discover_harvested_virtual_hosts', failed_discovery)
+
+    response = await theharvester_main.start(
+        EnumerationOptions(
+            domain='example.com',
+            quiet=True,
+            vhost_endpoint='http://192.0.2.10/',
+            vhost_candidates=('admin.example.com',),
+        ),
+        return_completed_result=True,
+    )
+
+    execution = next(item for item in response[-1].active_evidence.executions if item.action == 'vhost')
+    assert execution.status == 'failed'
+    assert execution.error_type == 'TimeoutError'
+    assert execution.stop_reason == 'request-errors'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('stop_reason', 'scan_error_type', 'expected_error_type'),
+    [
+        ('request-errors', None, 'TimeoutError'),
+        ('scan-error', 'ConnectionError', 'ConnectionError'),
+    ],
+)
+async def test_virtual_host_action_reports_mixed_or_scan_errors_as_partial(
+    monkeypatch: pytest.MonkeyPatch,
+    stop_reason: str,
+    scan_error_type: str | None,
+    expected_error_type: str,
+) -> None:
+    saved: list[CompletedResult] = []
+
+    async def partial_discovery(**_kwargs: object) -> HarvestedVirtualHostResult:
+        return HarvestedVirtualHostResult(
+            observations=(_confirmed_vhost(),),
+            request_count=5,
+            endpoint_count=1,
+            total_endpoint_count=1,
+            candidate_endpoint_count=1,
+            total_candidate_endpoint_count=1,
+            stop_reason=stop_reason,
+            request_error_count=1,
+            request_error_types=('TimeoutError',),
+            scan_error_type=scan_error_type,
+        )
+
+    monkeypatch.setattr(theharvester_main, 'ResultStore', _recording_result_store(saved))
+    monkeypatch.setattr(theharvester_main, 'discover_harvested_virtual_hosts', partial_discovery)
+
+    response = await theharvester_main.start(
+        EnumerationOptions(
+            domain='example.com',
+            quiet=True,
+            vhost_endpoint='http://192.0.2.10/',
+            vhost_candidates=('admin.example.com',),
+        ),
+        return_completed_result=True,
+    )
+
+    completed = response[-1]
+    execution = next(item for item in completed.active_evidence.executions if item.action == 'vhost')
+    assert execution.status == 'partial'
+    assert execution.error_type == expected_error_type
+    assert execution.stop_reason == stop_reason
+    assert completed.virtual_hosts == (_confirmed_vhost(),)
+    assert saved[-1].virtual_hosts == (_confirmed_vhost(),)
+
+
+@pytest.mark.asyncio
+async def test_virtual_host_cancellation_persists_partial_observations_and_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    saved: list[CompletedResult] = []
+    partial = HarvestedVirtualHostResult(
+        observations=(_confirmed_vhost(),),
+        request_count=5,
+        endpoint_count=1,
+        total_endpoint_count=2,
+        candidate_endpoint_count=1,
+        total_candidate_endpoint_count=2,
+        stop_reason='cancelled',
+        request_error_count=1,
+        request_error_types=('TimeoutError',),
+        scan_error_type='CancelledError',
+    )
+
+    async def cancelled_discovery(**_kwargs: object) -> HarvestedVirtualHostResult:
+        raise VirtualHostDiscoveryCancelled(partial)
+
+    monkeypatch.setattr(theharvester_main, 'ResultStore', _recording_result_store(saved))
+    monkeypatch.setattr(theharvester_main, 'discover_harvested_virtual_hosts', cancelled_discovery)
+
+    with pytest.raises(VirtualHostDiscoveryCancelled):
+        await theharvester_main.start(
+            EnumerationOptions(
+                domain='example.com',
+                quiet=True,
+                vhost_endpoint='http://192.0.2.10/',
+                vhost_candidates=('admin.example.com',),
+            ),
+            return_completed_result=True,
+        )
+
+    completed = saved[-1]
+    execution = next(item for item in completed.active_evidence.executions if item.action == 'vhost')
+    assert execution.status == 'partial'
+    assert execution.error_type == 'CancelledError'
+    assert execution.stop_reason == 'cancelled'
+    assert completed.virtual_hosts == (_confirmed_vhost(),)
+
+
+@pytest.mark.asyncio
+async def test_virtual_host_cancellation_persists_failure_and_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    saved: list[CompletedResult] = []
+
+    async def cancelled_discovery(**_kwargs: object) -> HarvestedVirtualHostResult:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(theharvester_main, 'ResultStore', _recording_result_store(saved))
+    monkeypatch.setattr(theharvester_main, 'discover_harvested_virtual_hosts', cancelled_discovery)
+
+    with pytest.raises(asyncio.CancelledError):
+        await theharvester_main.start(
+            EnumerationOptions(
+                domain='example.com',
+                quiet=True,
+                vhost_endpoint='http://192.0.2.10/',
+                vhost_candidates=('admin.example.com',),
+            ),
+            return_completed_result=True,
+        )
+
+    execution = next(item for item in saved[-1].active_evidence.executions if item.action == 'vhost')
+    assert execution.status == 'failed'
+    assert execution.error_type == 'CancelledError'
+    assert execution.stop_reason == 'cancelled'
+
+
+@pytest.mark.asyncio
+async def test_virtual_host_carried_cancellation_without_a_finding_is_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    saved: list[CompletedResult] = []
+    cancelled = HarvestedVirtualHostResult(
+        observations=(),
+        request_count=5,
+        endpoint_count=1,
+        total_endpoint_count=2,
+        candidate_endpoint_count=1,
+        total_candidate_endpoint_count=2,
+        stop_reason='cancelled',
+        scan_error_type='CancelledError',
+    )
+
+    async def cancelled_discovery(**_kwargs: object) -> HarvestedVirtualHostResult:
+        raise VirtualHostDiscoveryCancelled(cancelled)
+
+    monkeypatch.setattr(theharvester_main, 'ResultStore', _recording_result_store(saved))
+    monkeypatch.setattr(theharvester_main, 'discover_harvested_virtual_hosts', cancelled_discovery)
+
+    with pytest.raises(VirtualHostDiscoveryCancelled):
+        await theharvester_main.start(
+            EnumerationOptions(
+                domain='example.com',
+                quiet=True,
+                vhost_endpoint='http://192.0.2.10/',
+                vhost_candidates=('admin.example.com',),
+            ),
+            return_completed_result=True,
+        )
+
+    execution = next(item for item in saved[-1].active_evidence.executions if item.action == 'vhost')
+    assert execution.status == 'failed'
+    assert execution.error_type == 'CancelledError'
+    assert execution.stop_reason == 'cancelled'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('stop_reason', ['request-limit', 'runtime-limit'])
+async def test_virtual_host_limits_remain_partial_without_a_finding(
+    monkeypatch: pytest.MonkeyPatch,
+    stop_reason: str,
+) -> None:
+    async def limited_discovery(**_kwargs: object) -> HarvestedVirtualHostResult:
+        return HarvestedVirtualHostResult((), 4, 1, 1, 0, 1, stop_reason)
+
+    monkeypatch.setattr(theharvester_main, 'ResultStore', _NoopResultStore)
+    monkeypatch.setattr(theharvester_main, 'discover_harvested_virtual_hosts', limited_discovery)
+
+    response = await theharvester_main.start(
+        EnumerationOptions(
+            domain='example.com',
+            quiet=True,
+            vhost_endpoint='http://192.0.2.10/',
+            vhost_candidates=('admin.example.com',),
+        ),
+        return_completed_result=True,
+    )
+
+    execution = next(item for item in response[-1].active_evidence.executions if item.action == 'vhost')
+    assert execution.status == 'partial'
+    assert execution.stop_reason == stop_reason
+
+
+@pytest.mark.asyncio
+async def test_virtual_host_output_keeps_legacy_lists_and_structured_jsonl(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output_path = tmp_path / 'vhost-report'
+
+    async def fake_discover(**_kwargs: object) -> HarvestedVirtualHostResult:
+        return HarvestedVirtualHostResult((_confirmed_vhost(),), 5, 1, 1, 1, 1, 'completed')
+
+    monkeypatch.setattr(theharvester_main, 'ResultStore', _NoopResultStore)
+    monkeypatch.setattr(theharvester_main, 'discover_harvested_virtual_hosts', fake_discover)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'theHarvester',
+            '-d',
+            'example.com',
+            '--vhost-endpoint',
+            'http://192.0.2.10/',
+            '--vhost-candidate',
+            'admin.example.com',
+            '-f',
+            str(output_path),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    assert json.loads(output_path.with_suffix('.json').read_text())['vhosts'] == ['admin.example.com']
+    assert [item.text for item in ElementTree.parse(output_path.with_suffix('.xml')).getroot().findall('vhost')] == [
+        'admin.example.com'
+    ]
+    jsonl = [json.loads(line) for line in output_path.with_suffix('.jsonl').read_text().splitlines()]
+    finding = next(item for item in jsonl if item['type'] == 'hostname')
+    assert finding['value'] == 'admin.example.com'
+    assert finding['actions'] == ['vhost']
+    assert len(finding['observations']) == 1
+    assert finding['observations'][0]['endpoint'] == 'http://192.0.2.10:80/'
 
 
 @pytest.mark.parametrize('target', ['Example.COM.', 'WWW.Example.COM.'])

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -36,6 +37,7 @@ WIKI_PAGES = {
     'Results-and-Local-Data.md',
     'Roadmap.md',
     'Troubleshooting.md',
+    'Virtual-Host-Discovery.md',
     '_Footer.md',
     '_Sidebar.md',
 }
@@ -111,6 +113,30 @@ def test_wiki_navigation_and_readme_links_resolve() -> None:
     assert all(Path(target).is_file() for target in readme_wiki_links)
 
 
+def test_virtual_host_wiki_examples_match_the_structured_result_contract() -> None:
+    page = Path('docs/wiki/Virtual-Host-Discovery.md').read_text()
+
+    assert '-b rapiddns \\\n  --vhost' in page
+    assert '"sources": ["rapiddns"]' in page
+    assert '"type": "hostname"' in page
+    assert '"value": "admin.authorized.example"' in page
+    assert '"actions": ["vhost"]' in page
+    assert '"observations": [' in page
+    assert page.count('"endpoint": "https://192.0.2.') == 2
+    assert '"source": "action:vhost"' not in page
+    assert 'schema_version' not in page
+
+    json_examples = re.findall(r'```json\n(.*?)\n```', page, flags=re.DOTALL)
+    finding = next(
+        json.loads(example)
+        for example in json_examples
+        if '"type": "hostname"' in example and '"observations"' in example
+    )
+    assert finding['value'] == 'admin.authorized.example'
+    assert finding['actions'] == ['vhost']
+    assert len(finding['observations']) == 2
+
+
 def test_readme_preserves_project_social_attribution() -> None:
     readme = Path('README.md').read_text()
     profiles = {
@@ -133,4 +159,6 @@ def test_readme_explains_jsonl_record_and_structured_value_parsing() -> None:
     assert 'select(.type == "dns-recursive-finding") | .value | fromjson' in readme
     assert 'JSONL is easy to stream one record at a time.' in readme
     assert '`person`, `infostealer`, `shodan`, and `takeover`' in readme
+    assert 'select(.type == "hostname" and .observations) | {hostname: .value, observations}' in readme
+    assert 'Several endpoint observations can enrich the same hostname' in readme
     assert 'The summary preserves the evidence status, source and action outcomes' in readme

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -120,6 +120,19 @@ from theHarvester.lib.source_catalog import (
     SourceSpec,
     get_source_spec,
 )
+from theHarvester.lib.virtual_host import (
+    DEFAULT_VHOST_CONCURRENCY,
+    DEFAULT_VHOST_REQUEST_LIMIT,
+    DEFAULT_VHOST_RUNTIME_SECONDS,
+    DEFAULT_VHOST_TIMEOUT_SECONDS,
+    VirtualHostDiscoveryCancelled,
+    VirtualHostLimits,
+    VirtualHostObservation,
+    discover_harvested_virtual_hosts,
+    normalize_virtual_host_candidates,
+    normalize_virtual_host_endpoint,
+    normalize_virtual_host_hostname,
+)
 from theHarvester.screenshot.screenshot import ScreenShotter
 
 logger = logging.getLogger(__name__)
@@ -304,6 +317,63 @@ async def start(
         help='Check common API paths with GET, HEAD, and OPTIONS. Requests follow redirects.',
         action='store_true',
     )
+    vhost_group = parser.add_argument_group(
+        'virtual host discovery',
+        'P2 direct interaction (active reconnaissance): sends direct HTTP and TLS requests. '
+        'For normal use, pass only --vhost; bounded safety defaults apply automatically. '
+        'Supplying --vhost-endpoint or --vhost-candidate also enables discovery.',
+    )
+    vhost_group.add_argument(
+        '--vhost',
+        help='Test harvested in-scope hostnames against harvested literal IPs, using HTTPS before HTTP.',
+        action='store_true',
+    )
+    vhost_group.add_argument(
+        '--vhost-endpoint',
+        help='Replace harvested IPs with one authorized HTTP or HTTPS endpoint using a literal IP.',
+        default='',
+    )
+    vhost_group.add_argument(
+        '--vhost-candidate',
+        dest='vhost_candidates',
+        help='Repeat to add an authorized in-scope hostname. Candidate names are never resolved through DNS.',
+        action='append',
+        default=[],
+        metavar='HOSTNAME',
+    )
+    vhost_advanced_group = parser.add_argument_group(
+        'virtual host advanced controls',
+        'Optional safety overrides. Bounded defaults apply when these options are omitted.',
+    )
+    vhost_advanced_group.add_argument(
+        '--vhost-request-limit',
+        help='Hard request cap shared by baseline, controls, candidates, and confirmations (default: %(default)s).',
+        default=DEFAULT_VHOST_REQUEST_LIMIT,
+        type=int,
+    )
+    vhost_advanced_group.add_argument(
+        '--vhost-runtime-seconds',
+        help='Hard wall-clock cap for virtual-host discovery (default: %(default)s seconds).',
+        default=DEFAULT_VHOST_RUNTIME_SECONDS,
+        type=float,
+    )
+    vhost_advanced_group.add_argument(
+        '--vhost-timeout-seconds',
+        help='Timeout for each virtual-host request (default: %(default)s seconds).',
+        default=DEFAULT_VHOST_TIMEOUT_SECONDS,
+        type=float,
+    )
+    vhost_advanced_group.add_argument(
+        '--vhost-concurrency',
+        help='Maximum concurrent candidate requests (default: %(default)s).',
+        default=DEFAULT_VHOST_CONCURRENCY,
+        type=int,
+    )
+    vhost_advanced_group.add_argument(
+        '--vhost-insecure',
+        help='Do not verify TLS certificates for HTTPS probes; evidence records tls_verified=false.',
+        action='store_true',
+    )
     parser.add_argument(
         '-q',
         '--quiet',
@@ -311,7 +381,7 @@ async def start(
         default=False,
         action='store_true',
     )
-    parser.add_argument('--verbose', help='Show informational diagnostic messages.', action='store_true')
+    parser.add_argument('-v', '--verbose', help='Show informational diagnostic messages.', action='store_true')
     parser.add_argument(
         '-b',
         '--source',
@@ -346,6 +416,23 @@ async def start(
         configure_logging(verbose=args.verbose)
         if args.verbose:
             logger.info('Verbose logging enabled')
+    vhost_enabled = args.vhost or bool(args.vhost_endpoint) or bool(args.vhost_candidates)
+    vhost_scope = ''
+    vhost_endpoint = ''
+    vhost_candidates: tuple[str, ...] = ()
+    vhost_limits: VirtualHostLimits | None = None
+    if vhost_enabled:
+        vhost_scope = normalize_virtual_host_hostname(args.domain)
+        if args.proxies:
+            raise ValueError('virtual-host discovery supports direct transport only; do not use --proxies')
+        vhost_endpoint = normalize_virtual_host_endpoint(args.vhost_endpoint) if args.vhost_endpoint else ''
+        vhost_candidates = normalize_virtual_host_candidates(vhost_scope, args.vhost_candidates)
+        vhost_limits = VirtualHostLimits(
+            request_limit=args.vhost_request_limit,
+            runtime_seconds=args.vhost_runtime_seconds,
+            timeout_seconds=args.vhost_timeout_seconds,
+            concurrency=args.vhost_concurrency,
+        )
     Core.quiet = getattr(args, 'quiet', False)
     try:
         db = ResultStore() if result_database is None else ResultStore(result_database)
@@ -420,7 +507,7 @@ async def start(
     shodan = args.shodan
     start: int = args.start
     all_urls: list = []
-    vhost: list = []
+    vhost_observations: list[VirtualHostObservation] = []
     word: str = args.domain.rstrip('\n')
     takeover_status = args.take_over
     use_proxy = args.proxies
@@ -453,10 +540,12 @@ async def start(
     dns_resolution_failure_types: set[str] = set()
     dns_resolution_cancelled = False
 
+    def confirmed_virtual_hostnames() -> list[str]:
+        return sorted({observation.hostname for observation in vhost_observations})
+
     def finish_completed_result(
         *,
         extra_hostnames: Iterable[str] = (),
-        virtual_hosts: Iterable[str] = (),
         committed_sources_only: bool = False,
     ) -> CompletedResult | None:
         groups: dict[ResultKind, Iterable[str]] = {
@@ -466,7 +555,9 @@ async def start(
             'cms': map(str, all_cms),
             'email': map(str, all_emails),
             'framework': map(str, all_frameworks),
-            'hostname': _normalize_hosts_for_storage(all_hosts, word) | screenshot_hostnames,
+            'hostname': (
+                _normalize_hosts_for_storage(all_hosts, word) | screenshot_hostnames | set(confirmed_virtual_hostnames())
+            ),
             'infostealer': (
                 json.dumps(stealer, ensure_ascii=False, separators=(',', ':'), sort_keys=True) for stealer in all_infostealers
             ),
@@ -477,7 +568,6 @@ async def start(
             'server': map(str, all_servers),
             'twitter-person': map(str, twitter_people_list_tracker),
             'url': map(str, all_urls),
-            'vhost': map(str, virtual_hosts),
         }
         if committed_sources_only:
             committed_groups: dict[ResultKind, list[str]] = {}
@@ -485,7 +575,11 @@ async def start(
                 committed_groups.setdefault(observation.kind, []).append(observation.value)
             groups = {kind: iter(values) for kind, values in committed_groups.items()}
         elif extra_hostnames:
-            groups['hostname'] = _normalize_hosts_for_storage((*all_hosts, *extra_hostnames), word) | screenshot_hostnames
+            groups['hostname'] = (
+                _normalize_hosts_for_storage((*all_hosts, *extra_hostnames), word)
+                | screenshot_hostnames
+                | set(confirmed_virtual_hostnames())
+            )
         try:
             return CompletedResult.finish(
                 run_id=run_id,
@@ -496,6 +590,7 @@ async def start(
                 source_executions=source_executions,
                 observations=observations,
                 active_evidence=ActiveEvidence(tuple(action_executions)),
+                virtual_hosts=vhost_observations,
             )
         except (ValueError, TypeError) as error:
             output_logger.info(f'[!] An error occurred while completing the result: {error}')
@@ -504,7 +599,6 @@ async def start(
     async def checkpoint_completed_result(
         *,
         extra_hostnames: Iterable[str] = (),
-        virtual_hosts: Iterable[str] = (),
         committed_sources_only: bool = False,
     ) -> None:
         if (
@@ -512,7 +606,6 @@ async def start(
             and (
                 result := finish_completed_result(
                     extra_hostnames=extra_hostnames,
-                    virtual_hosts=virtual_hosts,
                     committed_sources_only=committed_sources_only,
                 )
             )
@@ -531,9 +624,8 @@ async def start(
     async def checkpoint_action_result(
         *,
         extra_hostnames: Iterable[str] = (),
-        virtual_hosts: Iterable[str] = (),
     ) -> None:
-        result = finish_completed_result(extra_hostnames=extra_hostnames, virtual_hosts=virtual_hosts)
+        result = finish_completed_result(extra_hostnames=extra_hostnames)
         if result is None:
             return
         try:
@@ -608,17 +700,16 @@ async def start(
         nonlocal dns_resolution_cancelled, dns_resolution_completed_count
         nonlocal dns_resolution_duration_ms, dns_resolution_query_error_count
 
-        await search_engine.process(use_proxy)
         source = source_spec.name
         routes = source_spec.routes
+        if source:
+            output_logger.info(f'[*] Searching {source[0].upper() + source[1:]}. ')
+        await search_engine.process(use_proxy)
 
         def record_source_observations(source_name: str, kind: ResultKind, values: Iterable[object]) -> None:
             source_observations.update(
                 ResultObservation(source_name, kind, value) for item in values if (value := str(item).strip())
             )
-
-        if source:
-            output_logger.info(f'[*] Searching {source[0].upper() + source[1:]}. ')
 
         if ResultRoute.SUBDOMAINS in routes:
             discovered_hosts = await search_engine.get_hostnames()
@@ -754,13 +845,14 @@ async def start(
             observations.update(source_observations)
             raise
         except Exception as error:
-            logger.exception(f'Source {source_name} failed')
             result_count = len(source_observations)
+            duration_ms = (time.perf_counter() - started) * 1000
+            logger.exception(f'Source {source_name} failed after {duration_ms / 1000:.2f}s with {result_count} result(s)')
             source_executions.append(
                 SourceExecution(
                     source_name,
                     'partial' if result_count else 'failed',
-                    (time.perf_counter() - started) * 1000,
+                    duration_ms,
                     result_count,
                     type(error).__name__,
                 )
@@ -769,19 +861,24 @@ async def start(
             await checkpoint_completed_result(committed_sources_only=True)
             raise
         result_count = len(source_observations)
+        duration_ms = (time.perf_counter() - started) * 1000
         stop_reason = getattr(search_engine, 'stop_reason', None)
         source_executions.append(
             SourceExecution(
                 source_name,
                 execution_status,
-                (time.perf_counter() - started) * 1000,
+                duration_ms,
                 result_count,
                 stop_reason=stop_reason if isinstance(stop_reason, str) else None,
             )
         )
         observations.update(source_observations)
         await checkpoint_completed_result(committed_sources_only=True)
-        logger.info(f'Source {source_name} completed')
+        stop_summary = f'; stop={stop_reason}' if isinstance(stop_reason, str) else ''
+        logger.info(
+            f'Source {source_name} finished in {duration_ms / 1000:.2f}s: '
+            f'status={execution_status}; results={result_count}{stop_summary}'
+        )
 
     stor_lst = []
     if args.source is not None:
@@ -791,7 +888,7 @@ async def start(
         activities.add(ActivityClass.PASSIVE)
     if dnslookup or dnsbrute[0] or dnsresolve != '' or recursive_limits is not None:
         activities.add(ActivityClass.DNS)
-    if takeover_status or args.screenshot or args.api_scan:
+    if takeover_status or args.screenshot or args.api_scan or vhost_enabled:
         activities.add(ActivityClass.DIRECT)
     if activities:
         activity_labels = {
@@ -1539,7 +1636,7 @@ async def start(
 
                 elif engineitem == 'waybackarchive':
                     try:
-                        waybackarchive_search = waybackarchive.SearchWaybackarchive(word)
+                        waybackarchive_search = waybackarchive.SearchWaybackarchive(word, limit)
                         stor_lst.append(
                             store(
                                 waybackarchive_search,
@@ -1825,6 +1922,7 @@ async def start(
         and rest_args.dns_brute is False
         and not dnslookup
         and not return_completed_result
+        and not vhost_enabled
     ):
         # Indicates user is using REST api but not wanting output to be saved to a file
         # cast to string so Rest API can understand the type
@@ -2177,6 +2275,131 @@ async def start(
         )
         await checkpoint_completed_result(extra_hostnames=dnsrev)
 
+    if vhost_enabled:
+        vhost_started = time.perf_counter()
+        assert vhost_limits is not None
+        output_logger.info('[*] Virtual-host discovery is P2 direct interaction (active reconnaissance).')
+        harvested_action_hosts = {
+            observation.value
+            for execution in action_executions
+            for observation in execution.observations
+            if observation.kind == 'hostname'
+        }
+        harvested_action_ips = {
+            observation.value
+            for execution in action_executions
+            for observation in execution.observations
+            if observation.kind == 'ip'
+        }
+        harvested_candidates = {
+            normalized
+            for candidate in (*all_hosts, *dnsrev, *harvested_action_hosts)
+            if (normalized := normalize_scoped_hostname(candidate, vhost_scope)) and normalized != vhost_scope
+        }
+        candidates = tuple(sorted(harvested_candidates | set(vhost_candidates)))
+        addresses = tuple(
+            sorted(
+                _normalize_ip_addresses((*all_ip, *harvested_action_ips)),
+                key=lambda value: (ip_address(value).version, int(ip_address(value))),
+            )
+        )
+        logger.info(
+            'Virtual-host discovery prepared: endpoints=%d; candidates=%d; request-limit=%d; '
+            'runtime=%.2fs; timeout=%.2fs; concurrency=%d',
+            1 if vhost_endpoint else len(addresses) * 2,
+            len(candidates),
+            vhost_limits.request_limit,
+            vhost_limits.runtime_seconds,
+            vhost_limits.timeout_seconds,
+            vhost_limits.concurrency,
+        )
+        try:
+            sweep = await discover_harvested_virtual_hosts(
+                scope=vhost_scope,
+                addresses=addresses,
+                candidates=candidates,
+                limits=vhost_limits,
+                insecure=args.vhost_insecure,
+                endpoint_override=vhost_endpoint,
+            )
+        except asyncio.CancelledError as error:
+            if isinstance(error, VirtualHostDiscoveryCancelled):
+                vhost_observations.extend(
+                    observation for observation in error.result.observations if observation.classification == 'distinct'
+                )
+            confirmed_vhosts = confirmed_virtual_hostnames()
+            action_executions.append(
+                ActionExecution.finish(
+                    action='vhost',
+                    status='partial' if confirmed_vhosts else 'failed',
+                    duration_ms=(time.perf_counter() - vhost_started) * 1000,
+                    groups={'hostname': confirmed_vhosts},
+                    error_type='CancelledError',
+                    stop_reason='cancelled',
+                )
+            )
+            await persist_result(finish_completed_result(extra_hostnames=dnsrev))
+            raise
+        except Exception as error:
+            confirmed_vhosts = confirmed_virtual_hostnames()
+            action_executions.append(
+                ActionExecution.finish(
+                    action='vhost',
+                    status='partial' if confirmed_vhosts else 'failed',
+                    duration_ms=(time.perf_counter() - vhost_started) * 1000,
+                    groups={'hostname': confirmed_vhosts},
+                    error_type=type(error).__name__,
+                    stop_reason='scan-error',
+                )
+            )
+            output_logger.info(f'[!] Virtual-host discovery failed: {type(error).__name__}')
+        else:
+            vhost_observations.extend(
+                observation for observation in sweep.observations if observation.classification == 'distinct'
+            )
+            confirmed_vhosts = confirmed_virtual_hostnames()
+            if sweep.stop_reason in {'no-candidates', 'no-endpoints'}:
+                vhost_status: ExecutionStatus = 'skipped'
+            elif sweep.stop_reason in {'request-limit', 'runtime-limit'}:
+                vhost_status = 'partial'
+            elif sweep.scan_error_type or sweep.request_error_count or sweep.stop_reason in {'request-errors', 'scan-error'}:
+                vhost_status = 'partial' if confirmed_vhosts else 'failed'
+            else:
+                vhost_status = 'completed'
+            vhost_error_type = sweep.scan_error_type or next(iter(sweep.request_error_types), None)
+            action_executions.append(
+                ActionExecution.finish(
+                    action='vhost',
+                    status=vhost_status,
+                    duration_ms=(time.perf_counter() - vhost_started) * 1000,
+                    groups={'hostname': confirmed_vhosts},
+                    error_type=vhost_error_type,
+                    stop_reason=sweep.stop_reason,
+                )
+            )
+            output_logger.info(
+                f'[*] Virtual hosts: confirmed={len(vhost_observations)}; '
+                f'candidate-endpoints={sweep.candidate_endpoint_count}/{sweep.total_candidate_endpoint_count}; '
+                f'endpoints={sweep.endpoint_count}/{sweep.total_endpoint_count}; requests={sweep.request_count}; '
+                f'stop={sweep.stop_reason}; elapsed={time.perf_counter() - vhost_started:.2f}s'
+            )
+            stop_hint = {
+                'no-candidates': 'No candidate hostnames were available; select hostname-producing sources or add --vhost-candidate.',
+                'no-endpoints': 'No literal-IP endpoints were available; select IP-producing sources, enable a DNS action, or use --vhost-endpoint.',
+                'request-limit': 'Coverage stopped at the request limit; raise --vhost-request-limit or narrow the scan.',
+                'request-errors': 'All requested coverage finished, but one or more requests failed.',
+                'runtime-limit': 'Coverage stopped at the runtime limit; raise --vhost-runtime-seconds or narrow the scan.',
+                'scan-error': 'Coverage stopped after an endpoint scan failed.',
+            }.get(sweep.stop_reason)
+            if stop_hint:
+                output_logger.info(f'[!] {stop_hint}')
+            for observation in vhost_observations:
+                output_logger.info(
+                    f'{observation.hostname} at {observation.endpoint}: '
+                    f'status={observation.status}; signals={",".join(observation.distinct_signals)}'
+                )
+        await checkpoint_action_result(extra_hostnames=dnsrev)
+
     # Screenshots
     if len(args.screenshot) > 0:
         screenshot_started = time.perf_counter()
@@ -2459,14 +2682,8 @@ async def start(
                         )
                     elif host not in paired_hosts:
                         await file.write(f'<host>{sanitize_for_xml(host)}</host>')
-                for x in vhost:
-                    host, ip = x.split(':', 1) if ':' in x else (x, '')
-                    if ip and len(ip) > 3:
-                        await file.write(
-                            f'<vhost><ip>{sanitize_for_xml(ip)} </ip><hostname>{sanitize_for_xml(host)}</hostname></vhost>'
-                        )
-                    else:
-                        await file.write(f'<vhost>{sanitize_for_xml(host)}</vhost>')
+                for host in confirmed_virtual_hostnames():
+                    await file.write(f'<vhost>{sanitize_for_xml(host)}</vhost>')
                 # TODO add Shodan output into XML report
                 await file.write('</theHarvester>')
                 output_logger.info('[*] XML File saved.')
@@ -2624,7 +2841,7 @@ async def start(
                         stop_reason='cancelled',
                     )
                 )
-            await persist_result(finish_completed_result(extra_hostnames=dnsrev, virtual_hosts=vhost))
+            await persist_result(finish_completed_result(extra_hostnames=dnsrev))
             raise
         except Exception as error:
             endpoints_found, _interesting, api_action_groups = collect_api_action_groups(api_scanner, best_effort=True)
@@ -2647,7 +2864,7 @@ async def start(
                 output_logger.info(f'\n[!] API endpoint scanning failed with {type(error).__name__}.')
                 output_logger.info('    Continuing with the rest of the scan...')
 
-        await checkpoint_action_result(extra_hostnames=dnsrev, virtual_hosts=vhost)
+        await checkpoint_action_result(extra_hostnames=dnsrev)
 
     all_urls = sorted_unique(all_urls)
 
@@ -2675,8 +2892,8 @@ async def start(
             else:
                 json_dict['hosts'] = []
 
-            if vhost and len(vhost) > 0:
-                json_dict['vhosts'] = vhost
+            if virtual_hostnames := confirmed_virtual_hostnames():
+                json_dict['vhosts'] = virtual_hostnames
 
             if len(all_urls) > 0:
                 json_dict['urls'] = all_urls
@@ -2705,7 +2922,7 @@ async def start(
             output_logger.info(f'[!] An error occurred while saving the JSON file: {er} ')
         output_logger.info('\n\n')
 
-    completed_result = finish_completed_result(extra_hostnames=dnsrev, virtual_hosts=vhost)
+    completed_result = finish_completed_result(extra_hostnames=dnsrev)
 
     if filename and completed_result is not None:
         try:

--- a/theHarvester/discovery/baidusearch.py
+++ b/theHarvester/discovery/baidusearch.py
@@ -12,8 +12,12 @@ class SearchBaidu:
         self.hostname = 'www.baidu.com'
         self.limit = limit
         self.proxy = False
+        self.execution_status: str | None = None
+        self.stop_reason: str | None = None
 
     async def do_search(self) -> None:
+        self.execution_status = None
+        self.stop_reason = None
         headers = {'Host': self.hostname, 'User-agent': Core.get_user_agent()}
         base_url = f'https://{self.server}/s'
         urls = [
@@ -23,12 +27,16 @@ class SearchBaidu:
         ]
         responses = await AsyncFetcher.fetch_all(urls, headers=headers, proxy=self.proxy)
         if not responses or all(not response for response in responses):
-            raise RuntimeError('Baidu returned an empty response')
+            self.execution_status = 'failed'
+            self.stop_reason = 'no-response'
+            return
         for response in responses:
             if not response:
                 continue
             if '百度安全验证' in response or 'wappass.baidu.com/static/captcha' in response:
-                raise RuntimeError('Baidu returned a security verification page')
+                self.execution_status = 'partial' if self.total_results else 'rate-limited'
+                self.stop_reason = 'security-verification'
+                return
             self.total_results += f' {response}'
 
     async def process(self, proxy: bool = False) -> None:

--- a/theHarvester/discovery/commoncrawl.py
+++ b/theHarvester/discovery/commoncrawl.py
@@ -1,3 +1,4 @@
+import asyncio
 import json as _stdlib_json
 import logging
 from datetime import datetime, timedelta
@@ -29,6 +30,7 @@ class SearchCommoncrawl:
     INDEX_LOOKBACK = timedelta(days=365)
     PAGE_SIZE = 5
     PAGE_BATCH_SIZE = 10
+    RUNTIME_SECONDS = 30.0
     # Protect the shared index service even when its page count is unexpectedly large.
     MAX_PAGES_PER_QUERY = 100
 
@@ -38,6 +40,8 @@ class SearchCommoncrawl:
         self.totalhosts: set[str] = set()
         self.proxy = False
         self.hostname = 'https://index.commoncrawl.org'
+        self.execution_status: str | None = None
+        self.stop_reason: str | None = None
 
     @staticmethod
     def _safe_parse_json_lines(payload: str) -> list:
@@ -117,6 +121,8 @@ class SearchCommoncrawl:
 
     async def do_search(self) -> None:
         try:
+            self.execution_status = None
+            self.stop_reason = None
             if self.limit == 0:
                 return
 
@@ -125,20 +131,43 @@ class SearchCommoncrawl:
                 [f'{self.hostname}/collinfo.json'], headers=headers, proxy=self.proxy, json=True
             )
             if not catalog_response or not isinstance(catalog_response[0], list) or not catalog_response[0]:
+                self.execution_status = 'failed'
+                self.stop_reason = 'invalid-catalog'
                 logger.error('Common Crawl API error: invalid index catalog')
                 return
 
             indexes = self._select_indexes(catalog_response[0])
             if not indexes:
+                self.execution_status = 'failed'
+                self.stop_reason = 'no-usable-indexes'
                 logger.error('Common Crawl API error: index catalog contains no usable entries')
                 return
 
+            query_total = len(indexes) * 2
+            logger.info(
+                'Common Crawl selected %d %s and %d queries',
+                len(indexes),
+                'index' if len(indexes) == 1 else 'indexes',
+                query_total,
+            )
+
             records_seen = 0
             successful_queries = 0
+            failed_queries = 0
+            page_limit_reached = False
+            query_number = 0
             for index in indexes:
                 endpoint = index['cdx-api']
                 for query in (f'*.{self.word}', f'{self.word}/*'):
+                    query_number += 1
+                    logger.info(
+                        'Common Crawl query %d/%d: index=%s',
+                        query_number,
+                        query_total,
+                        index.get('id', 'unknown'),
+                    )
                     try:
+                        query_had_errors = False
                         count_url = f'{endpoint}?{urlencode({"url": query, "output": "json", "pageSize": self.PAGE_SIZE, "showNumPages": "true"})}'
                         count_response = await AsyncFetcher.fetch_all([count_url], headers=headers, proxy=self.proxy)
                         count_payload = json.loads(count_response[0])
@@ -160,6 +189,8 @@ class SearchCommoncrawl:
                             responses = await AsyncFetcher.fetch_all(page_urls, headers=headers, proxy=self.proxy)
                             if not isinstance(responses, list) or not responses:
                                 raise ValueError('invalid page batch')
+                            usable_response = False
+                            page_errors: dict[str, int] = {}
                             for response in responses:
                                 try:
                                     if not response:
@@ -172,29 +203,49 @@ class SearchCommoncrawl:
                                             domain = self._extract_domain_from_url(record.get('url', ''))
                                             if domain.endswith(f'.{self.word}') or domain == self.word:
                                                 self.totalhosts.add(domain)
+                                    usable_response = True
                                     query_succeeded = True
                                 except ValueError as error:
-                                    logger.warning(f'Common Crawl page error for index {index.get("id", "unknown")}: {error}')
+                                    message = str(error)
+                                    page_errors[message] = page_errors.get(message, 0) + 1
                                 except Exception:
-                                    logger.warning(
-                                        f'Common Crawl page error for index {index.get("id", "unknown")}: unexpected page failure'
-                                    )
+                                    message = 'unexpected page failure'
+                                    page_errors[message] = page_errors.get(message, 0) + 1
+                            if page_errors:
+                                query_had_errors = True
+                                summary = ', '.join(f'{count}x {message}' for message, count in sorted(page_errors.items()))
+                                logger.warning(f'Common Crawl page errors for index {index.get("id", "unknown")}: {summary}')
+                            if not usable_response:
+                                raise ValueError('page batch contained no usable responses')
                         if page_count > page_limit:
+                            page_limit_reached = True
                             logger.warning(
                                 f'Common Crawl page limit reached for index {index.get("id", "unknown")}; '
                                 'results may be incomplete'
                             )
                         if query_succeeded:
                             successful_queries += 1
+                        if query_had_errors:
+                            failed_queries += 1
                     except Exception as error:
+                        failed_queries += 1
                         logger.warning(f'Common Crawl API error for index {index.get("id", "unknown")}: {error}')
 
-            if not successful_queries and not self.totalhosts:
-                raise RuntimeError('all Common Crawl queries failed')
+            if failed_queries:
+                if successful_queries or self.totalhosts:
+                    self.execution_status = 'partial'
+                    self.stop_reason = 'query-errors'
+                else:
+                    self.execution_status = 'failed'
+                    self.stop_reason = 'all-queries-failed'
+                    logger.warning(f'Common Crawl failed all {query_total} queries')
+            elif page_limit_reached:
+                self.execution_status = 'partial'
+                self.stop_reason = 'page-limit'
 
-        except RuntimeError:
-            raise
         except Exception as error:
+            self.execution_status = 'partial' if self.totalhosts else 'failed'
+            self.stop_reason = 'unexpected-error'
             logger.error(f'Common Crawl API error: {error}')
 
     async def get_hostnames(self) -> set:
@@ -202,4 +253,12 @@ class SearchCommoncrawl:
 
     async def process(self, proxy: bool = False) -> None:
         self.proxy = proxy
-        await self.do_search()
+        try:
+            async with asyncio.timeout(self.RUNTIME_SECONDS):
+                await self.do_search()
+        except TimeoutError:
+            self.execution_status = 'partial' if self.totalhosts else 'failed'
+            self.stop_reason = 'runtime-limit'
+            logger.info(
+                f'Common Crawl runtime limit reached after {self.RUNTIME_SECONDS:g}s; preserved {len(self.totalhosts)} hosts'
+            )

--- a/theHarvester/discovery/waybackarchive.py
+++ b/theHarvester/discovery/waybackarchive.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from urllib.parse import unquote_plus, urlencode, urlsplit
 
@@ -13,14 +14,18 @@ class SearchWaybackarchive:
     """
 
     PAGE_SIZE = 1000
+    RUNTIME_SECONDS = 30.0
     # ponytail: hard cap protects against endless cursors; raise only if real targets exceed one million rows.
     MAX_PAGES_PER_QUERY = 1000
 
-    def __init__(self, word) -> None:
+    def __init__(self, word, limit: int = 500) -> None:
         self.word = word.strip().rstrip('.').lower()
+        self.limit = max(limit, 0)
         self.totalhosts: set = set()
         self.proxy = False
         self.hostname = 'https://web.archive.org'
+        self.execution_status: str | None = None
+        self.stop_reason: str | None = None
 
     def _extract_domain_from_url(self, url: str) -> str:
         """Extract domain from URL"""
@@ -54,10 +59,10 @@ class SearchWaybackarchive:
         continuation_lines = [line.strip() for line in continuation.splitlines() if line.strip()]
         return body.splitlines(), continuation_lines[0] if len(continuation_lines) == 1 else None
 
-    async def _search_pattern(self, pattern: str, headers: dict[str, str]) -> None:
+    async def _search_pattern(self, pattern: str, headers: dict[str, str]) -> str | None:
         resume_key: str | None = None
         seen_resume_keys: set[str] = set()
-        for _ in range(self.MAX_PAGES_PER_QUERY):
+        for page_number in range(1, self.MAX_PAGES_PER_QUERY + 1):
             query = {
                 'url': pattern,
                 'fl': 'original',
@@ -72,15 +77,15 @@ class SearchWaybackarchive:
             response = await AsyncFetcher.fetch_all([url], headers=headers, proxy=self.proxy)
             if not response or not isinstance(response, list):
                 logger.info(f'Wayback Archive returned an invalid response container for pattern {pattern}')
-                return
+                return 'invalid-response'
             if not response[0]:
                 logger.info(f'Wayback Archive returned no page data for pattern {pattern}')
-                return
+                return None
 
             page = self._parse_page(response[0])
             if page is None:
                 logger.info(f'Wayback Archive returned invalid page data for pattern {pattern}; stopping pagination')
-                return
+                return 'invalid-response'
             lines, next_resume_key = page
             for line in lines:
                 if not line:
@@ -88,26 +93,59 @@ class SearchWaybackarchive:
                 domain = self._extract_domain_from_url(line.strip())
                 if domain.endswith(f'.{self.word}') or domain == self.word:
                     self.totalhosts.add(domain)
+                    if len(self.totalhosts) >= self.limit:
+                        return 'result-limit'
+
+            if page_number == 1 or page_number % 10 == 0:
+                logger.info(f'Wayback Archive page {page_number}: hosts={len(self.totalhosts)}')
 
             if next_resume_key is None or next_resume_key in seen_resume_keys:
-                return
+                return None
             seen_resume_keys.add(next_resume_key)
             resume_key = next_resume_key
         logger.info(f'Wayback Archive page limit reached for pattern {pattern}; results may be incomplete')
+        return 'page-limit'
 
     async def do_search(self) -> None:
+        self.execution_status = None
+        self.stop_reason = None
+        if self.limit == 0:
+            return
         try:
             headers = {'User-agent': Core.get_user_agent()}
-
-            for pattern in (f'*.{self.word}', f'{self.word}/*'):
-                try:
-                    await self._search_pattern(pattern, headers)
-
-                except Exception as e:
-                    logger.info(f'Wayback Archive API error for pattern {pattern}: {e}')
-                    continue
-
+            degraded_reason: str | None = None
+            try:
+                async with asyncio.timeout(self.RUNTIME_SECONDS):
+                    for pattern in (f'*.{self.word}', f'{self.word}/*'):
+                        try:
+                            outcome = await self._search_pattern(pattern, headers)
+                        except Exception as e:
+                            degraded_reason = degraded_reason or 'request-error'
+                            logger.info(f'Wayback Archive API error for pattern {pattern}: {e}')
+                            continue
+                        if outcome == 'result-limit':
+                            if degraded_reason is None:
+                                self.stop_reason = 'result-limit'
+                            break
+                        if outcome == 'page-limit':
+                            degraded_reason = degraded_reason or outcome
+                            break
+                        if outcome is not None:
+                            degraded_reason = degraded_reason or outcome
+            except TimeoutError:
+                self.execution_status = 'partial' if self.totalhosts else 'failed'
+                self.stop_reason = 'runtime-limit'
+                logger.info(
+                    f'Wayback Archive runtime limit reached after {self.RUNTIME_SECONDS:g}s; '
+                    f'preserved {len(self.totalhosts)} hosts'
+                )
+                return
+            if degraded_reason is not None:
+                self.execution_status = 'partial' if self.totalhosts or degraded_reason == 'page-limit' else 'failed'
+                self.stop_reason = degraded_reason
         except Exception as e:
+            self.execution_status = 'partial' if self.totalhosts else 'failed'
+            self.stop_reason = 'unexpected-error'
             logger.info(f'Wayback Archive API error: {e}')
 
     async def get_hostnames(self) -> set:

--- a/theHarvester/lib/api/run_evidence.py
+++ b/theHarvester/lib/api/run_evidence.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import ipaddress
 from datetime import datetime, timedelta
 from typing import Any
 from uuid import UUID
 
 from fastapi import HTTPException, status
 
-from theHarvester.lib.completed_result import parse_result_jsonl
+from theHarvester.lib.completed_result import parse_result_jsonl, parse_virtual_host_details, virtual_host_details
 from theHarvester.lib.evidence_types import EVIDENCE_STATUSES
 
 from .run_models import _normalize_target
@@ -51,15 +52,7 @@ def parse_jsonl_import(body: bytes) -> dict[str, Any]:
         'status': summary.get('evidence_status'),
         'started_at': summary.get('started_at'),
         'completed_at': summary.get('completed_at'),
-        'results': [
-            {
-                'type': record['type'],
-                'value': record['value'],
-                'sources': record['sources'],
-                'actions': record['actions'],
-            }
-            for record in findings
-        ],
+        'results': [dict(record) for record in findings],
         'source_executions': summary.get('source_executions', []),
         'action_executions': summary.get('action_executions', []),
         'artifacts': summary.get('artifacts', []),
@@ -95,4 +88,71 @@ def validate_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f'Evidence field {field} must be an array',
             )
+    for result in evidence['results']:
+        if not isinstance(result, dict):
+            continue
+        if result.get('type') == 'vhost':
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail='vhost is not a result type; use hostname with virtual-host observations',
+            )
+        if 'observations' not in result:
+            continue
+        if result.get('type') != 'hostname':
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail='Virtual-host observations belong to hostname findings',
+            )
+        allowed_keys = {'type', 'value', 'sources', 'actions', 'observations'}
+        if set(result) - allowed_keys:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail='Virtual-host evidence contains unsupported fields',
+            )
+        sources = result.get('sources', [])
+        actions = result.get('actions', [])
+        if (
+            not isinstance(sources, list)
+            or any(not isinstance(source, str) or not source.strip() for source in sources)
+            or not isinstance(actions, list)
+            or any(not isinstance(action, str) or not action.strip() for action in actions)
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail='Virtual-host producers must be arrays of non-empty strings',
+            )
+        details = result.get('observations')
+        if not isinstance(details, list) or not details:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail='Virtual-host evidence requires structured observations',
+            )
+        result_value = result.get('value')
+        if not isinstance(result_value, str):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail='Virtual-host evidence must identify a hostname',
+            )
+        try:
+            observations = parse_virtual_host_details(result_value, details)
+        except ValueError as error:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
+        target = str(evidence['target'])
+        try:
+            ipaddress.ip_address(target)
+        except ValueError:
+            pass
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail='Virtual-host evidence requires a hostname target scope',
+            )
+        if any(observation.hostname == target or not observation.hostname.endswith(f'.{target}') for observation in observations):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail='Virtual-host evidence must be a strict descendant of the run target',
+            )
+        result['sources'] = sorted(set(sources))
+        result['actions'] = sorted(set(actions))
+        result['observations'] = virtual_host_details(observations)
     return evidence

--- a/theHarvester/lib/api/run_models.py
+++ b/theHarvester/lib/api/run_models.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import ipaddress
 from datetime import UTC, datetime
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from theHarvester.lib.completed_result import parse_virtual_host_details
 from theHarvester.lib.enumeration import (
     DEFAULT_DNS_RECURSIVE_QUERY_LIMIT,
     DEFAULT_DNS_RECURSIVE_RUNTIME_SECONDS,
@@ -14,6 +15,16 @@ from theHarvester.lib.enumeration import (
 from theHarvester.lib.evidence_types import EvidenceStatus  # noqa: TC001 - Pydantic resolves this annotation at runtime
 from theHarvester.lib.resolver_selection import DEFAULT_DNS_RESOLVERS, normalize_resolver_addresses
 from theHarvester.lib.source_catalog import SOURCE_SPECS, ActivityClass, selected_action_names
+from theHarvester.lib.virtual_host import (
+    DEFAULT_VHOST_CONCURRENCY,
+    DEFAULT_VHOST_REQUEST_LIMIT,
+    DEFAULT_VHOST_RUNTIME_SECONDS,
+    DEFAULT_VHOST_TIMEOUT_SECONDS,
+    VirtualHostLimits,
+    VirtualHostRequest,
+    normalize_virtual_host_candidates,
+    normalize_virtual_host_endpoint,
+)
 
 
 def utc_now() -> str:
@@ -124,6 +135,49 @@ class RunRequest(BaseModel):
         max_length=500,
         description='Optional endpoint paths used by API scan instead of its bundled wordlist.',
     )
+    vhost: bool = Field(
+        default=False,
+        description='Test harvested in-scope hostnames against harvested literal IPs within one shared cap.',
+    )
+    vhost_endpoint: str = Field(
+        default='',
+        description='Optional literal-IP HTTP or HTTPS endpoint; providing one also enables virtual-host discovery.',
+    )
+    vhost_candidates: list[str] = Field(
+        default_factory=list,
+        max_length=1000,
+        description='Optional in-scope hostnames added to harvested candidates; providing one also enables discovery.',
+    )
+    vhost_request_limit: int = Field(
+        default=DEFAULT_VHOST_REQUEST_LIMIT,
+        ge=5,
+        le=10_000,
+        description='Hard request cap shared by virtual-host context, controls, candidates, and confirmations.',
+    )
+    vhost_runtime_seconds: float = Field(
+        default=DEFAULT_VHOST_RUNTIME_SECONDS,
+        gt=0,
+        le=3600,
+        allow_inf_nan=False,
+        description='Hard wall-clock cap for virtual-host discovery.',
+    )
+    vhost_timeout_seconds: float = Field(
+        default=DEFAULT_VHOST_TIMEOUT_SECONDS,
+        gt=0,
+        le=300,
+        allow_inf_nan=False,
+        description='Timeout for each virtual-host request.',
+    )
+    vhost_concurrency: int = Field(
+        default=DEFAULT_VHOST_CONCURRENCY,
+        ge=1,
+        le=100,
+        description='Maximum concurrent virtual-host candidate requests.',
+    )
+    vhost_insecure: bool = Field(
+        default=False,
+        description='Disable certificate verification for virtual-host HTTPS probes and retain that fact in evidence.',
+    )
 
     @field_validator('target')
     @classmethod
@@ -160,6 +214,42 @@ class RunRequest(BaseModel):
         return paths
 
     @model_validator(mode='after')
+    def validate_virtual_host_request(self) -> Self:
+        has_endpoint = bool(self.vhost_endpoint.strip())
+        has_candidates = bool(self.vhost_candidates)
+        if not (self.vhost or has_endpoint or has_candidates):
+            return self
+        try:
+            ipaddress.ip_address(self.target)
+        except ValueError:
+            pass
+        else:
+            raise ValueError('Virtual-host discovery requires a hostname target scope')
+        if self.proxies:
+            raise ValueError('Virtual-host discovery supports direct transport only; proxies must be disabled')
+        if not self.sources and not (has_endpoint and has_candidates):
+            raise ValueError('Virtual-host discovery needs a discovery source unless endpoint and candidates are supplied')
+        self.vhost = True
+        if has_endpoint:
+            self.vhost_endpoint = normalize_virtual_host_endpoint(self.vhost_endpoint)
+        if has_candidates:
+            self.vhost_candidates = list(normalize_virtual_host_candidates(self.target, tuple(self.vhost_candidates)))
+        if has_endpoint and has_candidates:
+            VirtualHostRequest(
+                endpoint=self.vhost_endpoint,
+                scope=self.target,
+                candidates=tuple(self.vhost_candidates),
+                limits=VirtualHostLimits(
+                    request_limit=self.vhost_request_limit,
+                    runtime_seconds=self.vhost_runtime_seconds,
+                    timeout_seconds=self.vhost_timeout_seconds,
+                    concurrency=self.vhost_concurrency,
+                ),
+                insecure=self.vhost_insecure,
+            )
+        return self
+
+    @model_validator(mode='after')
     def validate_selected_work(self) -> RunRequest:
         if not self.sources and not selected_action_names(self.model_dump()):
             raise ValueError('Select at least one discovery source or action')
@@ -191,11 +281,58 @@ class DatabaseImportResponse(BaseModel):
     skipped_run_ids: list[str]
 
 
+class VirtualHostObservationResponse(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    endpoint: str
+    http_host: str
+    tls_server_name: str | None
+    classification: Literal['distinct']
+    phase: Literal['body']
+    status: int
+    location: str | None
+    body_sha256: str
+    body_size: int
+    body_truncated: bool
+    context_phase: Literal['body']
+    context_status: int
+    context_location: str | None
+    context_body_sha256: str
+    context_body_size: int
+    context_body_truncated: bool
+    control_phase: Literal['body']
+    control_status: int
+    control_location: str | None
+    control_body_sha256: str
+    control_body_size: int
+    control_body_truncated: bool
+    confirmation_body_sha256: str | None
+    tls_verified: bool | None
+    distinct_signals: list[str]
+    reflection_normalized: bool
+
+
 class NormalizedResult(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
     type: str
     value: str
     sources: list[str] = Field(default_factory=list)
     actions: list[str] = Field(default_factory=list)
+    observations: list[VirtualHostObservationResponse] | None = Field(default=None, min_length=1)
+
+    @model_validator(mode='after')
+    def validate_result(self) -> Self:
+        if self.type == 'vhost':
+            raise ValueError('vhost is not a result type; use hostname with virtual-host observations')
+        if self.observations is not None:
+            if self.type != 'hostname':
+                raise ValueError('Virtual-host observations belong to hostname results')
+            parse_virtual_host_details(self.value, [details.model_dump() for details in self.observations])
+        return self
+
+
+RunResult = NormalizedResult
 
 
 class ScreenshotRecord(BaseModel):
@@ -233,7 +370,7 @@ class RunSummary(BaseModel):
 
 class RunDetail(RunSummary):
     request: RunRequest | ImportedRunRequest
-    results: list[NormalizedResult]
+    results: list[RunResult]
     source_executions: list[dict[str, Any]]
     action_executions: list[dict[str, Any]]
     artifacts: list[dict[str, Any]]

--- a/theHarvester/lib/api/run_projection.py
+++ b/theHarvester/lib/api/run_projection.py
@@ -32,14 +32,17 @@ def normalized_results(evidence: dict[str, Any] | None) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
     for item in evidence.get('results') or []:
         if isinstance(item, dict) and item.get('type') != 'screenshot':
-            results.append(
-                {
-                    'type': str(item.get('type', 'other')),
-                    'value': str(item.get('value', '')),
-                    'sources': sorted({str(source) for source in item.get('sources', [])}),
-                    'actions': sorted({str(action) for action in item.get('actions', [])}),
-                }
-            )
+            result: dict[str, Any] = {
+                'type': str(item.get('type', 'other')),
+                'value': str(item.get('value', '')),
+                'sources': sorted({str(source) for source in item.get('sources', [])}),
+                'actions': sorted({str(action) for action in item.get('actions', [])}),
+            }
+            if item.get('type') == 'hostname' and item.get('observations'):
+                result['observations'] = [
+                    dict(observation) for observation in item.get('observations', []) if isinstance(observation, dict)
+                ]
+            results.append(result)
     return results
 
 

--- a/theHarvester/lib/api/run_store.py
+++ b/theHarvester/lib/api/run_store.py
@@ -9,7 +9,12 @@ from uuid import UUID, uuid4
 from fastapi import HTTPException, status
 
 from theHarvester.lib.active_evidence import ActionExecution, ActiveEvidence, ArtifactReference
-from theHarvester.lib.completed_result import CompletedResult, ResultObservation, SourceExecution
+from theHarvester.lib.completed_result import (
+    CompletedResult,
+    ResultObservation,
+    SourceExecution,
+    parse_virtual_host_details,
+)
 from theHarvester.lib.database import DuplicateRunError, ResultStore, ResultStoreError, RunLifecycleStore
 from theHarvester.lib.evidence_types import EXECUTION_STATUSES, EvidenceStatus, ExecutionStatus, ResultKind
 
@@ -19,6 +24,8 @@ from .run_projection import activities_for_evidence, activities_for_request, nor
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from theHarvester.lib.virtual_host import VirtualHostObservation
 
 WORKER_LEASE_TIMEOUT_SECONDS = 30
 DATABASE_IMPORT_BATCH_SIZE = 100
@@ -43,10 +50,13 @@ def _completed_result(
     source_origins: set[ResultObservation] = set()
     source_counts: Counter[str] = Counter()
     action_groups: dict[str, dict[ResultKind, set[str]]] = defaultdict(lambda: defaultdict(set))
+    virtual_hosts: list[VirtualHostObservation] = []
     for item in results:
         kind = cast('ResultKind', str(item['type']))
         value = str(item['value'])
         groups[kind].add(value)
+        if kind == 'hostname' and item.get('observations'):
+            virtual_hosts.extend(parse_virtual_host_details(value, item.get('observations')))
         for source in set(item.get('sources', [])):
             source_name = str(source)
             source_origins.add(ResultObservation(source_name, kind, value))
@@ -131,6 +141,7 @@ def _completed_result(
         source_executions=completed_sources,
         observations=sorted(source_origins),
         active_evidence=active_evidence,
+        virtual_hosts=virtual_hosts,
         evidence_status=(
             cast('EvidenceStatus', str(evidence['status']))
             if evidence.get('status') is not None and not execution_status_is_authoritative

--- a/theHarvester/lib/api/run_worker.py
+++ b/theHarvester/lib/api/run_worker.py
@@ -20,6 +20,12 @@ from theHarvester.lib.enumeration import (
     EnumerationOptions,
 )
 from theHarvester.lib.resolver_selection import DEFAULT_DNS_RESOLVERS
+from theHarvester.lib.virtual_host import (
+    DEFAULT_VHOST_CONCURRENCY,
+    DEFAULT_VHOST_REQUEST_LIMIT,
+    DEFAULT_VHOST_RUNTIME_SECONDS,
+    DEFAULT_VHOST_TIMEOUT_SECONDS,
+)
 
 from .run_artifacts import ensure_private_directory, read_child_evidence, write_child_evidence
 from .run_store import RunStore
@@ -307,6 +313,14 @@ async def _child_execute(run_id: str, database: Path) -> None:
         source=','.join(request['sources']),
         start=request.get('start', DEFAULT_RESULT_START),
         take_over=request.get('takeover', False),
+        vhost=request.get('vhost', False),
+        vhost_candidates=tuple(request.get('vhost_candidates', ())),
+        vhost_concurrency=request.get('vhost_concurrency', DEFAULT_VHOST_CONCURRENCY),
+        vhost_endpoint=request.get('vhost_endpoint', ''),
+        vhost_insecure=request.get('vhost_insecure', False),
+        vhost_request_limit=request.get('vhost_request_limit', DEFAULT_VHOST_REQUEST_LIMIT),
+        vhost_runtime_seconds=request.get('vhost_runtime_seconds', DEFAULT_VHOST_RUNTIME_SECONDS),
+        vhost_timeout_seconds=request.get('vhost_timeout_seconds', DEFAULT_VHOST_TIMEOUT_SECONDS),
         wordlist=api_scan_wordlist,
     )
     checkpoint_lock = asyncio.Lock()

--- a/theHarvester/lib/api/static/harvestview/app.css
+++ b/theHarvester/lib/api/static/harvestview/app.css
@@ -577,6 +577,8 @@ a:focus-visible {
 .tabulator .tabulator-footer .tabulator-page-size { min-height: 44px; }
 .tabulator .tabulator-footer .tabulator-page.active { color: var(--nav); background: var(--accent); }
 .value-cell { overflow-wrap: anywhere; font-family: var(--font-mono); font-size: 12px; }
+.vhost-observations { display: grid; gap: 6px; overflow-wrap: anywhere; }
+.vhost-observations span { display: block; font: 11px/1.45 var(--font-mono); }
 .result-actions { display: flex; flex-wrap: wrap; gap: 6px; }
 .result-actions .button { flex: 1 1 118px; white-space: nowrap; }
 .dns-label { display: inline-flex; min-width: 82px; align-items: center; gap: 6px; font-size: 11px; font-weight: 750; }

--- a/theHarvester/lib/api/static/harvestview/app.js
+++ b/theHarvester/lib/api/static/harvestview/app.js
@@ -300,7 +300,15 @@
       ['Recursive DNS runtime', request.dns_recursive_runtime_seconds ? `${request.dns_recursive_runtime_seconds} seconds` : 'Not recorded'],
       ['Screenshots', request.screenshot ? 'Selected' : 'Off'],
       ['Takeover transport', request.takeover ? (request.proxies ? 'Configured proxy' : 'Direct') : 'Off'],
-      ['API endpoint interaction', request.api_scan ? 'Selected' : 'Off']
+      ['API endpoint interaction', request.api_scan ? 'Selected' : 'Off'],
+      ['Virtual-host discovery', request.vhost ? 'Selected' : 'Off'],
+      ['Virtual-host endpoint override', request.vhost ? request.vhost_endpoint || 'Harvested IPs' : 'Not applicable'],
+      ['Virtual-host candidates', request.vhost ? request.vhost_candidates?.join(', ') || 'Harvested hostnames' : 'Not applicable'],
+      ['Virtual-host request budget', request.vhost ? request.vhost_request_limit : 'Not applicable'],
+      ['Virtual-host runtime', request.vhost ? `${request.vhost_runtime_seconds} seconds` : 'Not applicable'],
+      ['Virtual-host timeout', request.vhost ? `${request.vhost_timeout_seconds} seconds` : 'Not applicable'],
+      ['Virtual-host concurrency', request.vhost ? request.vhost_concurrency : 'Not applicable'],
+      ['Virtual-host TLS verification', request.vhost ? (request.vhost_insecure ? 'Disabled' : 'Enabled') : 'Not applicable']
     ];
     if (request.filename) options.unshift(['Imported file', request.filename]);
     nodes.requestOptions.innerHTML = options.map(([label, value]) => `<div><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`).join('');
@@ -381,6 +389,40 @@
     </div>`;
   }
 
+  function vhostObservationsFormatter(cell) {
+    const observations = Array.isArray(cell.getValue()) ? cell.getValue() : [];
+    if (!observations.length) return 'No endpoint evidence';
+    return `<div class="vhost-observations">${observations.map(observation => {
+      const status = observation.status == null ? observation.phase || 'No response' : `HTTP ${observation.status}`;
+      const location = observation.location ? ` → ${observation.location}` : '';
+      const signals = Array.isArray(observation.distinct_signals) && observation.distinct_signals.length
+        ? ` · ${observation.distinct_signals.join(', ')}`
+        : '';
+      const baselines = observation.context_status == null || observation.control_status == null
+        ? ''
+        : ` · IP HTTP ${observation.context_status} · unknown HTTP ${observation.control_status}`;
+      const confirmation = observation.confirmation_body_sha256 ? ' · body confirmed' : '';
+      const tls = observation.tls_verified == null ? '' : observation.tls_verified ? ' · TLS verified' : ' · TLS unverified';
+      const text = `${observation.endpoint || 'Unknown endpoint'} · ${status}${location}${signals}${baselines}${confirmation}${tls}`;
+      return `<span title="${escapeHtml(text)}">${escapeHtml(text)}</span>`;
+    }).join('')}</div>`;
+  }
+
+  function vhostObservationsFilter(headerValue, rowValue) {
+    const query = String(headerValue || '').trim().toLowerCase().replaceAll('-', ' ');
+    const text = (Array.isArray(rowValue) ? rowValue : []).flatMap(observation => [
+      observation.endpoint, observation.status, observation.phase, observation.location,
+      observation.context_status, observation.control_status, observation.confirmation_body_sha256,
+      observation.tls_verified, ...(observation.distinct_signals || [])
+    ]).join(' ').toLowerCase().replaceAll('-', ' ');
+    return text.includes(query);
+  }
+
+  function provenanceFormatter(cell) {
+    const values = Array.isArray(cell.getValue()) ? cell.getValue() : [];
+    return escapeHtml(values.join(', ') || '-');
+  }
+
   function mountResultTable(rows) {
     state.resultTable?.destroy();
     nodes.copySelected.disabled = true;
@@ -389,6 +431,13 @@
       {title: 'Value', field: 'value', formatter: cell => `<span class="value-cell">${escapeHtml(cell.getValue())}</span>`, minWidth: 260, widthGrow: 2, headerFilter: 'input', headerFilterFunc: columnTextFilter, headerFilterPlaceholder: 'Filter values'},
       {title: 'DNS', field: 'dns_status', formatter: dnsFormatter, width: 130, responsive: 1, headerFilter: 'input', headerFilterFunc: columnTextFilter, headerFilterPlaceholder: 'Filter DNS'},
     ];
+    if (state.route === 'hostname' && rows.some(row => Array.isArray(row.observations) && row.observations.length)) {
+      columns.push(
+        {title: 'Virtual-host observations', field: 'observations', formatter: vhostObservationsFormatter, minWidth: 420, widthGrow: 4, variableHeight: true, headerFilter: 'input', headerFilterFunc: vhostObservationsFilter, headerFilterPlaceholder: 'Filter endpoint evidence'},
+        {title: 'Sources', field: 'sources', formatter: provenanceFormatter, minWidth: 130, responsive: 2, headerFilter: 'input', headerFilterFunc: columnTextFilter},
+        {title: 'Produced by', field: 'actions', formatter: provenanceFormatter, minWidth: 130, responsive: 2, headerFilter: 'input', headerFilterFunc: columnTextFilter},
+      );
+    }
     if (state.route === 'hostname') {
       columns.push({
         title: 'Actions', field: 'value', formatter: resultActionFormatter, headerSort: false,
@@ -632,15 +681,29 @@
 
   function selectedActivities() {
     const activities = new Set();
+    const vhost = virtualHostSelection();
     for (const source of state.sources) if (state.selectedSources.has(source.name)) activities.add(source.activity);
     for (const action of state.actions) {
       const field = nodes.newRunForm.elements[ACTION_FIELDS[action.name] || action.name.replaceAll('-', '_')];
       const selected = action.name === 'dns-recursive'
         ? Number(field?.value) > 0
+        : action.name === 'vhost'
+          ? vhost.selected
         : field?.checked;
       if (selected) activities.add(action.activity);
     }
     return activities;
+  }
+
+  function virtualHostSelection() {
+    const endpoint = nodes.newRunForm.elements.vhost_endpoint.value.trim();
+    const candidates = nodes.newRunForm.elements.vhost_candidates.value
+      .split(/\r?\n/).map(value => value.trim()).filter(Boolean);
+    return {
+      endpoint,
+      candidates,
+      selected: nodes.newRunForm.elements.vhost.checked || Boolean(endpoint) || candidates.length > 0,
+    };
   }
 
   function updateActivitySummary() {
@@ -731,12 +794,19 @@
     event.preventDefault();
     showFormError(nodes.newRunError, '');
     const form = new FormData(nodes.newRunForm);
+    const vhost = virtualHostSelection();
     const actionSelected = state.actions.some(action => {
       const field = ACTION_FIELDS[action.name] || action.name.replaceAll('-', '_');
-      return action.name === 'dns-recursive' ? Number(form.get(field)) > 0 : form.has(field);
+      if (action.name === 'dns-recursive') return Number(form.get(field)) > 0;
+      if (action.name === 'vhost') return vhost.selected;
+      return form.has(field);
     });
     if (!state.selectedSources.size && !actionSelected) {
       showFormError(nodes.newRunError, 'Select at least one discovery source or additional activity.');
+      return;
+    }
+    if (!state.selectedSources.size && vhost.selected && (!vhost.endpoint || !vhost.candidates.length)) {
+      showFormError(nodes.newRunError, 'Virtual-host discovery without sources requires both a literal-IP endpoint and at least one candidate hostname.');
       return;
     }
     const payload = {
@@ -751,7 +821,15 @@
       takeover: form.has('takeover'), api_scan: form.has('api_scan'),
       api_scan_paths: form.has('api_scan')
         ? String(form.get('api_scan_paths')).split(/\r?\n/).map(value => value.trim()).filter(Boolean)
-        : []
+        : [],
+      vhost: vhost.selected,
+      vhost_endpoint: vhost.endpoint,
+      vhost_candidates: vhost.candidates,
+      vhost_request_limit: Number(form.get('vhost_request_limit')),
+      vhost_runtime_seconds: Number(form.get('vhost_runtime_seconds')),
+      vhost_timeout_seconds: Number(form.get('vhost_timeout_seconds')),
+      vhost_concurrency: Number(form.get('vhost_concurrency')),
+      vhost_insecure: form.has('vhost_insecure')
     };
     setBusy(nodes.submitRun, true, 'Submitting…');
     try {
@@ -931,6 +1009,9 @@
     updateActivitySummary();
   });
   nodes.newRunForm.addEventListener('change', updateActivitySummary);
+  nodes.newRunForm.addEventListener('input', event => {
+    if (event.target.matches('[name="vhost_endpoint"], [name="vhost_candidates"]')) updateActivitySummary();
+  });
   nodes.dnsResolverFile.addEventListener('change', async () => {
     const file = nodes.dnsResolverFile.files[0];
     if (!file) return;

--- a/theHarvester/lib/api/static/harvestview/index.html
+++ b/theHarvester/lib/api/static/harvestview/index.html
@@ -266,6 +266,43 @@
             <label class="action-choice p2"><input type="checkbox" name="takeover"><span><strong>P2 · Takeover checks</strong><small>Contact discovered hosts, through configured proxies when enabled, for takeover evidence.</small></span></label>
             <label class="action-choice p2"><input type="checkbox" name="api_scan"><span><strong>P2 · API endpoint interaction</strong><small>Contact the target for endpoint evidence.</small></span></label>
           </div>
+          <details class="advanced-execution">
+            <summary>P2 · Virtual-host discovery</summary>
+            <p>Test harvested in-scope hostnames against every harvested literal IP that fits the shared request cap, breadth-first on HTTPS 443 then HTTP 80. This is harvested-candidate testing, not wordlist brute forcing. HTTP Host and TLS SNI stay aligned; candidate DNS and redirects are never used.</p>
+            <div class="form-grid three">
+              <label class="inline-choice"><input id="vhost-enabled" name="vhost" type="checkbox"><span>Probe harvested IPs for virtual hosts</span></label>
+              <label>Literal-IP endpoint override
+                <input id="vhost-endpoint" name="vhost_endpoint" placeholder="https://192.0.2.10:443/" autocomplete="off">
+                <small>Optional: probe only this endpoint instead of harvested IPs. Providing it also enables discovery.</small>
+              </label>
+              <label>Additional candidate hostnames
+                <textarea id="vhost-candidates" name="vhost_candidates" rows="4" placeholder="admin.example.com&#10;preview.example.com"></textarea>
+                <small>Optional: augment in-scope hostnames harvested during this run. Providing a name also enables discovery.</small>
+              </label>
+            </div>
+            <details class="advanced-execution">
+              <summary>Advanced safety controls</summary>
+              <div class="form-grid three">
+                <label>Request budget
+                  <input id="vhost-request-limit" name="vhost_request_limit" type="number" min="5" max="10000" value="100">
+                  <small>Includes context, controls, candidates, and confirmations.</small>
+                </label>
+                <label>Runtime seconds
+                  <input id="vhost-runtime-seconds" name="vhost_runtime_seconds" type="number" min="0.1" max="3600" step="0.1" value="30">
+                  <small>Hard wall-clock cap.</small>
+                </label>
+                <label>Per-request timeout
+                  <input id="vhost-timeout-seconds" name="vhost_timeout_seconds" type="number" min="0.1" max="300" step="0.1" value="5">
+                  <small>Seconds allowed for each request.</small>
+                </label>
+                <label>Concurrency
+                  <input id="vhost-concurrency" name="vhost_concurrency" type="number" min="1" max="100" value="5">
+                  <small>Maximum simultaneous candidate requests.</small>
+                </label>
+                <label class="inline-choice"><input id="vhost-insecure" name="vhost_insecure" type="checkbox"><span>Disable HTTPS certificate verification and record that choice</span></label>
+              </div>
+            </details>
+          </details>
         </fieldset>
 
         <p id="activity-summary" class="activity-summary">P0 selected · P1 off · P2 off</p>

--- a/theHarvester/lib/completed_result.py
+++ b/theHarvester/lib/completed_result.py
@@ -16,6 +16,31 @@ from theHarvester.lib.evidence_types import (
     ResultKind,
     format_utc,
 )
+from theHarvester.lib.virtual_host import VirtualHostObservation, normalize_virtual_host_hostname
+
+
+def virtual_host_details(observations: Iterable[VirtualHostObservation]) -> list[dict[str, object]]:
+    details: list[dict[str, object]] = []
+    for observation in sorted(set(observations), key=VirtualHostObservation.sort_key):
+        record = observation.to_record()
+        details.append({key: value for key, value in record.items() if key not in {'type', 'hostname'}})
+    return details
+
+
+def parse_virtual_host_details(hostname: str, details: object) -> tuple[VirtualHostObservation, ...]:
+    if not isinstance(details, list) or not details:
+        raise ValueError('virtual-host details must be a non-empty array')
+    observations: list[VirtualHostObservation] = []
+    for detail in details:
+        if not isinstance(detail, dict) or {'type', 'hostname'} & set(detail):
+            raise ValueError('virtual-host details must contain endpoint evidence objects')
+        observation = VirtualHostObservation.from_record({'type': 'vhost', 'hostname': hostname, **detail})
+        if observation.hostname != hostname:
+            raise ValueError('virtual-host result value must be a canonical hostname')
+        if detail != virtual_host_details((observation,))[0]:
+            raise ValueError('virtual-host details must use canonical structured evidence')
+        observations.append(observation)
+    return tuple(sorted(set(observations), key=VirtualHostObservation.sort_key))
 
 
 def encode_result_jsonl(
@@ -43,9 +68,13 @@ def parse_result_jsonl(payload: bytes | str) -> tuple[dict[str, object], list[di
     for record in findings:
         sources = record.get('sources', [])
         actions = record.get('actions', [])
+        result_kind = record.get('type')
+        allowed_keys = {'type', 'value', 'sources', 'actions'}
+        if result_kind == 'hostname' and 'observations' in record:
+            allowed_keys.add('observations')
         if (
-            set(record) - {'type', 'value', 'sources', 'actions'}
-            or record.get('type') not in RESULT_KINDS
+            set(record) - allowed_keys
+            or result_kind not in RESULT_KINDS
             or not isinstance(record.get('value'), str)
             or not record['value'].strip()
             or not isinstance(sources, list)
@@ -56,6 +85,12 @@ def parse_result_jsonl(payload: bytes | str) -> tuple[dict[str, object], list[di
             raise ValueError('JSONL findings must contain a known type, non-empty value, and producer names')
         record['sources'] = sorted(set(sources))
         record['actions'] = sorted(set(actions))
+        if result_kind == 'hostname' and 'observations' in record:
+            try:
+                observations = parse_virtual_host_details(record['value'], record.get('observations'))
+            except ValueError as error:
+                raise ValueError(f'JSONL hostname has invalid virtual-host observations: {error}') from error
+            record['observations'] = virtual_host_details(observations)
     return summary, findings
 
 
@@ -135,6 +170,7 @@ class CompletedResult:
     source_executions: tuple[SourceExecution, ...] = ()
     observations: tuple[ResultObservation, ...] = ()
     active_evidence: ActiveEvidence = field(default_factory=ActiveEvidence)
+    virtual_hosts: tuple[VirtualHostObservation, ...] = ()
     evidence_status: EvidenceStatus | None = None
 
     def __post_init__(self) -> None:
@@ -175,6 +211,36 @@ class CompletedResult:
             for _action, artifact in self.active_evidence.artifacts
         ):
             raise ValueError('every artifact must reference a completed result')
+        sorted_virtual_hosts = tuple(sorted(set(self.virtual_hosts), key=VirtualHostObservation.sort_key))
+        if self.virtual_hosts != sorted_virtual_hosts:
+            raise ValueError('virtual-host observations must be deduplicated and sorted')
+        if self.virtual_hosts:
+            try:
+                virtual_host_scope = normalize_virtual_host_hostname(self.target)
+            except ValueError as error:
+                raise ValueError('virtual-host observations require a hostname run target scope') from error
+        for observation in self.virtual_hosts:
+            if observation.hostname == virtual_host_scope or not observation.hostname.endswith(f'.{virtual_host_scope}'):
+                raise ValueError('virtual-host observation must be a descendant of the run target scope')
+            try:
+                canonical = parse_virtual_host_details(
+                    observation.hostname,
+                    virtual_host_details((observation,)),
+                )
+            except ValueError as error:
+                raise ValueError('virtual-host observations must contain canonical distinct evidence') from error
+            if canonical != (observation,):
+                raise ValueError('virtual-host observations must contain canonical distinct evidence')
+        structured_vhost_results = {('hostname', observation.hostname) for observation in self.virtual_hosts}
+        if not structured_vhost_results.issubset(result_set):
+            raise ValueError('every virtual-host observation must reference a hostname result')
+        vhost_action_results = {
+            (observation.kind, observation.value)
+            for action, observation in self.active_evidence.observations
+            if action == 'vhost'
+        }
+        if vhost_action_results != structured_vhost_results:
+            raise ValueError('structured virtual-host evidence must exactly match vhost action provenance')
         if self.evidence_status is not None and self.evidence_status not in EVIDENCE_STATUSES:
             raise ValueError('evidence status must be complete, partial, or failed')
 
@@ -190,6 +256,7 @@ class CompletedResult:
         source_executions: Iterable[SourceExecution] = (),
         observations: Iterable[ResultObservation] = (),
         active_evidence: ActiveEvidence | None = None,
+        virtual_hosts: Iterable[VirtualHostObservation] = (),
         evidence_status: EvidenceStatus | None = None,
     ) -> Self:
         completed_active_evidence = active_evidence if active_evidence is not None else ActiveEvidence()
@@ -201,8 +268,11 @@ class CompletedResult:
                 if not isinstance(value, str) or not value.strip():
                     raise ValueError('results must contain non-empty string values')
                 results.add((kind, value.strip()))
-        for _action, observation in completed_active_evidence.observations:
-            results.add((observation.kind, observation.value))
+        for _action, action_observation in completed_active_evidence.observations:
+            results.add((action_observation.kind, action_observation.value))
+        completed_virtual_hosts = tuple(sorted(set(virtual_hosts), key=VirtualHostObservation.sort_key))
+        for virtual_host in completed_virtual_hosts:
+            results.add(('hostname', virtual_host.hostname))
         return cls(
             run_id=run_id or uuid4(),
             target=target.strip(),
@@ -212,6 +282,7 @@ class CompletedResult:
             source_executions=tuple(source_executions),
             observations=tuple(sorted(set(observations))),
             active_evidence=completed_active_evidence,
+            virtual_hosts=completed_virtual_hosts,
             evidence_status=evidence_status,
         )
 
@@ -261,11 +332,16 @@ class CompletedResult:
 
     def _result_records(self, *, include_actions: bool) -> list[dict[str, object]]:
         sources_by_result: dict[tuple[ResultKind, str], list[str]] = {}
-        for observation in self.observations:
-            sources_by_result.setdefault((observation.kind, observation.value), []).append(observation.source)
+        for source_observation in self.observations:
+            sources_by_result.setdefault((source_observation.kind, source_observation.value), []).append(
+                source_observation.source
+            )
         actions_by_result: dict[tuple[ResultKind, str], list[str]] = {}
         for action, action_observation in self.active_evidence.observations:
             actions_by_result.setdefault((action_observation.kind, action_observation.value), []).append(action)
+        vhosts_by_hostname: dict[str, list[VirtualHostObservation]] = {}
+        for virtual_host in self.virtual_hosts:
+            vhosts_by_hostname.setdefault(virtual_host.hostname, []).append(virtual_host)
         records: list[dict[str, object]] = []
         for kind, value in self.results:
             record: dict[str, object] = {
@@ -275,5 +351,7 @@ class CompletedResult:
             }
             if include_actions and (actions := actions_by_result.get((kind, value))):
                 record['actions'] = actions
+            if kind == 'hostname' and (virtual_hosts := vhosts_by_hostname.get(value)):
+                record['observations'] = virtual_host_details(virtual_hosts)
             records.append(record)
         return records

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -486,10 +486,8 @@ class AsyncFetcher:
         response: aiohttp.ClientResponse,
         *,
         json: bool,
-        delay: int,
         include_metadata: bool = False,
     ) -> Any:
-        await asyncio.sleep(delay)
         if json is False:
             body = await response.text()
         elif include_metadata:
@@ -520,7 +518,6 @@ class AsyncFetcher:
         *,
         json: bool = False,
         json_body: dict[str, Any] | None = None,
-        delay: int = 5,
         request_timeout: int | None = None,
         include_metadata: bool = False,
         **request_kwargs: Any,
@@ -534,7 +531,6 @@ class AsyncFetcher:
                     return await cls._read_response(
                         response,
                         json=json,
-                        delay=delay,
                         include_metadata=include_metadata,
                     )
 
@@ -542,7 +538,6 @@ class AsyncFetcher:
             return await cls._read_response(
                 response,
                 json=json,
-                delay=delay,
                 include_metadata=include_metadata,
             )
 
@@ -611,7 +606,6 @@ class AsyncFetcher:
                         url,
                         json=json,
                         json_body=json_body,
-                        delay=3,
                         include_metadata=include_metadata,
                         **request_kwargs,
                     )
@@ -624,7 +618,6 @@ class AsyncFetcher:
                         data=cls._normalize_data(data) if json_body is None else None,
                         json=json,
                         json_body=json_body,
-                        delay=3,
                         include_metadata=include_metadata,
                     )
             else:
@@ -638,7 +631,6 @@ class AsyncFetcher:
                         params=params,
                         json=json,
                         json_body=json_body,
-                        delay=3,
                         include_metadata=include_metadata,
                     )
         except (aiohttp.ClientError, TimeoutError, OSError, ssl.SSLError, UnicodeDecodeError, ValueError):
@@ -697,7 +689,6 @@ class AsyncFetcher:
                     method,
                     url,
                     json=json,
-                    delay=5,
                     request_timeout=request_timeout,
                     include_metadata=include_metadata,
                     **request_kwargs,

--- a/theHarvester/lib/database.py
+++ b/theHarvester/lib/database.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+import json
 import logging
 import sqlite3
 from collections import Counter
@@ -45,14 +46,17 @@ from theHarvester.lib.completed_result import (
     ResultObservation,
     SourceExecution,
     SourceYield,
+    parse_virtual_host_details,
+    virtual_host_details,
 )
+from theHarvester.lib.virtual_host import VirtualHostObservation
 
 if TYPE_CHECKING:
     from theHarvester.lib.evidence_types import EvidenceStatus
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 7
+SCHEMA_VERSION = 8
 _DEFAULT_DATABASE = Path('~/.local/share/theHarvester/stash.sqlite').expanduser()
 
 _LEGACY_RESULT_KIND_RENAMES = {
@@ -63,6 +67,7 @@ _LEGACY_RESULT_KIND_RENAMES = {
     'ip-address': 'ip',
     'linkedin-link': 'url',
     'linkedinlinks': 'url',
+    'vhost': 'hostname',
 }
 
 
@@ -125,6 +130,7 @@ class _ResultRow(_Base):
     position: Mapped[int] = mapped_column(primary_key=True)
     kind: Mapped[str] = mapped_column(Text)
     value: Mapped[str] = mapped_column(Text)
+    details_json: Mapped[str | None] = mapped_column(Text)
 
 
 class _ExecutionRow(_Base):
@@ -401,6 +407,9 @@ class _SQLiteDatabase:
                         run_column_rows = await connection.exec_driver_sql('PRAGMA table_info(runs)')
                         if 'evidence_status' not in {row[1] for row in run_column_rows}:
                             await connection.exec_driver_sql('ALTER TABLE runs ADD COLUMN evidence_status TEXT')
+                        result_column_rows = await connection.exec_driver_sql('PRAGMA table_info(results)')
+                        if 'details_json' not in {row[1] for row in result_column_rows}:
+                            await connection.exec_driver_sql('ALTER TABLE results ADD COLUMN details_json TEXT')
                         if has_legacy_results:
                             await connection.exec_driver_sql(
                                 'INSERT INTO legacy_observations (domain, resource, kind, discovered_on, source) '
@@ -694,6 +703,9 @@ class ResultStore:
 
     async def save_run(self, result: CompletedResult) -> None:
         run_id = str(result.run_id)
+        vhosts_by_hostname: dict[str, list[VirtualHostObservation]] = {}
+        for observation in result.virtual_hosts:
+            vhosts_by_hostname.setdefault(observation.hostname, []).append(observation)
         async with self._session() as session:
             try:
                 session.add(
@@ -707,7 +719,22 @@ class ResultStore:
                 )
                 await session.flush()
                 session.add_all(
-                    _ResultRow(run_id=run_id, position=position, kind=kind, value=value)
+                    _ResultRow(
+                        run_id=run_id,
+                        position=position,
+                        kind=kind,
+                        value=value,
+                        details_json=(
+                            json.dumps(
+                                virtual_host_details(vhosts_by_hostname[value]),
+                                ensure_ascii=False,
+                                separators=(',', ':'),
+                                sort_keys=True,
+                            )
+                            if kind == 'hostname' and value in vhosts_by_hostname
+                            else None
+                        ),
+                    )
                     for position, (kind, value) in enumerate(result.results)
                 )
                 producers: list[tuple[str, str, SourceExecution | ActionExecution]] = [
@@ -794,6 +821,29 @@ class ResultStore:
             ).all()
         results_by_position = {row.position: row for row in rows}
         executions_by_position = {row.position: row for row in execution_rows}
+        vhost_execution_positions = {
+            row.position for row in execution_rows if row.producer_kind == 'action' and row.name == 'vhost'
+        }
+        vhost_result_positions = {
+            row.result_position for row in origin_rows if row.execution_position in vhost_execution_positions
+        }
+        virtual_hosts: list[VirtualHostObservation] = []
+        for result_row in rows:
+            is_vhost_result = result_row.position in vhost_result_positions
+            if is_vhost_result and (result_row.kind != 'hostname' or result_row.details_json is None):
+                raise ResultStoreError(f'Persisted virtual-host details are missing: {result_row.value}')
+            if result_row.details_json is None:
+                continue
+            if result_row.kind != 'hostname' or not is_vhost_result:
+                raise ResultStoreError('Persisted virtual-host details require hostname results with vhost provenance')
+            try:
+                details = json.loads(result_row.details_json)
+                parsed_virtual_hosts = parse_virtual_host_details(result_row.value, details)
+            except (json.JSONDecodeError, ValueError) as error:
+                raise ResultStoreError(f'Persisted virtual-host details are invalid: {result_row.value}') from error
+            if details != virtual_host_details(parsed_virtual_hosts):
+                raise ResultStoreError(f'Persisted virtual-host details are not canonical: {result_row.value}')
+            virtual_hosts.extend(parsed_virtual_hosts)
         unknown_producer_kinds = {row.producer_kind for row in execution_rows} - {'source', 'action'}
         if unknown_producer_kinds:
             raise ResultStoreError(f'Unknown persisted producer kind: {sorted(unknown_producer_kinds)[0]}')
@@ -836,21 +886,21 @@ class ResultStore:
                 )
             )
         action_executions: list[ActionExecution] = []
-        for row in execution_rows:
-            if row.producer_kind != 'action':
+        for execution_row in execution_rows:
+            if execution_row.producer_kind != 'action':
                 continue
-            action_observations = tuple(sorted(observations_by_execution.get(row.position, [])))
-            if row.result_count != len(action_observations):
-                raise ResultStoreError(f'Persisted action result count does not match origins: {row.name}')
+            action_observations = tuple(sorted(observations_by_execution.get(execution_row.position, [])))
+            if execution_row.result_count != len(action_observations):
+                raise ResultStoreError(f'Persisted action result count does not match origins: {execution_row.name}')
             action_executions.append(
                 ActionExecution(
-                    action=row.name,
-                    status=cast('ExecutionStatus', row.status),
-                    duration_ms=row.duration_ms,
+                    action=execution_row.name,
+                    status=cast('ExecutionStatus', execution_row.status),
+                    duration_ms=execution_row.duration_ms,
                     observations=action_observations,
-                    artifacts=tuple(sorted(artifacts_by_execution.get(row.position, []))),
-                    error_type=row.error_type,
-                    stop_reason=row.stop_reason,
+                    artifacts=tuple(sorted(artifacts_by_execution.get(execution_row.position, []))),
+                    error_type=execution_row.error_type,
+                    stop_reason=execution_row.stop_reason,
                 )
             )
         return CompletedResult(
@@ -873,6 +923,7 @@ class ResultStore:
             ),
             observations=tuple(sorted(source_observations)),
             active_evidence=ActiveEvidence(executions=tuple(action_executions)),
+            virtual_hosts=tuple(sorted(set(virtual_hosts), key=VirtualHostObservation.sort_key)),
             evidence_status=cast('EvidenceStatus', parent.evidence_status) if parent.evidence_status is not None else None,
         )
 

--- a/theHarvester/lib/enumeration.py
+++ b/theHarvester/lib/enumeration.py
@@ -4,6 +4,12 @@ from dataclasses import dataclass
 from typing import Any, Self
 
 from theHarvester.lib.recursive_dns import DEFAULT_RECURSIVE_DNS_QUERY_LIMIT
+from theHarvester.lib.virtual_host import (
+    DEFAULT_VHOST_CONCURRENCY,
+    DEFAULT_VHOST_REQUEST_LIMIT,
+    DEFAULT_VHOST_RUNTIME_SECONDS,
+    DEFAULT_VHOST_TIMEOUT_SECONDS,
+)
 
 DEFAULT_RESULT_LIMIT = 500
 DEFAULT_RESULT_START = 0
@@ -35,6 +41,14 @@ class EnumerationOptions:
     filename: str = ''
     wordlist: str = ''
     api_scan: bool = False
+    vhost: bool = False
+    vhost_endpoint: str = ''
+    vhost_candidates: tuple[str, ...] = ()
+    vhost_request_limit: int = DEFAULT_VHOST_REQUEST_LIMIT
+    vhost_runtime_seconds: float = DEFAULT_VHOST_RUNTIME_SECONDS
+    vhost_timeout_seconds: float = DEFAULT_VHOST_TIMEOUT_SECONDS
+    vhost_concurrency: int = DEFAULT_VHOST_CONCURRENCY
+    vhost_insecure: bool = False
     quiet: bool = False
     verbose: bool = False
 
@@ -69,6 +83,14 @@ class EnumerationOptions:
             filename=getattr(value, 'filename', ''),
             wordlist=getattr(value, 'wordlist', ''),
             api_scan=getattr(value, 'api_scan', False),
+            vhost=getattr(value, 'vhost', False),
+            vhost_endpoint=getattr(value, 'vhost_endpoint', ''),
+            vhost_candidates=tuple(getattr(value, 'vhost_candidates', ())),
+            vhost_request_limit=getattr(value, 'vhost_request_limit', DEFAULT_VHOST_REQUEST_LIMIT),
+            vhost_runtime_seconds=getattr(value, 'vhost_runtime_seconds', DEFAULT_VHOST_RUNTIME_SECONDS),
+            vhost_timeout_seconds=getattr(value, 'vhost_timeout_seconds', DEFAULT_VHOST_TIMEOUT_SECONDS),
+            vhost_concurrency=getattr(value, 'vhost_concurrency', DEFAULT_VHOST_CONCURRENCY),
+            vhost_insecure=getattr(value, 'vhost_insecure', False),
             quiet=getattr(value, 'quiet', False),
             verbose=getattr(value, 'verbose', False),
         )

--- a/theHarvester/lib/evidence_types.py
+++ b/theHarvester/lib/evidence_types.py
@@ -23,7 +23,6 @@ ResultKind = Literal[
     'takeover',
     'twitter-person',
     'url',
-    'vhost',
 ]
 ExecutionStatus = Literal['completed', 'partial', 'failed', 'rate-limited', 'skipped']
 EvidenceStatus = Literal['complete', 'partial', 'failed']

--- a/theHarvester/lib/output.py
+++ b/theHarvester/lib/output.py
@@ -14,6 +14,7 @@ class _OperatorOutputHandler(logging.Handler):
     def emit(self, record: logging.LogRecord) -> None:
         try:
             sys.stdout.write(f'{self.format(record)}\n')
+            sys.stdout.flush()
         except Exception:
             self.handleError(record)
 

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -19,6 +19,7 @@ ACTION_ACTIVITIES: Final = {
     'api-scan': ActivityClass.DIRECT,
     'screenshot': ActivityClass.DIRECT,
     'takeover': ActivityClass.DIRECT,
+    'vhost': ActivityClass.DIRECT,
 }
 ACTION_REQUEST_FIELDS: Final = {
     **{name: name.replace('-', '_') for name in ACTION_ACTIVITIES},
@@ -28,6 +29,8 @@ ACTION_REQUEST_FIELDS: Final = {
 
 def selected_action_names(request: Mapping[str, object]) -> tuple[str, ...]:
     def selected(name: str) -> bool:
+        if name == 'vhost':
+            return bool(request.get('vhost') or request.get('vhost_endpoint') or request.get('vhost_candidates'))
         value = request.get(ACTION_REQUEST_FIELDS[name])
         return isinstance(value, (int, float)) and value > 0 if name == 'dns-recursive' else bool(value)
 

--- a/theHarvester/lib/virtual_host.py
+++ b/theHarvester/lib/virtual_host.py
@@ -1,3 +1,5 @@
+"""Probe authorized IP endpoints for virtual hosts without resolving candidate names."""
+
 from __future__ import annotations
 
 import asyncio

--- a/theHarvester/lib/virtual_host.py
+++ b/theHarvester/lib/virtual_host.py
@@ -1,0 +1,1186 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import ipaddress
+import logging
+import math
+import re
+import secrets
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Literal, Self, cast
+from urllib.parse import urlsplit
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+ProbePhase = Literal['connect', 'tls', 'headers', 'body']
+VirtualHostClassification = Literal['distinct', 'default', 'indeterminate']
+DEFAULT_VHOST_CONCURRENCY = 5
+DEFAULT_VHOST_REQUEST_LIMIT = 100
+DEFAULT_VHOST_RUNTIME_SECONDS = 30.0
+DEFAULT_VHOST_TIMEOUT_SECONDS = 5.0
+VHOST_BODY_LIMIT = 1024 * 1024
+VHOST_CONTROL_COUNT = 3
+VHOST_BASELINE_REQUEST_COUNT = 1 + VHOST_CONTROL_COUNT
+
+
+@dataclass(frozen=True, slots=True)
+class VirtualHostLimits:
+    request_limit: int = DEFAULT_VHOST_REQUEST_LIMIT
+    runtime_seconds: float = DEFAULT_VHOST_RUNTIME_SECONDS
+    timeout_seconds: float = DEFAULT_VHOST_TIMEOUT_SECONDS
+    concurrency: int = DEFAULT_VHOST_CONCURRENCY
+
+    def __post_init__(self) -> None:
+        if isinstance(self.request_limit, bool) or not isinstance(self.request_limit, int):
+            raise ValueError('virtual-host request limit must be an integer')
+        if isinstance(self.concurrency, bool) or not isinstance(self.concurrency, int):
+            raise ValueError('virtual-host concurrency must be an integer')
+        if self.request_limit <= VHOST_BASELINE_REQUEST_COUNT:
+            raise ValueError(f'virtual-host request limit must be greater than {VHOST_BASELINE_REQUEST_COUNT}')
+        if (
+            isinstance(self.runtime_seconds, bool)
+            or not isinstance(self.runtime_seconds, int | float)
+            or not math.isfinite(self.runtime_seconds)
+            or self.runtime_seconds <= 0
+        ):
+            raise ValueError('virtual-host runtime seconds must be positive and finite')
+        if (
+            isinstance(self.timeout_seconds, bool)
+            or not isinstance(self.timeout_seconds, int | float)
+            or not math.isfinite(self.timeout_seconds)
+            or self.timeout_seconds <= 0
+        ):
+            raise ValueError('virtual-host timeout seconds must be positive and finite')
+        if self.concurrency <= 0:
+            raise ValueError('virtual-host concurrency must be positive')
+
+
+def normalize_virtual_host_hostname(value: str) -> str:
+    hostname = value.strip().rstrip('.').lower()
+    if not hostname:
+        raise ValueError('virtual-host candidate must not be empty')
+    try:
+        hostname = hostname.encode('idna').decode('ascii')
+    except UnicodeError as error:
+        raise ValueError('virtual-host candidate must be a valid hostname') from error
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    else:
+        raise ValueError('virtual-host candidate must be a hostname, not an IP address')
+    labels = hostname.split('.')
+    if len(hostname) > 253 or any(
+        not label
+        or len(label) > 63
+        or label.startswith('-')
+        or label.endswith('-')
+        or not all(character.isalnum() or character == '-' for character in label)
+        for label in labels
+    ):
+        raise ValueError('virtual-host candidate must be a valid hostname')
+    return hostname
+
+
+def _candidate_shape(candidate: str, scope: str) -> tuple[int, ...]:
+    if candidate == scope:
+        return (1,)
+    relative_name = candidate[: -(len(scope) + 1)]
+    return tuple(len(label) for label in relative_name.split('.'))
+
+
+def normalize_virtual_host_endpoint(endpoint: str) -> str:
+    parsed = urlsplit(endpoint.strip())
+    if parsed.scheme not in {'http', 'https'}:
+        raise ValueError('virtual-host endpoint scheme must be http or https')
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError('virtual-host endpoint must not contain user information')
+    if parsed.path not in {'', '/'} or parsed.query or parsed.fragment:
+        raise ValueError('virtual-host endpoint must contain only scheme, literal IP, and optional port')
+    try:
+        address = ipaddress.ip_address(parsed.hostname or '')
+    except ValueError as error:
+        raise ValueError('virtual-host endpoint must use a literal IP address') from error
+    try:
+        port = parsed.port if parsed.port is not None else (443 if parsed.scheme == 'https' else 80)
+    except ValueError as error:
+        raise ValueError('virtual-host endpoint port must be between 1 and 65535') from error
+    if not 1 <= port <= 65535:
+        raise ValueError('virtual-host endpoint port must be between 1 and 65535')
+    authority = f'[{address.compressed}]' if address.version == 6 else address.compressed
+    return f'{parsed.scheme}://{authority}:{port}/'
+
+
+def normalize_virtual_host_candidates(scope: str, candidates: tuple[str, ...]) -> tuple[str, ...]:
+    normalized_scope = normalize_virtual_host_hostname(scope)
+    normalized_candidates: list[str] = []
+    for candidate in candidates:
+        normalized = normalize_virtual_host_hostname(candidate)
+        if normalized != normalized_scope and not normalized.endswith(f'.{normalized_scope}'):
+            raise ValueError(f'virtual-host candidate is outside authorized scope: {candidate}')
+        if normalized not in normalized_candidates:
+            normalized_candidates.append(normalized)
+    return tuple(normalized_candidates)
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class VirtualHostRequest:
+    endpoint: str
+    scope: str
+    candidates: tuple[str, ...]
+    limits: VirtualHostLimits
+    insecure: bool
+
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        scope: str,
+        candidates: tuple[str, ...],
+        limits: VirtualHostLimits | None = None,
+        insecure: bool = False,
+    ) -> None:
+        normalized_endpoint = normalize_virtual_host_endpoint(endpoint)
+        normalized_scope = normalize_virtual_host_hostname(scope)
+        normalized_candidates = normalize_virtual_host_candidates(normalized_scope, candidates)
+        if not normalized_candidates:
+            raise ValueError('virtual-host discovery requires at least one candidate')
+        normalized_limits = limits if limits is not None else VirtualHostLimits()
+        if not isinstance(normalized_limits, VirtualHostLimits):
+            raise ValueError('virtual-host limits must be VirtualHostLimits')
+        if not isinstance(insecure, bool):
+            raise ValueError('virtual-host insecure must be a boolean')
+        shape_counts: dict[tuple[int, ...], int] = {}
+        for candidate in normalized_candidates:
+            shape = _candidate_shape(candidate, normalized_scope)
+            if candidate != normalized_scope:
+                shape_counts[shape] = shape_counts.get(shape, 0) + 1
+            else:
+                shape_counts.setdefault(shape, 0)
+        for shape, candidate_count in shape_counts.items():
+            if 36 ** sum(shape) - candidate_count < VHOST_CONTROL_COUNT:
+                raise ValueError('virtual-host candidate shape leaves fewer than three available unknown controls')
+        control_shape_count = len(shape_counts)
+        minimum_request_count = 1 + VHOST_CONTROL_COUNT * control_shape_count
+        if normalized_limits.request_limit <= minimum_request_count:
+            raise ValueError(
+                f'virtual-host request limit must be greater than the {minimum_request_count} required context and control requests'
+            )
+        object.__setattr__(self, 'endpoint', normalized_endpoint)
+        object.__setattr__(self, 'scope', normalized_scope)
+        object.__setattr__(self, 'candidates', tuple(normalized_candidates))
+        object.__setattr__(self, 'limits', normalized_limits)
+        object.__setattr__(self, 'insecure', insecure)
+
+
+@dataclass(frozen=True, slots=True)
+class VirtualHostDiscoveryResult:
+    context: ProbeObservation
+    controls: tuple[ProbeObservation, ...]
+    observations: tuple[VirtualHostObservation, ...]
+    request_count: int
+    attempted_candidate_count: int
+    stop_reason: str
+    request_error_count: int = 0
+    request_error_types: tuple[str, ...] = ()
+    scan_error_type: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeObservation:
+    hostname: str
+    http_host: str
+    tls_server_name: str | None
+    phase: ProbePhase
+    status: int | None = None
+    location: str | None = None
+    body: bytes = b''
+    body_truncated: bool = False
+    tls_verified: bool | None = None
+    error_type: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class VirtualHostObservation:
+    endpoint: str
+    hostname: str
+    http_host: str
+    tls_server_name: str | None
+    classification: VirtualHostClassification
+    phase: ProbePhase
+    status: int | None
+    location: str | None
+    body_sha256: str
+    body_size: int
+    body_truncated: bool
+    tls_verified: bool | None
+    error_type: str | None
+    distinct_signals: tuple[str, ...]
+    reflection_normalized: bool
+    needs_confirmation: bool
+    context_phase: ProbePhase | None
+    context_status: int | None
+    context_location: str | None
+    context_body_sha256: str | None
+    context_body_size: int | None
+    context_body_truncated: bool | None
+    control_phase: ProbePhase | None
+    control_status: int | None
+    control_location: str | None
+    control_body_sha256: str | None
+    control_body_size: int | None
+    control_body_truncated: bool | None
+    confirmation_body_sha256: str | None
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, object]) -> Self:
+        if record.get('type') != 'vhost':
+            raise ValueError('virtual-host record type must be vhost')
+        hostname_value = record.get('hostname')
+        endpoint_value = record.get('endpoint')
+        if not isinstance(hostname_value, str) or not isinstance(endpoint_value, str):
+            raise ValueError('virtual-host record must identify an endpoint and hostname')
+        hostname = normalize_virtual_host_hostname(hostname_value)
+        endpoint = normalize_virtual_host_endpoint(endpoint_value)
+        parsed = urlsplit(endpoint)
+        port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+        expected_http_host = _authority(hostname, parsed.scheme, port)
+        expected_tls_server_name = hostname if parsed.scheme == 'https' else None
+        if record.get('http_host') != expected_http_host or record.get('tls_server_name') != expected_tls_server_name:
+            raise ValueError('virtual-host record must keep HTTP Host and TLS SNI aligned')
+        if record.get('classification') != 'distinct':
+            raise ValueError('completed virtual-host evidence must be classified distinct')
+        phase = record.get('phase')
+        if phase != 'body':
+            raise ValueError('completed virtual-host evidence must reach the response body')
+        status = record.get('status')
+        if isinstance(status, bool) or not isinstance(status, int) or not 100 <= status <= 599:
+            raise ValueError('virtual-host record has an invalid HTTP status')
+        location = record.get('location')
+        if location is not None and not isinstance(location, str):
+            raise ValueError('virtual-host record has an invalid location')
+        body_sha256 = record.get('body_sha256')
+        if (
+            not isinstance(body_sha256, str)
+            or len(body_sha256) != 64
+            or any(character not in '0123456789abcdef' for character in body_sha256)
+        ):
+            raise ValueError('virtual-host record has an invalid body digest')
+        body_size = record.get('body_size')
+        if isinstance(body_size, bool) or not isinstance(body_size, int) or body_size < 0:
+            raise ValueError('virtual-host record has an invalid body size')
+        body_truncated = record.get('body_truncated')
+        reflection_normalized = record.get('reflection_normalized')
+        if not isinstance(body_truncated, bool) or not isinstance(reflection_normalized, bool):
+            raise ValueError('virtual-host record has invalid body flags')
+        context_phase = record.get('context_phase')
+        if context_phase != 'body':
+            raise ValueError('virtual-host context evidence must reach the response body')
+        context_status = record.get('context_status')
+        if isinstance(context_status, bool) or not isinstance(context_status, int) or not 100 <= context_status <= 599:
+            raise ValueError('virtual-host record has an invalid context HTTP status')
+        context_location = record.get('context_location')
+        if context_location is not None and not isinstance(context_location, str):
+            raise ValueError('virtual-host record has an invalid context location')
+        context_body_sha256 = record.get('context_body_sha256')
+        if (
+            not isinstance(context_body_sha256, str)
+            or len(context_body_sha256) != 64
+            or any(character not in '0123456789abcdef' for character in context_body_sha256)
+        ):
+            raise ValueError('virtual-host record has an invalid context body digest')
+        context_body_size = record.get('context_body_size')
+        if isinstance(context_body_size, bool) or not isinstance(context_body_size, int) or context_body_size < 0:
+            raise ValueError('virtual-host record has an invalid context body size')
+        context_body_truncated = record.get('context_body_truncated')
+        if not isinstance(context_body_truncated, bool):
+            raise ValueError('virtual-host record has an invalid context body flag')
+        control_phase = record.get('control_phase')
+        if control_phase != 'body':
+            raise ValueError('virtual-host control evidence must reach the response body')
+        control_status = record.get('control_status')
+        if isinstance(control_status, bool) or not isinstance(control_status, int) or not 100 <= control_status <= 599:
+            raise ValueError('virtual-host record has an invalid control HTTP status')
+        control_location = record.get('control_location')
+        if control_location is not None and not isinstance(control_location, str):
+            raise ValueError('virtual-host record has an invalid control location')
+        control_body_sha256 = record.get('control_body_sha256')
+        if (
+            not isinstance(control_body_sha256, str)
+            or len(control_body_sha256) != 64
+            or any(character not in '0123456789abcdef' for character in control_body_sha256)
+        ):
+            raise ValueError('virtual-host record has an invalid control body digest')
+        control_body_size = record.get('control_body_size')
+        if isinstance(control_body_size, bool) or not isinstance(control_body_size, int) or control_body_size < 0:
+            raise ValueError('virtual-host record has an invalid control body size')
+        control_body_truncated = record.get('control_body_truncated')
+        if not isinstance(control_body_truncated, bool):
+            raise ValueError('virtual-host record has an invalid control body flag')
+        tls_verified = record.get('tls_verified')
+        if (parsed.scheme == 'https' and not isinstance(tls_verified, bool)) or (
+            parsed.scheme == 'http' and tls_verified is not None
+        ):
+            raise ValueError('virtual-host record has invalid TLS verification evidence')
+        if 'error_type' in record:
+            raise ValueError('virtual-host records must not serialize transient transport errors')
+        confirmation_body_sha256 = record.get('confirmation_body_sha256')
+        if confirmation_body_sha256 is not None and (
+            not isinstance(confirmation_body_sha256, str)
+            or len(confirmation_body_sha256) != 64
+            or any(character not in '0123456789abcdef' for character in confirmation_body_sha256)
+        ):
+            raise ValueError('virtual-host record has an invalid confirmation body digest')
+        if confirmation_body_sha256 is not None and confirmation_body_sha256 != body_sha256:
+            raise ValueError('virtual-host confirmation must match the candidate body digest')
+        signals_value = record.get('distinct_signals')
+        if (
+            not isinstance(signals_value, list)
+            or not signals_value
+            or any(not isinstance(signal, str) or signal not in _FINGERPRINT_SIGNALS for signal in signals_value)
+            or len(signals_value) != len(set(signals_value))
+        ):
+            raise ValueError('virtual-host record has invalid distinct signals')
+        candidate_fingerprint = _Fingerprint(
+            phase='body',
+            status=status,
+            location=location,
+            body_sha256=body_sha256,
+            body_size=body_size,
+            body_truncated=body_truncated,
+            error_type=None,
+        )
+        context_fingerprint = _Fingerprint(
+            phase='body',
+            status=context_status,
+            location=context_location,
+            body_sha256=context_body_sha256,
+            body_size=context_body_size,
+            body_truncated=context_body_truncated,
+            error_type=None,
+        )
+        control_fingerprint = _Fingerprint(
+            phase='body',
+            status=control_status,
+            location=control_location,
+            body_sha256=control_body_sha256,
+            body_size=control_body_size,
+            body_truncated=control_body_truncated,
+            error_type=None,
+        )
+        confirmation_fingerprint = candidate_fingerprint if confirmation_body_sha256 is not None else None
+        classification, actual_signals, needs_confirmation, _confirmation_used = _classify_fingerprints(
+            candidate_fingerprint,
+            context_fingerprint,
+            (control_fingerprint,) * VHOST_CONTROL_COUNT,
+            confirmation_fingerprint,
+        )
+        if classification != 'distinct' or needs_confirmation:
+            raise ValueError('virtual-host record does not contain confirmed distinct evidence')
+        if tuple(signals_value) != actual_signals:
+            raise ValueError('virtual-host record distinct signals do not match baseline evidence')
+        return cls(
+            endpoint=endpoint,
+            hostname=hostname,
+            http_host=expected_http_host,
+            tls_server_name=expected_tls_server_name,
+            classification='distinct',
+            phase=cast('ProbePhase', phase),
+            status=status,
+            location=location,
+            body_sha256=body_sha256,
+            body_size=body_size,
+            body_truncated=body_truncated,
+            tls_verified=cast('bool | None', tls_verified),
+            error_type=None,
+            distinct_signals=tuple(signals_value),
+            reflection_normalized=reflection_normalized,
+            needs_confirmation=False,
+            context_phase='body',
+            context_status=context_status,
+            context_location=context_location,
+            context_body_sha256=context_body_sha256,
+            context_body_size=context_body_size,
+            context_body_truncated=context_body_truncated,
+            control_phase=cast('ProbePhase', control_phase),
+            control_status=control_status,
+            control_location=control_location,
+            control_body_sha256=control_body_sha256,
+            control_body_size=control_body_size,
+            control_body_truncated=control_body_truncated,
+            confirmation_body_sha256=cast('str | None', confirmation_body_sha256),
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            'type': 'vhost',
+            'endpoint': self.endpoint,
+            'hostname': self.hostname,
+            'http_host': self.http_host,
+            'tls_server_name': self.tls_server_name,
+            'classification': self.classification,
+            'phase': self.phase,
+            'status': self.status,
+            'location': self.location,
+            'body_sha256': self.body_sha256,
+            'body_size': self.body_size,
+            'body_truncated': self.body_truncated,
+            'context_phase': self.context_phase,
+            'context_status': self.context_status,
+            'context_location': self.context_location,
+            'context_body_sha256': self.context_body_sha256,
+            'context_body_size': self.context_body_size,
+            'context_body_truncated': self.context_body_truncated,
+            'control_phase': self.control_phase,
+            'control_status': self.control_status,
+            'control_location': self.control_location,
+            'control_body_sha256': self.control_body_sha256,
+            'control_body_size': self.control_body_size,
+            'control_body_truncated': self.control_body_truncated,
+            'confirmation_body_sha256': self.confirmation_body_sha256,
+            'tls_verified': self.tls_verified,
+            'distinct_signals': list(self.distinct_signals),
+            'reflection_normalized': self.reflection_normalized,
+        }
+
+    def sort_key(self) -> tuple[object, ...]:
+        return (
+            self.endpoint,
+            self.hostname,
+            self.http_host,
+            self.tls_server_name or '',
+            self.classification,
+            self.phase,
+            self.status if self.status is not None else -1,
+            self.location or '',
+            self.body_sha256,
+            self.body_size,
+            self.body_truncated,
+            self.context_phase or '',
+            self.context_status if self.context_status is not None else -1,
+            self.context_location or '',
+            self.context_body_sha256 or '',
+            self.context_body_size if self.context_body_size is not None else -1,
+            -1 if self.context_body_truncated is None else int(self.context_body_truncated),
+            self.control_phase or '',
+            self.control_status if self.control_status is not None else -1,
+            self.control_location or '',
+            self.control_body_sha256 or '',
+            self.control_body_size if self.control_body_size is not None else -1,
+            -1 if self.control_body_truncated is None else int(self.control_body_truncated),
+            self.confirmation_body_sha256 or '',
+            -1 if self.tls_verified is None else int(self.tls_verified),
+            self.error_type or '',
+            self.distinct_signals,
+            self.reflection_normalized,
+            self.needs_confirmation,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HarvestedVirtualHostResult:
+    observations: tuple[VirtualHostObservation, ...]
+    request_count: int
+    endpoint_count: int
+    total_endpoint_count: int
+    candidate_endpoint_count: int
+    total_candidate_endpoint_count: int
+    stop_reason: str
+    request_error_count: int = 0
+    request_error_types: tuple[str, ...] = ()
+    scan_error_type: str | None = None
+
+
+class VirtualHostDiscoveryCancelled(asyncio.CancelledError):
+    """Carry completed virtual-host evidence while preserving cancellation."""
+
+    def __init__(self, result: HarvestedVirtualHostResult) -> None:
+        super().__init__('virtual-host discovery cancelled')
+        self.result = result
+
+
+@dataclass(frozen=True, slots=True)
+class _Fingerprint:
+    phase: ProbePhase
+    status: int | None
+    location: str | None
+    body_sha256: str
+    body_size: int
+    body_truncated: bool
+    error_type: str | None
+
+
+_FINGERPRINT_SIGNALS = ('phase', 'status', 'location', 'body_size', 'body_sha256')
+_BODY_SIGNALS = {'body_size', 'body_sha256'}
+
+
+def _usable_fingerprint(fingerprint: _Fingerprint) -> bool:
+    return fingerprint.error_type is None and fingerprint.phase == 'body' and fingerprint.status is not None
+
+
+def _fingerprint_signals(candidate: _Fingerprint, baseline: _Fingerprint) -> tuple[str, ...]:
+    signals = [signal for signal in ('phase', 'status', 'location') if getattr(candidate, signal) != getattr(baseline, signal)]
+    if not candidate.body_truncated and not baseline.body_truncated:
+        if candidate.body_size != baseline.body_size:
+            signals.append('body_size')
+        if candidate.body_sha256 != baseline.body_sha256:
+            signals.append('body_sha256')
+    return tuple(signals)
+
+
+def _classify_fingerprints(
+    candidate: _Fingerprint,
+    context: _Fingerprint,
+    controls: tuple[_Fingerprint, ...],
+    confirmation: _Fingerprint | None = None,
+) -> tuple[VirtualHostClassification, tuple[str, ...], bool, bool]:
+    if len(controls) < VHOST_CONTROL_COUNT:
+        raise ValueError('virtual-host classification requires at least three controls')
+    controls_are_stable = len(set(controls)) == 1 and _usable_fingerprint(controls[0])
+    if not controls_are_stable or not _usable_fingerprint(context) or not _usable_fingerprint(candidate):
+        return 'indeterminate', (), False, False
+    control = controls[0]
+    matches_control = not candidate.body_truncated and not control.body_truncated and candidate == control
+    matches_context = not candidate.body_truncated and not context.body_truncated and candidate == context
+    if matches_control or matches_context:
+        return 'default', (), False, False
+    control_signals = _fingerprint_signals(candidate, control)
+    context_signals = _fingerprint_signals(candidate, context)
+    distinct_signals = tuple(signal for signal in _FINGERPRINT_SIGNALS if signal in set(control_signals) | set(context_signals))
+    if not control_signals or not context_signals:
+        return 'indeterminate', distinct_signals, False, False
+    needs_confirmation = set(control_signals) <= _BODY_SIGNALS or set(context_signals) <= _BODY_SIGNALS
+    if not needs_confirmation:
+        return 'distinct', distinct_signals, False, False
+    if confirmation is None:
+        return 'indeterminate', distinct_signals, True, False
+    confirmed = _usable_fingerprint(confirmation) and not confirmation.body_truncated and confirmation == candidate
+    return ('distinct' if confirmed else 'indeterminate'), distinct_signals, False, confirmed
+
+
+def _authority(hostname: str, scheme: str, port: int) -> str:
+    try:
+        address = ipaddress.ip_address(hostname)
+        hostname = f'[{address.compressed}]' if address.version == 6 else address.compressed
+    except ValueError:
+        pass
+    default_port = 443 if scheme == 'https' else 80
+    return hostname if port == default_port else f'{hostname}:{port}'
+
+
+def _tls_verified(scheme: str, insecure: bool) -> bool | None:
+    return None if scheme != 'https' else not insecure
+
+
+async def _probe(
+    session: aiohttp.ClientSession,
+    request: VirtualHostRequest,
+    hostname: str | None,
+) -> ProbeObservation:
+    parsed = urlsplit(request.endpoint)
+    endpoint_hostname = parsed.hostname or ''
+    port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+    probe_hostname = hostname or endpoint_hostname
+    http_host = _authority(probe_hostname, parsed.scheme, port)
+    tls_server_name = hostname if parsed.scheme == 'https' else None
+    try:
+        async with session.get(
+            request.endpoint,
+            allow_redirects=False,
+            headers={'Host': http_host} if hostname is not None else None,
+            server_hostname=tls_server_name,
+            ssl=not (request.insecure and parsed.scheme == 'https'),
+        ) as response:
+            try:
+                body = bytearray()
+                while len(body) <= VHOST_BODY_LIMIT:
+                    chunk = await response.content.read(min(64 * 1024, VHOST_BODY_LIMIT + 1 - len(body)))
+                    if not chunk:
+                        break
+                    body.extend(chunk)
+            except (TimeoutError, aiohttp.ClientError) as error:
+                return ProbeObservation(
+                    hostname=probe_hostname,
+                    http_host=http_host,
+                    tls_server_name=tls_server_name,
+                    phase='headers',
+                    status=response.status,
+                    location=response.headers.get('Location'),
+                    tls_verified=_tls_verified(parsed.scheme, request.insecure),
+                    error_type=type(error).__name__,
+                )
+            body_truncated = len(body) > VHOST_BODY_LIMIT
+            return ProbeObservation(
+                hostname=probe_hostname,
+                http_host=http_host,
+                tls_server_name=tls_server_name,
+                phase='body',
+                status=response.status,
+                location=response.headers.get('Location'),
+                body=bytes(body[:VHOST_BODY_LIMIT]),
+                body_truncated=body_truncated,
+                tls_verified=_tls_verified(parsed.scheme, request.insecure),
+            )
+    except TimeoutError as error:
+        return ProbeObservation(
+            hostname=probe_hostname,
+            http_host=http_host,
+            tls_server_name=tls_server_name,
+            phase='connect',
+            tls_verified=_tls_verified(parsed.scheme, request.insecure),
+            error_type=type(error).__name__,
+        )
+    except aiohttp.ClientError as error:
+        phase: ProbePhase = (
+            'tls' if 'ssl' in type(error).__name__.lower() or 'certificate' in type(error).__name__.lower() else 'connect'
+        )
+        return ProbeObservation(
+            hostname=probe_hostname,
+            http_host=http_host,
+            tls_server_name=tls_server_name,
+            phase=phase,
+            tls_verified=_tls_verified(parsed.scheme, request.insecure),
+            error_type=type(error).__name__,
+        )
+
+
+async def _probe_batch(
+    session: aiohttp.ClientSession,
+    request: VirtualHostRequest,
+    hostnames: tuple[str, ...],
+    completed: dict[int, ProbeObservation],
+) -> None:
+    tasks = [asyncio.create_task(_probe(session, request, hostname)) for hostname in hostnames]
+
+    def retain_completed() -> None:
+        for index, task in enumerate(tasks):
+            if task.done() and not task.cancelled() and task.exception() is None:
+                completed[index] = task.result()
+
+    try:
+        completed.update(enumerate(await asyncio.gather(*tasks)))
+    except (asyncio.CancelledError, Exception):
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        retain_completed()
+        raise
+
+
+def _new_control_names(shape: tuple[int, ...], scope: str, used_names: set[str]) -> tuple[str, ...]:
+    alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789'
+    capacity = len(alphabet) ** sum(shape)
+    used_for_shape = {name for name in used_names if name.endswith(f'.{scope}') and _candidate_shape(name, scope) == shape}
+    control_names: list[str] = []
+    start = secrets.randbelow(capacity)
+    for offset in range(len(used_for_shape) + VHOST_CONTROL_COUNT):
+        value = (start + offset) % capacity
+        encoded = ['a'] * sum(shape)
+        for index in range(len(encoded) - 1, -1, -1):
+            value, remainder = divmod(value, len(alphabet))
+            encoded[index] = alphabet[remainder]
+        labels: list[str] = []
+        label_start = 0
+        for length in shape:
+            labels.append(''.join(encoded[label_start : label_start + length]))
+            label_start += length
+        control_name = '.'.join((*labels, scope))
+        if control_name not in used_for_shape:
+            used_for_shape.add(control_name)
+            used_names.add(control_name)
+            control_names.append(control_name)
+            if len(control_names) == VHOST_CONTROL_COUNT:
+                return tuple(control_names)
+    raise ValueError('virtual-host candidate shape leaves fewer than three available unknown controls')
+
+
+def _classify_candidate(
+    request: VirtualHostRequest,
+    context: ProbeObservation,
+    candidate: ProbeObservation,
+    controls: tuple[ProbeObservation, ...],
+    *,
+    confirmation: ProbeObservation | None = None,
+) -> VirtualHostObservation:
+    observation = classify_virtual_host(
+        request.endpoint,
+        context,
+        candidate,
+        controls,
+        confirmation=confirmation,
+    )
+    if candidate.hostname == request.scope:
+        return replace(
+            observation,
+            classification='indeterminate',
+            distinct_signals=(),
+            needs_confirmation=False,
+        )
+    return observation
+
+
+async def discover_virtual_hosts(
+    request: VirtualHostRequest,
+    *,
+    _preserve_partial_on_cancel: bool = False,
+) -> VirtualHostDiscoveryResult:
+    timeout = aiohttp.ClientTimeout(total=request.limits.timeout_seconds)
+    connector = aiohttp.TCPConnector(limit=request.limits.concurrency, force_close=True)
+    request_count = 0
+    observations: list[VirtualHostObservation] = []
+    controls: list[ProbeObservation] = []
+    controls_by_shape: dict[tuple[int, ...], tuple[ProbeObservation, ...]] = {}
+    context: ProbeObservation | None = None
+    attempted_candidate_count = 0
+    stop_reason: str | None = None
+    request_error_count = 0
+    request_error_types: set[str] = set()
+    scan_error_type: str | None = None
+
+    def record_request_errors(probes: tuple[ProbeObservation, ...] | list[ProbeObservation]) -> None:
+        nonlocal request_error_count
+        for probe in probes:
+            if probe.error_type is not None:
+                request_error_count += 1
+                request_error_types.add(probe.error_type)
+
+    try:
+        async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
+            try:
+                async with asyncio.timeout(request.limits.runtime_seconds):
+                    request_count += 1
+                    context = await _probe(session, request, None)
+                    assert context is not None
+                    record_request_errors((context,))
+                    used_names = set(request.candidates)
+                    for candidate in request.candidates:
+                        shape = _candidate_shape(candidate, request.scope)
+                        if shape in controls_by_shape:
+                            continue
+                        shape_controls: list[ProbeObservation] = []
+                        for control_name in _new_control_names(shape, request.scope, used_names):
+                            request_count += 1
+                            control = await _probe(session, request, control_name)
+                            record_request_errors((control,))
+                            shape_controls.append(control)
+                            controls.append(control)
+                        controls_by_shape[shape] = tuple(shape_controls)
+                    while attempted_candidate_count < len(request.candidates) and request_count < request.limits.request_limit:
+                        remaining_budget = request.limits.request_limit - request_count
+                        remaining_candidates = len(request.candidates) - attempted_candidate_count
+                        batch_size = min(
+                            request.limits.concurrency,
+                            remaining_candidates,
+                            max(1, remaining_budget // 2),
+                        )
+                        candidate_names = request.candidates[attempted_candidate_count : attempted_candidate_count + batch_size]
+                        request_count += len(candidate_names)
+                        completed_candidates: dict[int, ProbeObservation] = {}
+                        try:
+                            await _probe_batch(session, request, candidate_names, completed_candidates)
+                        except (asyncio.CancelledError, Exception):
+                            record_request_errors(list(completed_candidates.values()))
+                            observations.extend(
+                                _classify_candidate(
+                                    request,
+                                    context,
+                                    completed_candidates[index],
+                                    controls_by_shape[_candidate_shape(candidate_names[index], request.scope)],
+                                )
+                                for index in sorted(completed_candidates)
+                            )
+                            attempted_candidate_count += len(completed_candidates)
+                            raise
+                        candidate_probes = [completed_candidates[index] for index in range(len(candidate_names))]
+                        record_request_errors(candidate_probes)
+                        attempted_candidate_count += len(candidate_probes)
+                        batch_observations = [
+                            _classify_candidate(
+                                request,
+                                context,
+                                candidate,
+                                controls_by_shape[_candidate_shape(candidate.hostname, request.scope)],
+                            )
+                            for candidate in candidate_probes
+                        ]
+                        observation_offset = len(observations)
+                        observations.extend(batch_observations)
+                        confirmation_indexes = [
+                            index for index, observation in enumerate(batch_observations) if observation.needs_confirmation
+                        ][: request.limits.request_limit - request_count]
+                        request_count += len(confirmation_indexes)
+                        confirmation_names = tuple(candidate_names[index] for index in confirmation_indexes)
+                        completed_confirmations: dict[int, ProbeObservation] = {}
+                        try:
+                            await _probe_batch(session, request, confirmation_names, completed_confirmations)
+                        except (asyncio.CancelledError, Exception):
+                            record_request_errors(list(completed_confirmations.values()))
+                            for confirmation_index, confirmation in completed_confirmations.items():
+                                index = confirmation_indexes[confirmation_index]
+                                observations[observation_offset + index] = _classify_candidate(
+                                    request,
+                                    context,
+                                    candidate_probes[index],
+                                    controls_by_shape[_candidate_shape(candidate_names[index], request.scope)],
+                                    confirmation=confirmation,
+                                )
+                            raise
+                        record_request_errors(list(completed_confirmations.values()))
+                        for confirmation_index, confirmation in completed_confirmations.items():
+                            index = confirmation_indexes[confirmation_index]
+                            observations[observation_offset + index] = _classify_candidate(
+                                request,
+                                context,
+                                candidate_probes[index],
+                                controls_by_shape[_candidate_shape(candidate_names[index], request.scope)],
+                                confirmation=confirmation,
+                            )
+            except TimeoutError:
+                stop_reason = 'runtime-limit'
+            except Exception as error:
+                scan_error_type = type(error).__name__
+    except asyncio.CancelledError:
+        if not _preserve_partial_on_cancel:
+            raise
+        stop_reason = 'runtime-limit'
+    except Exception as error:
+        scan_error_type = type(error).__name__
+    if context is None:
+        parsed = urlsplit(request.endpoint)
+        endpoint_hostname = parsed.hostname or ''
+        port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+        context = ProbeObservation(
+            hostname=endpoint_hostname,
+            http_host=_authority(endpoint_hostname, parsed.scheme, port),
+            tls_server_name=None,
+            phase='connect',
+            tls_verified=_tls_verified(parsed.scheme, request.insecure),
+            error_type=scan_error_type or 'RuntimeLimit',
+        )
+    if stop_reason is None:
+        all_candidates_complete = attempted_candidate_count == len(request.candidates) and not any(
+            observation.needs_confirmation for observation in observations
+        )
+        if scan_error_type is not None:
+            stop_reason = 'scan-error'
+        elif not all_candidates_complete:
+            stop_reason = 'request-limit'
+        else:
+            stop_reason = 'request-errors' if request_error_count else 'completed'
+    return VirtualHostDiscoveryResult(
+        context=context,
+        controls=tuple(controls),
+        observations=tuple(observations),
+        request_count=request_count,
+        attempted_candidate_count=attempted_candidate_count,
+        stop_reason=stop_reason,
+        request_error_count=request_error_count,
+        request_error_types=tuple(sorted(request_error_types)),
+        scan_error_type=scan_error_type,
+    )
+
+
+def _harvested_endpoints(addresses: tuple[str, ...]) -> tuple[str, ...]:
+    parsed_addresses = set()
+    for value in addresses:
+        try:
+            parsed_addresses.add(ipaddress.ip_address(value.strip()))
+        except ValueError:
+            continue
+    ordered_addresses = sorted(parsed_addresses, key=lambda address: (address.version, int(address)))
+    return tuple(
+        f'{scheme}://{f"[{address.compressed}]" if address.version == 6 else address.compressed}:{port}/'
+        for scheme, port in (('https', 443), ('http', 80))
+        for address in ordered_addresses
+    )
+
+
+def _candidates_for_budget(
+    scope: str,
+    candidates: tuple[str, ...],
+    request_limit: int,
+) -> tuple[tuple[str, ...], bool]:
+    selected: list[str] = []
+    selected_shapes: set[tuple[int, ...]] = set()
+    non_apex_counts: dict[tuple[int, ...], int] = {}
+    truncated = False
+    for candidate in candidates:
+        shape = _candidate_shape(candidate, scope)
+        shape_count = non_apex_counts.get(shape, 0) + int(candidate != scope)
+        shape_total = len(selected_shapes | {shape})
+        minimum_requests = 1 + VHOST_CONTROL_COUNT * shape_total + len(selected) + 1
+        if 36 ** sum(shape) - shape_count < VHOST_CONTROL_COUNT or minimum_requests > request_limit:
+            truncated = True
+            continue
+        selected.append(candidate)
+        selected_shapes.add(shape)
+        non_apex_counts[shape] = shape_count
+    return tuple(selected), truncated
+
+
+async def discover_harvested_virtual_hosts(
+    *,
+    scope: str,
+    addresses: tuple[str, ...],
+    candidates: tuple[str, ...],
+    limits: VirtualHostLimits,
+    insecure: bool = False,
+    endpoint_override: str = '',
+) -> HarvestedVirtualHostResult:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + limits.runtime_seconds
+    observations: list[VirtualHostObservation] = []
+    request_count = 0
+    endpoint_count = 0
+    candidate_endpoint_count = 0
+    child_stop_reasons: list[str] = []
+    candidates_were_limited = False
+    runtime_limited = False
+    request_error_count = 0
+    request_error_types: set[str] = set()
+    scan_error_type: str | None = None
+    normalized_scope = normalize_virtual_host_hostname(scope)
+    normalized_candidates = normalize_virtual_host_candidates(normalized_scope, candidates)
+    endpoints = (normalize_virtual_host_endpoint(endpoint_override),) if endpoint_override else _harvested_endpoints(addresses)
+    total_endpoint_count = len(endpoints)
+    total_candidate_endpoint_count = total_endpoint_count * len(normalized_candidates)
+    if not normalized_candidates:
+        return HarvestedVirtualHostResult((), 0, 0, total_endpoint_count, 0, 0, 'no-candidates')
+    if not endpoints:
+        return HarvestedVirtualHostResult((), 0, 0, 0, 0, 0, 'no-endpoints')
+
+    def merge_result(result: VirtualHostDiscoveryResult) -> None:
+        nonlocal request_count, candidate_endpoint_count, request_error_count, scan_error_type
+        request_count += result.request_count
+        candidate_endpoint_count += result.attempted_candidate_count
+        request_error_count += result.request_error_count
+        request_error_types.update(result.request_error_types)
+        observations.extend(result.observations)
+        child_stop_reasons.append(result.stop_reason)
+        scan_error_type = scan_error_type or result.scan_error_type
+
+    def harvested_result(stop_reason: str) -> HarvestedVirtualHostResult:
+        return HarvestedVirtualHostResult(
+            observations=tuple(observations),
+            request_count=request_count,
+            endpoint_count=endpoint_count,
+            total_endpoint_count=total_endpoint_count,
+            candidate_endpoint_count=candidate_endpoint_count,
+            total_candidate_endpoint_count=total_candidate_endpoint_count,
+            stop_reason=stop_reason,
+            request_error_count=request_error_count,
+            request_error_types=tuple(sorted(request_error_types)),
+            scan_error_type=scan_error_type,
+        )
+
+    maximum_endpoint_count = limits.request_limit // (VHOST_BASELINE_REQUEST_COUNT + 1)
+    endpoints_were_limited = len(endpoints) > maximum_endpoint_count
+    endpoints = endpoints[:maximum_endpoint_count]
+    for index, endpoint in enumerate(endpoints):
+        endpoints_left = len(endpoints) - index
+        remaining_requests = limits.request_limit - request_count
+        endpoint_request_limit = remaining_requests // endpoints_left
+        endpoint_candidates, were_limited = _candidates_for_budget(
+            normalized_scope,
+            normalized_candidates,
+            endpoint_request_limit,
+        )
+        candidates_were_limited = candidates_were_limited or were_limited
+        if not endpoint_candidates:
+            candidates_were_limited = True
+            continue
+        remaining_runtime = deadline - loop.time()
+        if remaining_runtime <= 0:
+            runtime_limited = True
+            break
+        endpoint_runtime = remaining_runtime / endpoints_left
+        if endpoints_left == 1:
+            endpoint_runtime -= min(0.001, endpoint_runtime / 2)
+        endpoint_count += 1
+        logger.info(
+            'Virtual-host endpoint %d/%d started: candidates=%d; request-limit=%d; runtime=%.2fs',
+            endpoint_count,
+            len(endpoints),
+            len(endpoint_candidates),
+            endpoint_request_limit,
+            endpoint_runtime,
+        )
+        task = asyncio.create_task(
+            discover_virtual_hosts(
+                VirtualHostRequest(
+                    endpoint=endpoint,
+                    scope=normalized_scope,
+                    candidates=endpoint_candidates,
+                    limits=replace(
+                        limits,
+                        request_limit=endpoint_request_limit,
+                        runtime_seconds=endpoint_runtime,
+                    ),
+                    insecure=insecure,
+                ),
+                _preserve_partial_on_cancel=True,
+            )
+        )
+        try:
+            done, _pending = await asyncio.wait((task,), timeout=max(0, deadline - loop.time()))
+        except asyncio.CancelledError as error:
+            task.cancel()
+            outcome = (await asyncio.gather(task, return_exceptions=True))[0]
+            if isinstance(outcome, VirtualHostDiscoveryResult):
+                merge_result(outcome)
+            scan_error_type = 'CancelledError'
+            raise VirtualHostDiscoveryCancelled(harvested_result('cancelled')) from error
+        if task in done:
+            try:
+                result = task.result()
+            except asyncio.CancelledError as error:
+                scan_error_type = 'CancelledError'
+                raise VirtualHostDiscoveryCancelled(harvested_result('cancelled')) from error
+            except Exception as error:
+                scan_error_type = type(error).__name__
+                break
+        else:
+            runtime_limited = True
+            task.cancel()
+            try:
+                result = await task
+            except asyncio.CancelledError as error:
+                current_task = asyncio.current_task()
+                if current_task is not None and current_task.cancelling():
+                    scan_error_type = 'CancelledError'
+                    raise VirtualHostDiscoveryCancelled(harvested_result('cancelled')) from error
+                break
+            current_task = asyncio.current_task()
+            if current_task is not None and current_task.cancelling():
+                scan_error_type = 'CancelledError'
+                merge_result(result)
+                raise VirtualHostDiscoveryCancelled(harvested_result('cancelled'))
+        merge_result(result)
+        logger.info(
+            'Virtual-host endpoint %d/%d finished: stop=%s; requests=%d; candidates=%d/%d; errors=%d',
+            endpoint_count,
+            len(endpoints),
+            result.stop_reason,
+            result.request_count,
+            result.attempted_candidate_count,
+            len(endpoint_candidates),
+            result.request_error_count + int(result.scan_error_type is not None),
+        )
+        if runtime_limited or result.scan_error_type is not None:
+            break
+
+    if runtime_limited or 'runtime-limit' in child_stop_reasons:
+        stop_reason = 'runtime-limit'
+    elif scan_error_type is not None:
+        stop_reason = 'scan-error'
+    elif endpoints_were_limited or candidates_were_limited or 'request-limit' in child_stop_reasons:
+        stop_reason = 'request-limit'
+    elif request_error_count or 'request-errors' in child_stop_reasons:
+        stop_reason = 'request-errors'
+    else:
+        stop_reason = next((reason for reason in child_stop_reasons if reason != 'completed'), 'completed')
+    return harvested_result(stop_reason)
+
+
+def _replace_authority(value: bytes, authority: str) -> tuple[bytes, bool]:
+    hostname_character = rb'[A-Za-z0-9._-]'
+    pattern = re.compile(
+        rb'(?<!' + hostname_character + rb')' + re.escape(authority.encode('ascii')) + rb'(?!' + hostname_character + rb')',
+        re.IGNORECASE,
+    )
+    normalized, replacements = pattern.subn(b'{authority}', value)
+    return normalized, replacements > 0
+
+
+def _normalize(observation: ProbeObservation) -> tuple[_Fingerprint, str | None, bool]:
+    normalized_body, body_reflected = _replace_authority(observation.body, observation.http_host)
+    normalized_location: str | None = None
+    location_reflected = False
+    if observation.location is not None:
+        location_bytes, location_reflected = _replace_authority(
+            observation.location.encode('utf-8'),
+            observation.http_host,
+        )
+        normalized_location = location_bytes.decode('utf-8')
+    return (
+        _Fingerprint(
+            phase=observation.phase,
+            status=observation.status,
+            location=normalized_location,
+            body_sha256=hashlib.sha256(normalized_body).hexdigest(),
+            body_size=len(normalized_body),
+            body_truncated=observation.body_truncated,
+            error_type=observation.error_type,
+        ),
+        normalized_location,
+        body_reflected or location_reflected,
+    )
+
+
+def classify_virtual_host(
+    endpoint: str,
+    context: ProbeObservation,
+    candidate: ProbeObservation,
+    controls: tuple[ProbeObservation, ...],
+    *,
+    confirmation: ProbeObservation | None = None,
+) -> VirtualHostObservation:
+    context_fingerprint = _normalize(context)[0]
+    control_fingerprints = tuple(_normalize(control)[0] for control in controls)
+    candidate_fingerprint, normalized_location, reflection_normalized = _normalize(candidate)
+    confirmation_fingerprint: _Fingerprint | None = None
+    if confirmation is not None:
+        if (
+            confirmation.hostname != candidate.hostname
+            or confirmation.http_host != candidate.http_host
+            or confirmation.tls_server_name != candidate.tls_server_name
+        ):
+            raise ValueError('confirmation must repeat the same virtual-host authority')
+        confirmation_fingerprint = _normalize(confirmation)[0]
+    classification, distinct_signals, needs_confirmation, confirmation_used = _classify_fingerprints(
+        candidate_fingerprint,
+        context_fingerprint,
+        control_fingerprints,
+        confirmation_fingerprint,
+    )
+    control_fingerprint = control_fingerprints[0] if len(set(control_fingerprints)) == 1 else None
+    return VirtualHostObservation(
+        endpoint=endpoint,
+        hostname=candidate.hostname,
+        http_host=candidate.http_host,
+        tls_server_name=candidate.tls_server_name,
+        classification=classification,
+        phase=candidate.phase,
+        status=candidate.status,
+        location=normalized_location,
+        body_sha256=candidate_fingerprint.body_sha256,
+        body_size=candidate_fingerprint.body_size,
+        body_truncated=candidate.body_truncated,
+        tls_verified=candidate.tls_verified,
+        error_type=candidate.error_type,
+        distinct_signals=distinct_signals,
+        reflection_normalized=reflection_normalized,
+        needs_confirmation=needs_confirmation,
+        context_phase=context_fingerprint.phase,
+        context_status=context_fingerprint.status,
+        context_location=context_fingerprint.location,
+        context_body_sha256=context_fingerprint.body_sha256,
+        context_body_size=context_fingerprint.body_size,
+        context_body_truncated=context_fingerprint.body_truncated,
+        control_phase=control_fingerprint.phase if control_fingerprint is not None else None,
+        control_status=control_fingerprint.status if control_fingerprint is not None else None,
+        control_location=control_fingerprint.location if control_fingerprint is not None else None,
+        control_body_sha256=control_fingerprint.body_sha256 if control_fingerprint is not None else None,
+        control_body_size=control_fingerprint.body_size if control_fingerprint is not None else None,
+        control_body_truncated=control_fingerprint.body_truncated if control_fingerprint is not None else None,
+        confirmation_body_sha256=(
+            confirmation_fingerprint.body_sha256 if confirmation_used and confirmation_fingerprint is not None else None
+        ),
+    )


### PR DESCRIPTION
## Summary

- add opt-in, bounded virtual-host discovery to the CLI, REST API, HarvestView, SQLite evidence, and unversioned JSONL output
- keep ordinary operator use to one `--vhost` flag with bounded defaults; separate optional safety tuning in CLI help and HarvestView
- connect only to authorized literal-IP endpoints while aligning HTTP `Host` and TLS SNI; candidate names are never resolved by this action
- compare each candidate with the raw-IP response and three shape-matched unknown-host controls, with repeat confirmation for body-only differences
- keep one canonical `hostname` result and attach `vhost` action provenance plus structured per-endpoint observations

## Safety and limits

Virtual-host discovery is an explicit P2 direct action. It does not follow redirects, use configured proxies, expand target scope, scan ports, or generate a wordlist. Request count, runtime, per-request timeout, response size, and concurrency are bounded. Cancellation and later endpoint failures preserve any confirmed findings while reporting partial or failed evidence truthfully.

## Persistence and UI

The ResultStore schema advances to version 8 and stores structured observation details on the canonical hostname row. JSONL, database import, REST projection, and HarvestView use the same evidence shape. HarvestView keeps one Hostnames view and adds observation details only when a hostname has vhost evidence.

## Verification

- focused integration: 216 passed
- virtual-host HTTP/TLS module: 48 passed
- full non-browser suite before the final cancellation-only cleanup: 827 passed, 6 skipped, 23 deselected
- post-cleanup cancellation coverage: all 48 vhost module tests plus 3 orchestration regressions passed
- focused HarvestView Chromium flows: 3 passed
- Ruff check and format check: passed
- mypy: passed for 98 source files
- `uv lock --check`, JavaScript syntax, and `git diff --check`: passed
- no tracked PEM files or private-key material; TLS tests generate one disposable self-signed certificate in pytest's temporary directory

## Scope

This PR does not add a second configuration-file contract, presets, wordlist-based vhost brute forcing, port scanning, redirect following, protocol desynchronization probes, or autonomous target expansion.
