### PR TITLE
feat(lunar): add Lunar Domain Exposure as an enrichment source (closes #2413)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Passive modules
 
 * leaklookup: Data breach search engine (https://leak-lookup.com)
 
+* lunar: Domain exposure enrichment from infostealer logs and data breaches, free and no API key required (https://lunarcyber.com)
+
 * mojeek: Mojeek search engine (https://www.mojeek.com)
 
 * netlas: A Shodan or Censys competitor (https://app.netlas.io)

--- a/tests/discovery/test_lunar.py
+++ b/tests/discovery/test_lunar.py
@@ -11,13 +11,11 @@ The module extracts hostnames and interesting URLs from the report's
 ``top_login_urls`` and keeps a flattened exposure summary.
 """
 
-import os
+from unittest.mock import AsyncMock
 
 import pytest
 
 from theHarvester.discovery import lunar
-
-github_ci: str | None = os.getenv('GITHUB_ACTIONS')
 
 
 # =============================================================================
@@ -74,7 +72,7 @@ class TestLunarReportParsing:
                 {'url': 'sts.example.com', 'events': 50},
                 {'url': 'https://vpn.example.com/login', 'events': 40},
                 {'url': 'portal.example.com/adfs/**/', 'events': 30},
-                {'url': 'unrelated-domain.net', 'events': 5},
+                {'url': 'unrelated.example', 'events': 5},
                 {'url': '*.wildcard.example.com', 'events': 1},
             ],
         }
@@ -87,7 +85,7 @@ class TestLunarReportParsing:
         assert 'sts.example.com' in search.totalhosts
         assert 'vpn.example.com' in search.totalhosts
         assert 'portal.example.com' in search.totalhosts
-        assert 'unrelated-domain.net' not in search.totalhosts
+        assert 'unrelated.example' not in search.totalhosts
         assert all('*' not in host for host in search.totalhosts)
 
     def test_parse_report_keeps_all_login_urls(self) -> None:
@@ -97,7 +95,7 @@ class TestLunarReportParsing:
         # it belongs to an unrelated domain.
         assert 'sts.example.com' in search.interesting_urls
         assert 'https://vpn.example.com/login' in search.interesting_urls
-        assert 'unrelated-domain.net' in search.interesting_urls
+        assert 'unrelated.example' in search.interesting_urls
 
     def test_parse_report_builds_summary(self) -> None:
         search = lunar.SearchLunar('example.com')
@@ -146,22 +144,23 @@ class TestLunarGetters:
 
 
 # =============================================================================
-# 4. Live integration (network, skipped in CI)
+# 4. Process contract (offline)
 # =============================================================================
-@pytest.mark.skipif(github_ci == 'true', reason='Skip live network tests in CI')
-class TestLunarLive:
+class TestLunarProcess:
     @pytest.mark.asyncio
-    async def test_process_returns_set_of_hostnames(self) -> None:
-        search = lunar.SearchLunar('stryker.com')
-        try:
-            await search.process()
-        except Exception:
-            pytest.skip('Skipping due to network error')
-        result = await search.get_hostnames()
-        assert isinstance(result, set)
-        for hostname in result:
-            assert hostname == hostname.lower()
-            assert 'stryker.com' in hostname
+    @pytest.mark.parametrize('target', ['example.test', 'www.example.test'])
+    async def test_process_preserves_reported_www_hostname(self, monkeypatch: pytest.MonkeyPatch, target: str) -> None:
+        report = {
+            'status': 'REPORT_READY',
+            'report': {'top_login_urls': [{'url': 'https://www.example.test/login'}]},
+        }
+        monkeypatch.setattr(lunar.AsyncFetcher, 'fetch_all', AsyncMock(return_value=[report]))
+        search = lunar.SearchLunar(target)
+
+        await search.process()
+
+        assert await search.get_hostnames() == {'www.example.test'}
+        assert await search.get_interestingurls() == ['https://www.example.test/login']
 
 
 if __name__ == '__main__':

--- a/tests/discovery/test_lunar.py
+++ b/tests/discovery/test_lunar.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+Tests for the Lunar Domain Exposure discovery module.
+
+Lunar exposes a free, keyless domain-exposure endpoint that aggregates
+infostealer-log and data-breach intelligence for a given domain:
+
+    https://api.lunarcyber.com/domain-exposure?domain=example.com
+
+The module extracts hostnames and interesting URLs from the report's
+``top_login_urls`` and keeps a flattened exposure summary.
+"""
+
+import os
+
+import pytest
+
+from theHarvester.discovery import lunar
+
+github_ci: str | None = os.getenv('GITHUB_ACTIONS')
+
+
+# =============================================================================
+# 1. Initialization and structure
+# =============================================================================
+class TestLunarInitialization:
+    def test_init_normalizes_word(self) -> None:
+        search = lunar.SearchLunar('  Example.COM  ')
+        assert search.word == 'example.com'
+
+    def test_init_creates_empty_collections(self) -> None:
+        search = lunar.SearchLunar('example.com')
+        assert search.totalhosts == set()
+        assert search.interesting_urls == set()
+        assert search.exposure == {}
+        assert search.malware_families == []
+
+    def test_init_proxy_default_false(self) -> None:
+        search = lunar.SearchLunar('example.com')
+        assert search.proxy is False
+
+    def test_class_has_required_methods(self) -> None:
+        search = lunar.SearchLunar('example.com')
+        for method in ('do_search', 'get_hostnames', 'get_interestingurls', 'process'):
+            assert hasattr(search, method)
+            assert callable(getattr(search, method))
+
+
+# =============================================================================
+# 2. Report parsing (offline, no network)
+# =============================================================================
+class TestLunarReportParsing:
+    @staticmethod
+    def _sample_report() -> dict:
+        return {
+            'domain': 'example.com',
+            'generated_at': '2026-08-01T00:00:00',
+            'summary': {
+                'total_events': 100,
+                'infostealer_events': 30,
+                'data_breach_events': 70,
+                'employee_events': 90,
+                'client_events': 10,
+                'first_seen': '2025-08-01',
+                'last_seen': '2026-07-31',
+            },
+            'infostealer_summary': {'malware_families_observed': 2},
+            'data_breach_summary': {'known_breach_sources_count': 5},
+            'malware_family_breakdown': [
+                {'family': 'Redline', 'events': 20},
+                {'family': 'LummaC2', 'events': 10},
+            ],
+            'top_login_urls': [
+                {'url': 'sts.example.com', 'events': 50},
+                {'url': 'https://vpn.example.com/login', 'events': 40},
+                {'url': 'portal.example.com/adfs/**/', 'events': 30},
+                {'url': 'unrelated-domain.net', 'events': 5},
+                {'url': '*.wildcard.example.com', 'events': 1},
+            ],
+        }
+
+    def test_parse_report_extracts_target_hosts(self) -> None:
+        search = lunar.SearchLunar('example.com')
+        search._parse_report(self._sample_report())
+        # Hostnames belonging to the target domain are captured, wildcards and
+        # unrelated domains are excluded.
+        assert 'sts.example.com' in search.totalhosts
+        assert 'vpn.example.com' in search.totalhosts
+        assert 'portal.example.com' in search.totalhosts
+        assert 'unrelated-domain.net' not in search.totalhosts
+        assert all('*' not in host for host in search.totalhosts)
+
+    def test_parse_report_keeps_all_login_urls(self) -> None:
+        search = lunar.SearchLunar('example.com')
+        search._parse_report(self._sample_report())
+        # Every parseable login URL is retained as an interesting URL, even if
+        # it belongs to an unrelated domain.
+        assert 'sts.example.com' in search.interesting_urls
+        assert 'https://vpn.example.com/login' in search.interesting_urls
+        assert 'unrelated-domain.net' in search.interesting_urls
+
+    def test_parse_report_builds_summary(self) -> None:
+        search = lunar.SearchLunar('example.com')
+        search._parse_report(self._sample_report())
+        assert search.exposure['total_events'] == 100
+        assert search.exposure['infostealer_events'] == 30
+        assert search.exposure['data_breach_events'] == 70
+        assert search.exposure['malware_families_observed'] == 2
+        assert search.exposure['known_breach_sources_count'] == 5
+
+    def test_parse_report_captures_malware_families(self) -> None:
+        search = lunar.SearchLunar('example.com')
+        search._parse_report(self._sample_report())
+        families = {entry['family'] for entry in search.malware_families}
+        assert families == {'Redline', 'LummaC2'}
+
+    def test_parse_empty_report_is_safe(self) -> None:
+        search = lunar.SearchLunar('example.com')
+        search._parse_report({})
+        assert search.totalhosts == set()
+        assert search.interesting_urls == set()
+
+
+# =============================================================================
+# 3. Async getter contracts (offline)
+# =============================================================================
+class TestLunarGetters:
+    @pytest.mark.asyncio
+    async def test_get_hostnames_returns_set(self) -> None:
+        search = lunar.SearchLunar('example.com')
+        result = await search.get_hostnames()
+        assert isinstance(result, set)
+
+    @pytest.mark.asyncio
+    async def test_get_interestingurls_returns_sorted_list(self) -> None:
+        search = lunar.SearchLunar('example.com')
+        search.interesting_urls = {'b.example.com', 'a.example.com'}
+        result = await search.get_interestingurls()
+        assert result == ['a.example.com', 'b.example.com']
+
+    @pytest.mark.asyncio
+    async def test_get_exposure_returns_dict(self) -> None:
+        search = lunar.SearchLunar('example.com')
+        result = await search.get_exposure()
+        assert isinstance(result, dict)
+
+
+# =============================================================================
+# 4. Live integration (network, skipped in CI)
+# =============================================================================
+@pytest.mark.skipif(github_ci == 'true', reason='Skip live network tests in CI')
+class TestLunarLive:
+    @pytest.mark.asyncio
+    async def test_process_returns_set_of_hostnames(self) -> None:
+        search = lunar.SearchLunar('stryker.com')
+        try:
+            await search.process()
+        except Exception:
+            pytest.skip('Skipping due to network error')
+        result = await search.get_hostnames()
+        assert isinstance(result, set)
+        for hostname in result:
+            assert hostname == hostname.lower()
+            assert 'stryker.com' in hostname
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -42,6 +42,7 @@ from theHarvester.discovery import (
     intelxsearch,
     leakix,
     leaklookup,
+    lunar,
     mojeek,
     netlas,
     onyphe,
@@ -200,7 +201,7 @@ async def start(rest_args: argparse.Namespace | None = None):
         '--source',
         help="""baidu, bevigil, bitbucket, brave, bufferoverun,
                             builtwith, censys, certspotter, chaos, commoncrawl, criminalip, crtsh, dehashed, dnsdumpster, duckduckgo, dymo, fofa, fullhunt, github-code,
-                            gitlab, hackertarget, haveibeenpwned, hudsonrock, hunter, hunterhow, intelx, leakix, leaklookup, mojeek, netlas, onyphe, otx, pentesttools,
+                            gitlab, hackertarget, haveibeenpwned, hudsonrock, hunter, hunterhow, intelx, leakix, leaklookup, lunar, mojeek, netlas, onyphe, otx, pentesttools,
                             projectdiscovery, rapiddns, robtex, rocketreach, securityscorecard, securityTrails, sherlockeye, shodan, shodanInternetDB, subdomaincenter,
                             subdomainfinderc99, thc, threatcrowd, tomba, urlscan, venacus, virustotal, waybackarchive, whoisxml, windvane, yahoo, zoomeye""",
     )
@@ -847,6 +848,20 @@ async def start(rest_args: argparse.Namespace | None = None):
                             print(f'A Missing Key error occurred in LeakLookup: {e}')
                         else:
                             print(f'An exception has occurred in LeakLookup search: {e}')
+
+                elif engineitem == 'lunar':
+                    try:
+                        lunar_search = lunar.SearchLunar(word)
+                        stor_lst.append(
+                            store(
+                                lunar_search,
+                                engineitem,
+                                store_host=True,
+                                store_interestingurls=True,
+                            )
+                        )
+                    except Exception as e:
+                        print(f'An exception has occurred in Lunar search: {e}')
 
                 elif engineitem == 'mojeek':
                     try:

--- a/theHarvester/discovery/lunar.py
+++ b/theHarvester/discovery/lunar.py
@@ -1,0 +1,163 @@
+import logging
+from typing import Any
+from urllib.parse import urlparse
+
+from theHarvester.lib.core import AsyncFetcher
+
+
+class SearchLunar:
+    """Lunar Domain Exposure API integration.
+
+    Lunar's Domain Exposure endpoint returns domain-level exposure intelligence
+    aggregated from infostealer logs and data breaches: exposure counts, a
+    monthly activity timeline, observed malware families, affected services and
+    the login URLs seen in stealer/breach records.
+
+    The endpoint is free and does not require an API key. It is an *enrichment*
+    source for an already-known target domain rather than a subdomain
+    enumeration source, but the ``top_login_urls`` it returns frequently expose
+    real subdomains of the target (auth portals, VPN gateways, ADFS endpoints),
+    which are surfaced as hostnames and interesting URLs.
+
+    API example:
+        https://api.lunarcyber.com/domain-exposure?domain=example.com
+    """
+
+    BASE_URL = 'https://api.lunarcyber.com/domain-exposure'
+    READY_STATUS = 'REPORT_READY'
+
+    def __init__(self, word: str) -> None:
+        self.word = word.strip().lower()
+        self.totalhosts: set[str] = set()
+        self.interesting_urls: set[str] = set()
+        self.exposure: dict[str, Any] = {}
+        self.malware_families: list[dict[str, Any]] = []
+        self.proxy: bool | str = False
+        self.logger = logging.getLogger(__name__)
+
+    async def do_search(self) -> None:
+        """Fetch and parse the domain exposure report."""
+        url = f'{self.BASE_URL}?domain={self.word}'
+        try:
+            responses = await AsyncFetcher.fetch_all([url], json=True, proxy=self.proxy)
+        except Exception as error:
+            self.logger.error(f'Lunar API request failed for {self.word}: {error}')
+            return
+
+        if not responses or not isinstance(responses[0], dict):
+            self.logger.warning(f'Lunar returned an unexpected response for {self.word}')
+            return
+
+        payload = responses[0]
+        status = payload.get('status')
+        if status and status != self.READY_STATUS:
+            # The report can be generated asynchronously for domains Lunar has
+            # not seen recently; in that case there is nothing to parse yet.
+            self.logger.info(f'Lunar report for {self.word} is not ready (status: {status})')
+            return
+
+        report = payload.get('report')
+        if not isinstance(report, dict):
+            self.logger.info(f'Lunar returned no exposure report for {self.word}')
+            return
+
+        self._parse_report(report)
+
+    def _parse_report(self, report: dict[str, Any]) -> None:
+        """Extract hostnames, interesting URLs and an exposure summary."""
+        top_login_urls = report.get('top_login_urls')
+        if isinstance(top_login_urls, list):
+            self._extract_login_urls(top_login_urls)
+
+        malware_breakdown = report.get('malware_family_breakdown')
+        if isinstance(malware_breakdown, list):
+            self.malware_families = [entry for entry in malware_breakdown if isinstance(entry, dict)]
+
+        self.exposure = self._build_summary(report)
+        self._log_summary()
+
+    def _extract_login_urls(self, top_login_urls: list[dict[str, Any]]) -> None:
+        """Pull hostnames and URLs out of Lunar's ``top_login_urls`` records.
+
+        Entries may be bare hostnames (``sts.example.com``), full URLs
+        (``https://sts.example.com``) or wildcard paths
+        (``sts.example.com/adfs/**/``). Only hostnames belonging to the target
+        domain are kept as hosts; every parseable login URL is retained as an
+        interesting URL.
+        """
+        for entry in top_login_urls:
+            if not isinstance(entry, dict):
+                continue
+            raw_url = entry.get('url')
+            if not isinstance(raw_url, str):
+                continue
+            raw_url = raw_url.strip()
+            if not raw_url:
+                continue
+
+            candidate = raw_url if '://' in raw_url else f'http://{raw_url}'
+            hostname = urlparse(candidate).hostname
+            if not hostname or '*' in hostname:
+                continue
+            hostname = hostname.lower().removeprefix('www.')
+
+            self.interesting_urls.add(raw_url)
+            if hostname == self.word or hostname.endswith(f'.{self.word}'):
+                self.totalhosts.add(hostname)
+
+    @staticmethod
+    def _build_summary(report: dict[str, Any]) -> dict[str, Any]:
+        """Condense the verbose report into a flat exposure summary."""
+        summary = report.get('summary') if isinstance(report.get('summary'), dict) else {}
+        breach = report.get('data_breach_summary') if isinstance(report.get('data_breach_summary'), dict) else {}
+        infostealer = report.get('infostealer_summary') if isinstance(report.get('infostealer_summary'), dict) else {}
+
+        return {
+            'domain': report.get('domain'),
+            'generated_at': report.get('generated_at'),
+            'total_events': summary.get('total_events'),
+            'infostealer_events': summary.get('infostealer_events'),
+            'data_breach_events': summary.get('data_breach_events'),
+            'employee_events': summary.get('employee_events'),
+            'client_events': summary.get('client_events'),
+            'first_seen': summary.get('first_seen'),
+            'last_seen': summary.get('last_seen'),
+            'malware_families_observed': infostealer.get('malware_families_observed'),
+            'known_breach_sources_count': breach.get('known_breach_sources_count'),
+        }
+
+    def _log_summary(self) -> None:
+        """Log the headline exposure numbers so operators see the intelligence."""
+        total = self.exposure.get('total_events')
+        if not total:
+            self.logger.info(f'Lunar found no exposure events for {self.word}')
+            return
+
+        top_families = ', '.join(
+            f'{entry.get("family")} ({entry.get("events")})' for entry in self.malware_families[:3] if entry.get('family')
+        )
+        self.logger.info(
+            f'Lunar exposure for {self.word}: {total} events '
+            f'({self.exposure.get("infostealer_events")} infostealer, '
+            f'{self.exposure.get("data_breach_events")} data breach), '
+            f'window {self.exposure.get("first_seen")} to {self.exposure.get("last_seen")}'
+            + (f'; top malware: {top_families}' if top_families else '')
+        )
+
+    async def get_hostnames(self) -> set[str]:
+        return self.totalhosts
+
+    async def get_interestingurls(self) -> list[str]:
+        return sorted(self.interesting_urls)
+
+    async def get_exposure(self) -> dict[str, Any]:
+        """Return the flattened exposure summary for this domain."""
+        return self.exposure
+
+    async def get_malware_families(self) -> list[dict[str, Any]]:
+        """Return the observed infostealer malware family breakdown."""
+        return self.malware_families
+
+    async def process(self, proxy: bool = False) -> None:
+        self.proxy = proxy
+        await self.do_search()

--- a/theHarvester/discovery/lunar.py
+++ b/theHarvester/discovery/lunar.py
@@ -32,7 +32,7 @@ class SearchLunar:
         self.interesting_urls: set[str] = set()
         self.exposure: dict[str, Any] = {}
         self.malware_families: list[dict[str, Any]] = []
-        self.proxy: bool | str = False
+        self.proxy: bool = False
         self.logger = logging.getLogger(__name__)
 
     async def do_search(self) -> None:
@@ -99,7 +99,7 @@ class SearchLunar:
             hostname = urlparse(candidate).hostname
             if not hostname or '*' in hostname:
                 continue
-            hostname = hostname.lower().removeprefix('www.')
+            hostname = hostname.lower()
 
             self.interesting_urls.add(raw_url)
             if hostname == self.word or hostname.endswith(f'.{self.word}'):
@@ -108,9 +108,9 @@ class SearchLunar:
     @staticmethod
     def _build_summary(report: dict[str, Any]) -> dict[str, Any]:
         """Condense the verbose report into a flat exposure summary."""
-        summary = report.get('summary') if isinstance(report.get('summary'), dict) else {}
-        breach = report.get('data_breach_summary') if isinstance(report.get('data_breach_summary'), dict) else {}
-        infostealer = report.get('infostealer_summary') if isinstance(report.get('infostealer_summary'), dict) else {}
+        summary = report['summary'] if isinstance(report.get('summary'), dict) else {}
+        breach = report['data_breach_summary'] if isinstance(report.get('data_breach_summary'), dict) else {}
+        infostealer = report['infostealer_summary'] if isinstance(report.get('infostealer_summary'), dict) else {}
 
         return {
             'domain': report.get('domain'),

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -307,6 +307,7 @@ class Core:
             'leaklookup',
             'linkedin',
             'linkedin_links',
+            'lunar',
             'mojeek',
             'netcraft',
             'netlas',


### PR DESCRIPTION
Closes #2413

Adds a new `lunar` source backed by Lunar's **free, keyless** Domain Exposure API:

```
https://api.lunarcyber.com/domain-exposure?domain=<domain>
```

It returns domain-level exposure intelligence aggregated from infostealer logs and data breaches — exposure counts, a monthly activity timeline, observed malware families, affected services, and the login URLs seen in stealer/breach records.

## What it does

New module `theHarvester/discovery/lunar.py` (`SearchLunar`) fetches the exposure report via `AsyncFetcher.fetch_all` and:

- Extracts subdomains of the target from `top_login_urls` (auth portals, VPN gateways, ADFS endpoints) → `get_hostnames()`
- Keeps every parseable login URL → `get_interestingurls()`
- Flattens the headline exposure figures → `get_exposure()`
- Exposes the infostealer malware-family breakdown → `get_malware_families()`
- Logs a one-line exposure summary so operators see the intelligence


## Integration

- Wired into `__main__.py`: import, `-b lunar` dispatch storing hosts + interesting URLs, and the `-b` help list.
- Registered in `Core.get_supportedengines()` so `-b all` includes it.
- Documented in the README source list. **No API key required**, so no entry is needed in the api-keys pricing section.

Robustness: the report can be produced asynchronously — a non-`REPORT_READY` status or missing `report` object is handled gracefully (nothing collected). Hostnames are filtered to the target domain and wildcard hosts are skipped.

## Tests

`tests/discovery/test_lunar.py` uses only mocked transport and reserved example domains:

- offline report parsing and asynchronous result getters
- process coverage proving `www.example.test` is preserved for both apex and exact-`www` targets
- no default live integration test or network-error skip

Validation:

- focused Lunar suite: **14 passed**
- both new hostname cases fail on the original parser and pass with the fix
- repository-wide Ruff lint, formatting, and ty checks: passed
- full suite: **127 passed, 5 skipped, 5 failed**; the failures are existing THC tests requiring live network access and were reproduced on the unchanged PR head during offline verification

The cleanup also aligns the proxy annotation and guarded summary dictionary reads with their existing runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)