### PR TITLE
Persist constructor-time missing credential outcomes

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ import logging
 import sys
 import xml.etree.ElementTree as ElementTree
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -1148,6 +1149,54 @@ async def test_dns_lookup_cancels_sibling_ranges_and_persists_partial_evidence(
     assert [(observation.kind, observation.value) for observation in execution.observations] == [
         ('hostname', 'partial.example.com')
     ]
+
+
+@pytest.mark.parametrize(
+    ('source', 'module', 'constructor_name'),
+    [
+        ('chaos', theharvester_main.chaos, 'SearchChaos'),
+        ('bevigil', theharvester_main.bevigil, 'SearchBeVigil'),
+    ],
+)
+@pytest.mark.asyncio
+async def test_constructor_missing_credentials_are_persisted_as_skipped_source(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+    module: ModuleType,
+    constructor_name: str,
+) -> None:
+    saved_results: list[CompletedResult] = []
+
+    class RecordingResultStore(_NoopResultStore):
+        async def save_run(self, result: CompletedResult) -> None:
+            saved_results.append(result)
+
+    class MissingCredentialSource:
+        construction_count = 0
+
+        def __init__(self, _word: str) -> None:
+            type(self).construction_count += 1
+            raise MissingKey(source)
+
+    monkeypatch.setattr(theharvester_main, 'ResultStore', RecordingResultStore)
+    monkeypatch.setattr(module, constructor_name, MissingCredentialSource)
+
+    response = await theharvester_main.start(
+        EnumerationOptions(domain='example.com', source=source, quiet=True),
+        return_completed_result=True,
+    )
+
+    completed = response[-1]
+    assert isinstance(completed, CompletedResult)
+    assert saved_results == [completed]
+    assert MissingCredentialSource.construction_count == 1
+    assert len(completed.source_executions) == 1
+    execution = completed.source_executions[0]
+    assert execution.source == source
+    assert execution.status == 'skipped'
+    assert execution.result_count == 0
+    assert execution.error_type == 'MissingKeyError'
+    assert execution.stop_reason == 'missing-credentials'
 
 
 @pytest.mark.asyncio

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -540,6 +540,9 @@ async def start(
     dns_resolution_failure_types: set[str] = set()
     dns_resolution_cancelled = False
 
+    def record_missing_credentials(source: str) -> None:
+        source_executions.append(SourceExecution(source, 'skipped', 0, 0, 'MissingKeyError', 'missing-credentials'))
+
     def confirmed_virtual_hostnames() -> list[str]:
         return sorted({observation.hostname for observation in vhost_observations})
 
@@ -933,6 +936,8 @@ async def start(
                             )
                         )
                     except Exception as e:
+                        if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                         show_default_error_message(engineitem, word, error=e)
 
                 elif engineitem == 'brave':
@@ -945,6 +950,8 @@ async def start(
                             )
                         )
                     except Exception as e:
+                        if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                         show_default_error_message(engineitem, word, error=e)
 
                 elif engineitem == 'bufferoverun':
@@ -957,6 +964,8 @@ async def start(
                             )
                         )
                     except Exception as e:
+                        if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                         show_default_error_message(engineitem, word, e)
 
                 elif engineitem == 'builtwith':
@@ -965,6 +974,7 @@ async def start(
                         stor_lst.append(store(builtwith_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             output_logger.info(f"Failed to perform BuiltWith search for word: '{word}'")
                             output_logger.info(f'A Missing Key Error occurred in builtwith: {e}')
                         else:
@@ -980,6 +990,7 @@ async def start(
                             )
                         )
                     except MissingKey as mk:
+                        record_missing_credentials(engineitem)
                         if not args.quiet:
                             output_logger.info(f'Censys API key is missing or invalid: {mk}')
                     except ConnectionError as ce:
@@ -1009,6 +1020,7 @@ async def start(
                         if not args.quiet:
                             output_logger.info(f'Certspotter returned invalid data: {ve}')
                     except MissingKey as mk:
+                        record_missing_credentials(engineitem)
                         if not args.quiet:
                             output_logger.info(f'Unexpected response structure from Certspotter (missing key): {mk}')
                     except Exception as e:
@@ -1026,6 +1038,7 @@ async def start(
                         )
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in Chaos: {e}')
                         else:
@@ -1054,6 +1067,7 @@ async def start(
                         )
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing key error occurred in criminalip: {e}')
                         else:
@@ -1077,6 +1091,7 @@ async def start(
                         )
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in dehashed: {e}')
                         else:
@@ -1087,6 +1102,7 @@ async def start(
                         dnsdb_search = dnsdb.SearchDNSDB(word)
                         stor_lst.append(store(dnsdb_search, engineitem))
                     except MissingKey as e:
+                        record_missing_credentials(engineitem)
                         if not args.quiet:
                             output_logger.info(e)
                     except Exception as e:
@@ -1102,6 +1118,7 @@ async def start(
                             )
                         )
                     except MissingKey as e:
+                        record_missing_credentials(engineitem)
                         if not args.quiet:
                             output_logger.info(e)
                     except Exception as e:
@@ -1122,6 +1139,7 @@ async def start(
                         stor_lst.append(store(dymo_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in dymo: {e}')
                         else:
@@ -1138,6 +1156,7 @@ async def start(
                         )
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in Fofa: {e}')
                         else:
@@ -1149,6 +1168,7 @@ async def start(
                         stor_lst.append(store(fullhunt_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in fullhunt: {e}')
 
@@ -1162,6 +1182,7 @@ async def start(
                             )
                         )
                     except MissingKey as ex:
+                        record_missing_credentials(engineitem)
                         if not args.quiet:
                             output_logger.info(f'A Missing Key error occurred in github-code: {ex}')
 
@@ -1201,6 +1222,7 @@ async def start(
                         hibp_search = hibpverified.SearchHibpVerified(word)
                         stor_lst.append(store(hibp_search, engineitem))
                     except MissingKey as error:
+                        record_missing_credentials(engineitem)
                         if not args.quiet:
                             output_logger.info(f'A Missing Key error occurred in hibpverified: {error}')
                     except Exception as error:
@@ -1229,6 +1251,7 @@ async def start(
                         )
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in Hunter: {e}')
 
@@ -1238,6 +1261,7 @@ async def start(
                         stor_lst.append(store(hunterhow_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in Hunter How: {e}')
                         else:
@@ -1254,6 +1278,7 @@ async def start(
                         )
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in intelx: {e}')
                         else:
@@ -1269,6 +1294,7 @@ async def start(
                             )
                         )
                     except MissingKey as e:
+                        record_missing_credentials(engineitem)
                         if not args.quiet:
                             output_logger.info(e)
                     except Exception as e:
@@ -1285,6 +1311,7 @@ async def start(
                         )
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             output_logger.info(f'A Missing Key error occurred in LeakLookup: {e}')
                         else:
                             output_logger.info(f'An exception has occurred in LeakLookup search: {e}')
@@ -1300,6 +1327,7 @@ async def start(
                         )
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             output_logger.info(f'A Missing Key error occurred in Mojeek: {e}')
                         else:
                             output_logger.info(f'An exception has occurred in Mojeek search: {e}')
@@ -1315,6 +1343,7 @@ async def start(
                         )
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in Netlas: {e}')
 
@@ -1340,6 +1369,8 @@ async def start(
                         if not args.quiet:
                             output_logger.info(f'Unexpected response structure from Onyphe (missing key): {ke}')
                     except Exception as e:
+                        if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                         if not args.quiet:
                             output_logger.info(f'Unexpected error occurred in Onyphe module: {e}')
 
@@ -1374,6 +1405,7 @@ async def start(
                         stor_lst.append(store(pentesttools_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in PentestTools search: {e}')
                         else:
@@ -1385,6 +1417,7 @@ async def start(
                         stor_lst.append(store(projectdiscovery_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in ProjectDiscovery: {e}')
                         else:
@@ -1428,6 +1461,7 @@ async def start(
                         stor_lst.append(store(rocketreach_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in RocketReach: {e}')
                         else:
@@ -1444,6 +1478,7 @@ async def start(
                         )
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             output_logger.info(MissingKey('SecurityScorecard'))
                         else:
                             output_logger.info(f'An exception has occurred in SecurityScorecard search: {e}')
@@ -1459,6 +1494,7 @@ async def start(
                         )
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred Security Trails: {e}')
 
@@ -1473,6 +1509,7 @@ async def start(
                         )
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in sherlockeye: {e}')
                         else:
@@ -1517,6 +1554,7 @@ async def start(
                         stor_lst.append(store(shodan_wrapper, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in Shodan search: {e}')
                         else:
@@ -1574,6 +1612,7 @@ async def start(
                         stor_lst.append(store(subdomainfinderc99_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in Subdomainfinderc99 search: {e}')
                         else:
@@ -1597,6 +1636,7 @@ async def start(
                         )
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in Tomba: {e}')
 
@@ -1631,6 +1671,7 @@ async def start(
                         stor_lst.append(store(virustotal_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in virustotal search: {e}')
 
@@ -1652,6 +1693,7 @@ async def start(
                         stor_lst.append(store(whoisxml_search, engineitem))
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in whoisxml search: {e}')
                         else:
@@ -1705,6 +1747,7 @@ async def start(
                         )
                     except Exception as e:
                         if isinstance(e, MissingKey):
+                            record_missing_credentials(engineitem)
                             if not args.quiet:
                                 output_logger.info(f'A Missing Key error occurred in zoomeye: {e}')
 


### PR DESCRIPTION
## Summary

- record constructor-time `MissingKey` failures as one skipped `SourceExecution`
- persist `error_type="MissingKeyError"` and `stop_reason="missing-credentials"` through one shared helper
- cover explicit and broad constructor catch styles without changing API-scanner or ordinary `KeyError` handling

## Root cause

Discovery adapters are constructed before `store()` starts. When a constructor raised `MissingKey`, the dispatch branch logged and swallowed it, so the final fallback could only persist the generic `SourceDidNotStart` outcome.

## Impact

Persisted run evidence now distinguishes an unconfigured credential from an unexplained source startup failure. Existing provider execution, request behavior, and compatibility identifiers are unchanged.

## Verification

- `pytest -q` — 932 passed, 6 skipped, 23 deselected
- `ruff check .`
- `ruff format --check .`
- `mypy theHarvester`
- `git diff --check`
- independent Standards and Spec reviews: no remaining findings
- fork CI: CodeQL, dependency review, Docker, and Python 3.12/3.13/3.14 all passed

This replacement branch is based directly on upstream `dev` and contains one commit touching only `theHarvester/__main__.py` and `tests/test_main.py`.

Tracking issue: https://github.com/NotoriousRebel/theHarvester/issues/272
