### PR TITLE
fix: extract hostnames from bufferover.run responses correctly

### DIFF
--- a/tests/discovery/test_bufferoverun.py
+++ b/tests/discovery/test_bufferoverun.py
@@ -1,0 +1,80 @@
+import pytest
+
+from theHarvester.discovery import bufferoverun
+
+
+def _patch_fetch(monkeypatch, payload):
+    import theHarvester.lib.core as core_module
+
+    async def fake_fetch_all(urls, headers=None, params='', json=False, takeover=False, proxy=False):
+        return [payload]
+
+    monkeypatch.setattr(core_module.AsyncFetcher, 'fetch_all', staticmethod(fake_fetch_all), raising=True)
+
+
+class TestSearchBufferover:
+    def test_init_sets_state(self, monkeypatch):
+        monkeypatch.setattr(bufferoverun.Core, 'bufferoverun_key', lambda: 'testkey')
+        search = bufferoverun.SearchBufferover('example.com')
+        assert search.word == 'example.com'
+        assert search.totalhosts == set()
+        assert search.totalips == set()
+        assert search.proxy is False
+
+    @pytest.mark.asyncio
+    async def test_extracts_hostnames_from_results(self, monkeypatch):
+        monkeypatch.setattr(bufferoverun.Core, 'bufferoverun_key', lambda: 'testkey')
+        _patch_fetch(
+            monkeypatch,
+            {
+                'Results': [
+                    '54.201.204.183,581faa6ff692d0ba8185753570c8624a2a6b4e8e47bd5322216cc12a41def044,,blog.example.com',
+                    '104.154.120.133,2122965ac9fa9a2cb9295fc8966569d9a3906995e8fcd61d82d6ec0f9d10dfea,,www.example.com',
+                ]
+            },
+        )
+        search = bufferoverun.SearchBufferover('example.com')
+        await search.process()
+        assert set(await search.get_hostnames()) == {'blog.example.com', 'www.example.com'}
+
+    @pytest.mark.asyncio
+    async def test_extracts_ips_from_results(self, monkeypatch):
+        monkeypatch.setattr(bufferoverun.Core, 'bufferoverun_key', lambda: 'testkey')
+        _patch_fetch(
+            monkeypatch,
+            {
+                'Results': [
+                    '54.201.204.183,581faa6ff692d0ba8185753570c8624a2a6b4e8e47bd5322216cc12a41def044,,blog.example.com',
+                    'not-an-ip,hash,,www.example.com',
+                ]
+            },
+        )
+        search = bufferoverun.SearchBufferover('example.com')
+        await search.process()
+        assert set(await search.get_ips()) == {'54.201.204.183'}
+
+    @pytest.mark.asyncio
+    async def test_handles_commas_in_cert_org(self, monkeypatch):
+        monkeypatch.setattr(bufferoverun.Core, 'bufferoverun_key', lambda: 'testkey')
+        _patch_fetch(monkeypatch, {'Results': ['10.0.0.5,aaabbbcccddd,,,ops.example.com']})
+        search = bufferoverun.SearchBufferover('example.com')
+        await search.process()
+        assert set(await search.get_hostnames()) == {'ops.example.com'}
+
+    @pytest.mark.asyncio
+    async def test_empty_response_returns_no_results(self, monkeypatch):
+        monkeypatch.setattr(bufferoverun.Core, 'bufferoverun_key', lambda: 'testkey')
+        _patch_fetch(monkeypatch, {})
+        search = bufferoverun.SearchBufferover('example.com')
+        await search.process()
+        assert await search.get_hostnames() == set()
+        assert await search.get_ips() == set()
+
+    @pytest.mark.asyncio
+    async def test_failed_fetch_returns_no_results(self, monkeypatch):
+        monkeypatch.setattr(bufferoverun.Core, 'bufferoverun_key', lambda: 'testkey')
+        _patch_fetch(monkeypatch, '')
+        search = bufferoverun.SearchBufferover('example.com')
+        await search.process()
+        assert await search.get_hostnames() == set()
+        assert await search.get_ips() == set()

--- a/theHarvester/discovery/bufferoverun.py
+++ b/theHarvester/discovery/bufferoverun.py
@@ -23,15 +23,13 @@ class SearchBufferover:
             proxy=self.proxy,
         )
         dct = response[0]
-        if dct['Results']:
-            self.totalhosts = {
-                (
-                    host.split(',')
-                    if ',' in host and self.word.replace('www.', '') in host.split(',')[0] in host
-                    else host.split(',')[4]
-                )
-                for host in dct['Results']
-            }
+        if not dct or not dct.get('Results'):
+            return
+
+        # Each entry is formatted as '<ip>,<sha256>,<cert-org>,<CN/SNI>', so the
+        # hostname is the last field. The certificate organization may itself
+        # contain commas, hence the right-split.
+        self.totalhosts = {hostname.strip() for host in dct['Results'] if (hostname := host.rsplit(',', 1)[-1].strip())}
 
         self.totalips = {
             ip.split(',')[0] for ip in dct['Results'] if re.match(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$', ip.split(',')[0])


### PR DESCRIPTION
## Summary

\SearchBufferover.do_search()\ crashes with an \IndexError\ on every real response from \	ls.bufferover.run\, so the bufferoverun source never returns any hosts.

The hostname extraction in \do_search\ was broken in three ways:

1. **Crash:** entries were indexed at \host.split(',')[4]\, but the API returns four comma-separated fields per line (\<ip>,<sha256>,<cert-org>,<CN/SNI>\), so index 4 is always out of range.
2. **Chained comparison bug:** the guard used \self.word in host.split(',')[0] in host\, which Python evaluates as \A in B and B in C\. The extra \host.split(',')[0] in host\ clause is always true (a field is always a substring of its own line) and the word was checked against the IP field rather than the hostname.
3. **Type mix:** the "true" branch of the old ternary returned the full \host.split(',')\ list into the \	otalhosts\ set, mixing lists and strings.

The IP extraction (\	otalips\) was also run unconditionally, so a failed/empty fetch (an empty string or a dict without \Results\) raised a \TypeError\ instead of returning gracefully.

## Changes

- Extract the hostname from the last field of each line (\split(',', 1)\) so commas in the certificate-organization field cannot shift the index, matching the documented API format.
- Return early when the response is empty or lacks \Results\, so failed fetches no longer raise.
- Keep the existing IP extraction but gate it behind the same guard.

## Test

Added \	ests/discovery/test_bufferoverun.py\ with six cases covering hostname/IP extraction, commas in the cert-org field, and empty/failed responses. All 128 api tests pass (1 pre-existing network-dependent failure in \	est_thc\), ruff check and format are clean.