### PR TITLE
Add APIs.guru hostname, email, and URL discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added bounded, keyless APIs.guru discovery through exact target-domain directory lookups, retaining only target-scoped hostnames, contact emails, and URLs from preferred OpenAPI specifications.
 - Added bounded virtual host discovery over harvested or operator-supplied literal-IP endpoints, with aligned HTTP `Host` and TLS SNI, synthetic unknown-host controls, hard request and runtime limits, and structured observations on canonical hostname results in JSONL, SQLite, the API, and HarvestView.
 - Added HarvestView, an authenticated local browser workspace backed by a durable single-worker `/api/v1` run lifecycle with cancellation, deadlines, JSONL-only file interchange, retained partial evidence, and real-browser regression coverage.
 - Added a pinned, non-root Docker Compose deployment for HarvestView and the REST API with localhost-only publishing, file-secret authentication, private durable run storage, and an authenticated API health check.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Read the **API key** column as follows:
 
 | Source | Subdomains | Emails | IPs | ASNs | URLs | People | Breaches | Additional action output (not consolidated report) | API key |
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- | :---: |
+| `apis-guru` | ✓ | ✓ | No | No | ✓ | No | No | No | No |
 | `arquivo` | ✓ | No | No | No | No | No | No | No | No |
 | `baidu` | ✓ | ✓ | No | No | No | No | No | No | No |
 | `bevigil` | ✓ | No | No | No | ✓ | No | No | No | ✓ |
@@ -218,6 +219,8 @@ Read the **API key** column as follows:
 | `zoomeye` | ✓ | ✓ | ✓ | ✓ | ✓ | No | No | No | ✓ |
 
 </details>
+
+`apis-guru` performs P0 provider-side collection through APIs.guru's public v2 API. It requests the exact target-domain directory entry and follows every matching preferred OpenAPI specification within hard 1,000-entry and 10-minute safety ceilings. `--limit` bounds retained results per output type without truncating catalog traversal. The source retains only target-scoped hostnames, contact emails, and HTTP(S) URLs; external OAuth, CDN, and third-party server references are excluded. API specifications, operations, security declarations, version provenance, and external relationships remain deferred until the normalized evidence model can represent them without flattening their meaning.
 
 Provider pricing is intentionally omitted because plans and quotas change frequently. See [Configuration and API Keys](docs/wiki/Configuration-and-API-Keys.md) and each provider's current documentation.
 

--- a/tests/discovery/test_apisguru.py
+++ b/tests/discovery/test_apisguru.py
@@ -1,0 +1,973 @@
+import asyncio
+from typing import Any
+
+import pytest
+
+from theHarvester.discovery import apisguru
+from theHarvester.lib.core import FetcherResponse, ResponseStreamError
+
+
+@pytest.mark.asyncio
+async def test_preferred_openapi_three_spec_returns_only_target_scoped_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_url = 'https://api.apis.guru/v2/specs/api.example.com/payments/1.0.0/openapi.json'
+    responses = [
+        FetcherResponse(
+            body={
+                'apis': {
+                    'example.com:payments': {
+                        'info': {'title': 'Payments', 'x-providerName': 'example.com'},
+                        'swaggerUrl': spec_url,
+                        'openapiVer': '3.0.3',
+                    },
+                    'notexample.com': {
+                        'info': {'title': 'Example Brand API', 'x-providerName': 'notexample.com'},
+                        'swaggerUrl': 'https://api.apis.guru/v2/specs/notexample.com/1.0.0/openapi.json',
+                        'openapiVer': '3.0.3',
+                    },
+                    'example.com.evil': {
+                        'info': {'x-providerName': 'example.com.evil'},
+                        'swaggerUrl': 'https://api.apis.guru/v2/specs/example.com.evil/1.0.0/openapi.json',
+                        'openapiVer': '3.0.3',
+                    },
+                }
+            },
+            status=200,
+            headers={},
+        ),
+        FetcherResponse(
+            body={
+                'openapi': '3.0.3',
+                'servers': [
+                    {'url': 'https://api.example.com/v1'},
+                    {'url': 'https://{tenant}.example.com/v1'},
+                    {'url': 'https://api.example.com/{version}'},
+                    {'url': 'https://auth.vendor.test/oauth'},
+                    {'url': 'https://example.com.evil/v1'},
+                ],
+                'info': {
+                    'contact': {
+                        'email': 'Security@Example.COM',
+                        'url': 'https://developers.example.com/support',
+                    },
+                    'termsOfService': 'https://legal.example.com/terms',
+                },
+                'externalDocs': {'url': 'https://docs.example.com/reference'},
+            },
+            status=200,
+            headers={},
+        ),
+    ]
+    calls: list[dict[str, Any]] = []
+
+    async def fake_fetch(**kwargs: Any) -> FetcherResponse:
+        calls.append(kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    await search.process(proxy=True)
+
+    assert await search.get_hostnames() == {
+        'api.example.com',
+        'developers.example.com',
+        'docs.example.com',
+        'legal.example.com',
+    }
+    assert await search.get_emails() == {'security@example.com'}
+    assert await search.get_urls() == {
+        'https://api.example.com/v1',
+        'https://developers.example.com/support',
+        'https://docs.example.com/reference',
+        'https://legal.example.com/terms',
+    }
+    assert [call['url'] for call in calls] == [
+        'https://api.apis.guru/v2/example.com.json',
+        spec_url,
+    ]
+    assert all(call['proxy'] is True for call in calls)
+    assert all(call['request_timeout'] == 60 for call in calls)
+    assert all(set(call) == {'url', 'proxy', 'request_timeout'} for call in calls)
+    assert search.execution_status == 'completed'
+    assert search.stop_reason is None
+
+
+@pytest.mark.asyncio
+async def test_templated_server_path_retains_its_concrete_hostname(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_url = 'https://api.apis.guru/v2/specs/example.com/templated/1.0/openapi.json'
+    responses = [
+        FetcherResponse(
+            body={
+                'apis': {
+                    'example.com:templated': {
+                        'info': {'x-providerName': 'example.com'},
+                        'swaggerUrl': spec_url,
+                        'openapiVer': '3.0.3',
+                    }
+                }
+            },
+            status=200,
+            headers={},
+        ),
+        FetcherResponse(
+            body={'openapi': '3.0.3', 'servers': [{'url': 'https://api.example.com/{version}'}]},
+            status=200,
+            headers={},
+        ),
+    ]
+
+    async def fake_fetch(**_kwargs: Any) -> FetcherResponse:
+        return responses.pop(0)
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=500)
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com'}
+    assert await search.get_urls() == set()
+    assert search.execution_status == 'completed'
+    assert search.stop_reason is None
+
+
+@pytest.mark.asyncio
+async def test_unwrapped_directory_and_openapi_two_spec_are_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_url = 'https://api.apis.guru/v2/specs/example.com/2.0/swagger.json'
+    responses = [
+        FetcherResponse(
+            body={
+                'example.com': {
+                    'preferred': '2.0',
+                    'versions': {
+                        '2.0': {
+                            'info': {'x-providerName': 'example.com'},
+                            'swaggerUrl': spec_url,
+                        }
+                    },
+                }
+            },
+            status=200,
+            headers={},
+        ),
+        FetcherResponse(
+            body={
+                'swagger': '2.0',
+                'host': 'API.Example.COM',
+                'basePath': '/v2',
+                'schemes': ['https', 'http', 'ftp'],
+                'info': {
+                    'contact': {
+                        'email': 'Ops@example.com',
+                        'url': 'https://support.example.com/help?token=discarded#fragment',
+                    },
+                },
+            },
+            status=200,
+            headers={},
+        ),
+    ]
+
+    async def fake_fetch(**_kwargs: Any) -> FetcherResponse:
+        return responses.pop(0)
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('EXAMPLE.com.', limit=5)
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com', 'support.example.com'}
+    assert await search.get_emails() == {'ops@example.com'}
+    assert await search.get_urls() == {
+        'http://api.example.com/v2',
+        'https://api.example.com/v2',
+        'https://support.example.com/help',
+    }
+    assert search.execution_status == 'completed'
+    assert search.stop_reason is None
+
+
+@pytest.mark.asyncio
+async def test_external_spec_url_is_not_fetched_and_valid_results_remain_partial(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    valid_spec_url = 'https://api.apis.guru/v2/specs/example.com/good/1.0/openapi.json'
+    responses = [
+        FetcherResponse(
+            body={
+                'apis': {
+                    'example.com:bad': {
+                        'preferred': '1.0',
+                        'versions': {
+                            '1.0': {
+                                'info': {'x-providerName': 'example.com'},
+                                'swaggerUrl': 'https://attacker.test/spec.json',
+                            }
+                        },
+                    },
+                    'example.com:good': {
+                        'preferred': '1.0',
+                        'versions': {
+                            '1.0': {
+                                'info': {'x-providerName': 'example.com'},
+                                'swaggerUrl': valid_spec_url,
+                            }
+                        },
+                    },
+                }
+            },
+            status=200,
+            headers={},
+        ),
+        FetcherResponse(
+            body={'openapi': '3.0.3', 'servers': [{'url': 'https://api.example.com/v1'}]},
+            status=200,
+            headers={},
+        ),
+    ]
+    requested_urls: list[str] = []
+
+    async def fake_fetch(**kwargs: Any) -> FetcherResponse:
+        requested_urls.append(kwargs['url'])
+        return responses.pop(0)
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    await search.process()
+
+    assert requested_urls == ['https://api.apis.guru/v2/example.com.json', valid_spec_url]
+    assert await search.get_hostnames() == {'api.example.com'}
+    assert search.execution_status == 'partial'
+    assert search.stop_reason == 'invalid-response'
+
+
+@pytest.mark.asyncio
+async def test_preferred_spec_requests_are_not_artificially_capped_at_five(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_urls = [f'https://api.apis.guru/v2/specs/example.com/service-{index}/1.0/openapi.json' for index in range(6)]
+    directory = {
+        f'example.com:service-{index}': {
+            'info': {'x-providerName': 'example.com'},
+            'swaggerUrl': spec_url,
+            'openapiVer': '3.0.3',
+        }
+        for index, spec_url in enumerate(spec_urls)
+    }
+    requested_urls: list[str] = []
+
+    async def fake_fetch(**kwargs: Any) -> FetcherResponse:
+        requested_urls.append(kwargs['url'])
+        if kwargs['url'] == 'https://api.apis.guru/v2/example.com.json':
+            return FetcherResponse(body={'apis': directory}, status=200, headers={})
+        index = spec_urls.index(kwargs['url'])
+        return FetcherResponse(
+            body={'openapi': '3.0.3', 'servers': [{'url': f'https://api-{index}.example.com'}]},
+            status=200,
+            headers={},
+        )
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=500)
+
+    await search.process()
+
+    assert requested_urls == ['https://api.apis.guru/v2/example.com.json', *spec_urls]
+    assert await search.get_hostnames() == {f'api-{index}.example.com' for index in range(6)}
+    assert search.execution_status == 'completed'
+    assert search.stop_reason is None
+
+
+@pytest.mark.asyncio
+async def test_oversized_preferred_spec_does_not_discard_later_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_urls = [
+        'https://api.apis.guru/v2/specs/example.com/oversized/1.0/openapi.json',
+        'https://api.apis.guru/v2/specs/example.com/usable/1.0/openapi.json',
+    ]
+    directory = {
+        f'example.com:service-{index}': {
+            'info': {'x-providerName': 'example.com'},
+            'swaggerUrl': spec_url,
+            'openapiVer': '3.0.3',
+        }
+        for index, spec_url in enumerate(spec_urls)
+    }
+    requested_urls: list[str] = []
+
+    async def fake_fetch(**kwargs: Any) -> FetcherResponse:
+        requested_urls.append(kwargs['url'])
+        if kwargs['url'] == 'https://api.apis.guru/v2/example.com.json':
+            return FetcherResponse(body={'apis': directory}, status=200, headers={})
+        if kwargs['url'] == spec_urls[0]:
+            raise ResponseStreamError('response-limit')
+        return FetcherResponse(
+            body={'openapi': '3.0.3', 'servers': [{'url': 'https://api.example.com'}]},
+            status=200,
+            headers={},
+        )
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=500)
+
+    await search.process()
+
+    assert requested_urls == ['https://api.apis.guru/v2/example.com.json', *spec_urls]
+    assert await search.get_hostnames() == {'api.example.com'}
+    assert search.execution_status == 'partial'
+    assert search.stop_reason == 'response-limit'
+
+
+@pytest.mark.asyncio
+async def test_missing_preferred_spec_does_not_discard_later_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_urls = [
+        'https://api.apis.guru/v2/specs/example.com/missing/1.0/openapi.json',
+        'https://api.apis.guru/v2/specs/example.com/usable/1.0/openapi.json',
+    ]
+    directory = {
+        f'example.com:service-{index}': {
+            'info': {'x-providerName': 'example.com'},
+            'swaggerUrl': spec_url,
+            'openapiVer': '3.0.3',
+        }
+        for index, spec_url in enumerate(spec_urls)
+    }
+    requested_urls: list[str] = []
+
+    async def fake_fetch(**kwargs: Any) -> FetcherResponse:
+        requested_urls.append(kwargs['url'])
+        if kwargs['url'] == 'https://api.apis.guru/v2/example.com.json':
+            return FetcherResponse(body={'apis': directory}, status=200, headers={})
+        if kwargs['url'] == spec_urls[0]:
+            return FetcherResponse(body=None, status=404, headers={})
+        return FetcherResponse(
+            body={'openapi': '3.0.3', 'servers': [{'url': 'https://api.example.com'}]},
+            status=200,
+            headers={},
+        )
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=500)
+
+    await search.process()
+
+    assert requested_urls == ['https://api.apis.guru/v2/example.com.json', *spec_urls]
+    assert await search.get_hostnames() == {'api.example.com'}
+    assert search.execution_status == 'partial'
+    assert search.stop_reason == 'http-404'
+
+
+@pytest.mark.asyncio
+async def test_access_denied_preferred_spec_stops_before_later_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_urls = [
+        'https://api.apis.guru/v2/specs/example.com/forbidden/1.0/openapi.json',
+        'https://api.apis.guru/v2/specs/example.com/later/1.0/openapi.json',
+    ]
+    directory = {
+        f'example.com:service-{index}': {
+            'info': {'x-providerName': 'example.com'},
+            'swaggerUrl': spec_url,
+            'openapiVer': '3.0.3',
+        }
+        for index, spec_url in enumerate(spec_urls)
+    }
+    requested_urls: list[str] = []
+
+    async def fake_fetch(**kwargs: Any) -> FetcherResponse:
+        requested_urls.append(kwargs['url'])
+        if kwargs['url'] == 'https://api.apis.guru/v2/example.com.json':
+            return FetcherResponse(body={'apis': directory}, status=200, headers={})
+        return FetcherResponse(body=None, status=403, headers={})
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=500)
+
+    await search.process()
+
+    assert requested_urls == ['https://api.apis.guru/v2/example.com.json', spec_urls[0]]
+    assert search.execution_status == 'failed'
+    assert search.stop_reason == 'access-denied'
+
+
+@pytest.mark.asyncio
+async def test_result_limit_does_not_truncate_preferred_spec_traversal(monkeypatch: pytest.MonkeyPatch) -> None:
+    spec_urls = [f'https://api.apis.guru/v2/specs/example.com/service-{index}/1.0/openapi.json' for index in range(3)]
+    directory = {
+        f'example.com:service-{index}': {
+            'preferred': '1.0',
+            'versions': {
+                '1.0': {
+                    'info': {'x-providerName': 'example.com'},
+                    'swaggerUrl': spec_url,
+                }
+            },
+        }
+        for index, spec_url in enumerate(spec_urls)
+    }
+    responses = [
+        FetcherResponse(body={'apis': directory}, status=200, headers={}),
+        FetcherResponse(
+            body={'openapi': '3.0.3', 'servers': [{'url': 'https://one.example.com'}]},
+            status=200,
+            headers={},
+        ),
+        FetcherResponse(
+            body={'openapi': '3.0.3', 'servers': [{'url': 'https://two.example.com'}]},
+            status=200,
+            headers={},
+        ),
+        FetcherResponse(
+            body={'openapi': '3.0.3', 'servers': [{'url': 'https://three.example.com'}]},
+            status=200,
+            headers={},
+        ),
+    ]
+    requested_urls: list[str] = []
+
+    async def fake_fetch(**kwargs: Any) -> FetcherResponse:
+        requested_urls.append(kwargs['url'])
+        return responses.pop(0)
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=2)
+
+    await search.process()
+
+    assert requested_urls == ['https://api.apis.guru/v2/example.com.json', *spec_urls]
+    assert await search.get_hostnames() == {'one.example.com', 'two.example.com'}
+    assert await search.get_urls() == {'https://one.example.com', 'https://two.example.com'}
+    assert search.execution_status == 'partial'
+    assert search.stop_reason == 'result-limit'
+
+
+@pytest.mark.asyncio
+async def test_malformed_preferred_spec_does_not_discard_later_valid_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_urls = [
+        'https://api.apis.guru/v2/specs/example.com/a/1.0/openapi.json',
+        'https://api.apis.guru/v2/specs/example.com/b/1.0/openapi.json',
+    ]
+    directory = {
+        f'example.com:{service}': {
+            'preferred': '1.0',
+            'versions': {
+                '1.0': {
+                    'info': {'x-providerName': 'example.com'},
+                    'swaggerUrl': spec_url,
+                }
+            },
+        }
+        for service, spec_url in zip(('a', 'b'), spec_urls, strict=True)
+    }
+    responses = [
+        FetcherResponse(body={'apis': directory}, status=200, headers={}),
+        FetcherResponse(body=['not-an-openapi-object'], status=200, headers={}),
+        FetcherResponse(
+            body={'openapi': '3.0.3', 'servers': [{'url': 'https://api.example.com/v2'}]},
+            status=200,
+            headers={},
+        ),
+    ]
+
+    async def fake_fetch(**_kwargs: Any) -> FetcherResponse:
+        return responses.pop(0)
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com'}
+    assert search.execution_status == 'partial'
+    assert search.stop_reason == 'invalid-response'
+
+
+@pytest.mark.asyncio
+async def test_malformed_spec_fields_preserve_scoped_results_as_partial(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_url = 'https://api.apis.guru/v2/specs/example.com/1.0/openapi.json'
+    responses = [
+        FetcherResponse(
+            body={
+                'example.com': {
+                    'preferred': '1.0',
+                    'versions': {
+                        '1.0': {
+                            'info': {'x-providerName': 'example.com'},
+                            'swaggerUrl': spec_url,
+                        }
+                    },
+                }
+            },
+            status=200,
+            headers={},
+        ),
+        FetcherResponse(
+            body={
+                'openapi': '3.0.3',
+                'servers': [{'url': 'https://api.example.com/v1'}, None, {'url': 7}],
+                'info': {'contact': {'email': 7}},
+            },
+            status=200,
+            headers={},
+        ),
+    ]
+
+    async def fake_fetch(**_kwargs: Any) -> FetcherResponse:
+        return responses.pop(0)
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com'}
+    assert await search.get_emails() == set()
+    assert search.execution_status == 'partial'
+    assert search.stop_reason == 'invalid-response'
+
+
+@pytest.mark.asyncio
+async def test_malformed_matching_directory_entry_is_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch(**_kwargs: Any) -> FetcherResponse:
+        return FetcherResponse(
+            body={
+                'apis': {
+                    'example.com:broken': {'preferred': '1.0', 'versions': {}},
+                    'notexample.com:ignored': None,
+                }
+            },
+            status=200,
+            headers={},
+        )
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert search.execution_status == 'failed'
+    assert search.stop_reason == 'invalid-response'
+
+
+@pytest.mark.asyncio
+async def test_directory_entry_scan_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    spec_urls = [f'https://api.apis.guru/v2/specs/example.com/service-{index}/1.0/openapi.json' for index in range(2)]
+    directory = {
+        f'example.com:service-{index}': {
+            'preferred': '1.0',
+            'versions': {
+                '1.0': {
+                    'info': {'x-providerName': 'example.com'},
+                    'swaggerUrl': spec_url,
+                }
+            },
+        }
+        for index, spec_url in enumerate(spec_urls)
+    }
+    responses = [
+        FetcherResponse(body={'apis': directory}, status=200, headers={}),
+        FetcherResponse(
+            body={'openapi': '3.0.3', 'servers': [{'url': 'https://api.example.com'}]},
+            status=200,
+            headers={},
+        ),
+    ]
+    requested_urls: list[str] = []
+
+    async def fake_fetch(**kwargs: Any) -> FetcherResponse:
+        requested_urls.append(kwargs['url'])
+        return responses.pop(0)
+
+    monkeypatch.setattr(apisguru.SearchApisGuru, 'MAX_DIRECTORY_ENTRIES', 1)
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    await search.process()
+
+    assert requested_urls == ['https://api.apis.guru/v2/example.com.json', spec_urls[0]]
+    assert await search.get_hostnames() == {'api.example.com'}
+    assert search.execution_status == 'partial'
+    assert search.stop_reason == 'directory-entry-limit'
+
+
+@pytest.mark.asyncio
+async def test_openapi_two_host_is_retained_without_inventing_a_server_scheme(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_url = 'https://api.apis.guru/v2/specs/example.com/1.0/swagger.json'
+    responses = [
+        FetcherResponse(
+            body={
+                'example.com': {
+                    'preferred': '1.0',
+                    'versions': {
+                        '1.0': {
+                            'info': {'x-providerName': 'example.com'},
+                            'swaggerUrl': spec_url,
+                        }
+                    },
+                }
+            },
+            status=200,
+            headers={},
+        ),
+        FetcherResponse(
+            body={'swagger': '2.0', 'host': 'api.example.com', 'basePath': '/v1'},
+            status=200,
+            headers={},
+        ),
+    ]
+
+    async def fake_fetch(**_kwargs: Any) -> FetcherResponse:
+        return responses.pop(0)
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com'}
+    assert await search.get_urls() == set()
+    assert search.execution_status == 'completed'
+    assert search.stop_reason is None
+
+
+@pytest.mark.parametrize(
+    ('response', 'execution_status', 'stop_reason'),
+    [
+        (None, 'failed', 'transport-error'),
+        (FetcherResponse(body={}, status=401, headers={}), 'failed', 'access-denied'),
+        (FetcherResponse(body={}, status=403, headers={}), 'failed', 'access-denied'),
+        (FetcherResponse(body={}, status=429, headers={}), 'rate-limited', 'http-429'),
+        (FetcherResponse(body={}, status=503, headers={}), 'failed', 'http-503'),
+        (FetcherResponse(body=[], status=200, headers={}), 'failed', 'invalid-response'),
+        (FetcherResponse(body={'apis': []}, status=200, headers={}), 'failed', 'invalid-response'),
+    ],
+)
+@pytest.mark.asyncio
+async def test_directory_failures_are_attributed(
+    monkeypatch: pytest.MonkeyPatch,
+    response: FetcherResponse | None,
+    execution_status: str,
+    stop_reason: str,
+) -> None:
+    async def fake_fetch(**_kwargs: Any) -> FetcherResponse | None:
+        return response
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert search.execution_status == execution_status
+    assert search.stop_reason == stop_reason
+
+
+@pytest.mark.asyncio
+async def test_missing_provider_is_completed_with_no_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch(**_kwargs: Any) -> FetcherResponse:
+        return FetcherResponse(body={}, status=404, headers={})
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    await search.process()
+
+    assert search.execution_status == 'completed'
+    assert search.stop_reason == 'no-results'
+
+
+@pytest.mark.parametrize('target', ['example.com/path', 'localhost', '192.0.2.1', 'straße.de'])
+@pytest.mark.asyncio
+async def test_invalid_target_is_rejected_before_provider_request(
+    monkeypatch: pytest.MonkeyPatch,
+    target: str,
+) -> None:
+    async def fake_fetch(**_kwargs: Any) -> FetcherResponse:
+        raise AssertionError('provider must not be contacted')
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru(target, limit=5)
+
+    await search.process()
+
+    assert search.execution_status == 'failed'
+    assert search.stop_reason == 'invalid-target'
+
+
+@pytest.mark.asyncio
+async def test_malformed_contact_email_is_not_retained(monkeypatch: pytest.MonkeyPatch) -> None:
+    spec_url = 'https://api.apis.guru/v2/specs/example.com/1.0/openapi.json'
+    responses = [
+        FetcherResponse(
+            body={
+                'example.com': {
+                    'preferred': '1.0',
+                    'versions': {
+                        '1.0': {
+                            'info': {'x-providerName': 'example.com'},
+                            'swaggerUrl': spec_url,
+                        }
+                    },
+                }
+            },
+            status=200,
+            headers={},
+        ),
+        FetcherResponse(
+            body={'openapi': '3.0.3', 'info': {'contact': {'email': '<x>@example.com'}}},
+            status=200,
+            headers={},
+        ),
+    ]
+
+    async def fake_fetch(**_kwargs: Any) -> FetcherResponse:
+        return responses.pop(0)
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    await search.process()
+
+    assert await search.get_emails() == set()
+    assert search.execution_status == 'completed'
+    assert search.stop_reason == 'no-results'
+
+
+@pytest.mark.parametrize(
+    'url',
+    [
+        'https://api.apis.guru/v2/specs/../../admin.json',
+        'https://api.apis.guru/v2/specs/%2e%2e/%2e%2e/admin.json',
+        'https://api.apis.guru/v2/specs/example.com/%5c..%5cadmin.json',
+        'https://api.apis.guru/v2/specs/example.com/\x1b.json',
+        f'https://api.apis.guru/v2/specs/example.com/{"x" * 4096}.json',
+    ],
+)
+def test_spec_url_rejects_noncanonical_paths(url: str) -> None:
+    assert apisguru.SearchApisGuru._spec_url(url) is None
+
+
+@pytest.mark.parametrize(
+    'url',
+    [
+        'https://api.example.com/path with space',
+        'https://api.example.com/\x1b[31m',
+        'https://api.example.com/\ud800',
+        f'https://api.example.com/{"x" * 4096}',
+    ],
+)
+def test_url_projection_rejects_unsafe_or_oversized_text(url: str) -> None:
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    search._add_url(url)
+
+    assert search.totalhosts == set()
+    assert search.urls == set()
+
+
+def test_quoted_contact_email_is_reconstructed_without_losing_required_quotes() -> None:
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    search._add_email('"A B"@Example.com')
+
+    assert search.totalemails == {'"a b"@example.com'}
+
+
+def test_oversized_contact_email_is_not_retained() -> None:
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    search._add_email(f'{"a" * 65}@example.com')
+
+    assert search.totalemails == set()
+
+
+@pytest.mark.asyncio
+async def test_directory_response_byte_limit_is_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch(**_kwargs: Any) -> FetcherResponse:
+        raise ResponseStreamError('response-limit')
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    await search.process()
+
+    assert search.execution_status == 'failed'
+    assert search.stop_reason == 'response-limit'
+
+
+@pytest.mark.asyncio
+async def test_apex_only_hostname_is_not_counted_as_a_retained_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    spec_url = 'https://api.apis.guru/v2/specs/example.com/1.0/swagger.json'
+    responses = [
+        FetcherResponse(
+            body={
+                'apis': {
+                    'example.com': {
+                        'info': {'x-providerName': 'example.com'},
+                        'swaggerUrl': spec_url,
+                        'openapiVer': '2.0',
+                    }
+                }
+            },
+            status=200,
+            headers={},
+        ),
+        FetcherResponse(body={'swagger': '2.0', 'host': 'example.com'}, status=200, headers={}),
+    ]
+
+    async def fake_fetch(**_kwargs: Any) -> FetcherResponse:
+        return responses.pop(0)
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    await search.process()
+
+    assert await search.get_hostnames() == set()
+    assert search.execution_status == 'completed'
+    assert search.stop_reason == 'no-results'
+
+
+@pytest.mark.asyncio
+async def test_scalar_results_are_hard_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    spec_url = 'https://api.apis.guru/v2/specs/example.com/1.0/openapi.json'
+    responses = [
+        FetcherResponse(
+            body={
+                'apis': {
+                    'example.com': {
+                        'info': {'x-providerName': 'example.com'},
+                        'swaggerUrl': spec_url,
+                        'openapiVer': '3.0.3',
+                    }
+                }
+            },
+            status=200,
+            headers={},
+        ),
+        FetcherResponse(
+            body={
+                'openapi': '3.0.3',
+                'servers': [
+                    {'url': 'https://one.example.com'},
+                    {'url': 'https://two.example.com'},
+                ],
+            },
+            status=200,
+            headers={},
+        ),
+    ]
+
+    async def fake_fetch(**_kwargs: Any) -> FetcherResponse:
+        return responses.pop(0)
+
+    monkeypatch.setattr(apisguru.SearchApisGuru, 'MAX_RESULTS_PER_ROUTE', 1)
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'one.example.com'}
+    assert await search.get_urls() == {'https://one.example.com'}
+    assert search.execution_status == 'partial'
+    assert search.stop_reason == 'result-limit'
+
+
+@pytest.mark.asyncio
+async def test_cancellation_is_attributed_and_propagated(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch(**_kwargs: Any) -> FetcherResponse:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    with pytest.raises(asyncio.CancelledError):
+        await search.process()
+
+    assert search.execution_status == 'failed'
+    assert search.stop_reason == 'cancelled'
+
+
+@pytest.mark.asyncio
+async def test_runtime_limit_is_attributed(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch(**_kwargs: Any) -> FetcherResponse:
+        await asyncio.Event().wait()
+        raise AssertionError('unreachable')
+
+    monkeypatch.setattr(apisguru.SearchApisGuru, 'MAX_RUNTIME_SECONDS', 0.01)
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=500)
+
+    await search.process()
+
+    assert search.execution_status == 'failed'
+    assert search.stop_reason == 'runtime-limit'
+
+
+@pytest.mark.parametrize(
+    ('spec_response', 'execution_status', 'stop_reason'),
+    [
+        (None, 'failed', 'transport-error'),
+        (FetcherResponse(body={}, status=401, headers={}), 'failed', 'access-denied'),
+        (FetcherResponse(body={}, status=403, headers={}), 'failed', 'access-denied'),
+        (FetcherResponse(body={}, status=429, headers={}), 'rate-limited', 'http-429'),
+        (FetcherResponse(body={}, status=502, headers={}), 'failed', 'http-502'),
+        (FetcherResponse(body='not-json', status=200, headers={}), 'failed', 'invalid-response'),
+    ],
+)
+@pytest.mark.asyncio
+async def test_preferred_spec_failures_are_attributed(
+    monkeypatch: pytest.MonkeyPatch,
+    spec_response: FetcherResponse | None,
+    execution_status: str,
+    stop_reason: str,
+) -> None:
+    spec_url = 'https://api.apis.guru/v2/specs/example.com/1.0/openapi.json'
+    responses = [
+        FetcherResponse(
+            body={
+                'example.com': {
+                    'preferred': '1.0',
+                    'versions': {
+                        '1.0': {
+                            'info': {'x-providerName': 'example.com'},
+                            'swaggerUrl': spec_url,
+                        }
+                    },
+                }
+            },
+            status=200,
+            headers={},
+        ),
+        spec_response,
+    ]
+
+    async def fake_fetch(**_kwargs: Any) -> FetcherResponse | None:
+        return responses.pop(0)
+
+    monkeypatch.setattr(apisguru.AsyncFetcher, 'fetch_json', fake_fetch)
+    search = apisguru.SearchApisGuru('example.com', limit=5)
+
+    await search.process()
+
+    assert search.execution_status == execution_status
+    assert search.stop_reason == stop_reason

--- a/tests/lib/test_core.py
+++ b/tests/lib/test_core.py
@@ -22,6 +22,7 @@ def mock_environ(monkeypatch, tmp_path: Path):
 
 def test_email_capability_expands_to_email_sources() -> None:
     assert Core.expand_source_selection("emails") == [
+        "apis-guru",
         "baidu",
         "brave",
         "censys",
@@ -46,6 +47,7 @@ def test_email_capability_expands_to_email_sources() -> None:
 
 def test_capabilities_and_explicit_sources_form_a_union() -> None:
     assert Core.expand_source_selection("certspotter, urls") == [
+        "apis-guru",
         "bevigil",
         "builtwith",
         "certspotter",

--- a/tests/lib/test_source_catalog.py
+++ b/tests/lib/test_source_catalog.py
@@ -1,7 +1,7 @@
 import ast
 from pathlib import Path
 
-from theHarvester.discovery import bevigil, builtwith, gitlabsearch, intelxsearch, rocketreach, urlscan, zoomeyesearch
+from theHarvester.discovery import apisguru, bevigil, builtwith, gitlabsearch, intelxsearch, rocketreach, urlscan, zoomeyesearch
 from theHarvester.lib.core import Core
 from theHarvester.lib.source_catalog import SOURCE_SPECS, ResultRoute, SourceSpec, get_source_spec
 
@@ -50,6 +50,9 @@ def test_subdomain_route_drives_subdomain_capability() -> None:
 
 
 def test_source_specs_describe_consolidated_routes_not_getter_presence() -> None:
+    assert SOURCE_SPECS['apis-guru'].routes == frozenset(
+        {ResultRoute.SUBDOMAINS, ResultRoute.EMAILS, ResultRoute.URLS}
+    )
     assert SOURCE_SPECS['gitlab'].routes == frozenset({ResultRoute.SUBDOMAINS, ResultRoute.EMAILS, ResultRoute.URLS})
     assert SOURCE_SPECS['haveibeenpwned'].routes == frozenset({ResultRoute.BREACHES})
     assert SOURCE_SPECS['hibpverified'].routes == frozenset({ResultRoute.EMAILS, ResultRoute.BREACHES})
@@ -65,7 +68,7 @@ def test_source_specs_describe_consolidated_routes_not_getter_presence() -> None
 
 
 def test_every_url_source_uses_one_route() -> None:
-    url_sources = {'bevigil', 'builtwith', 'gitlab', 'intelx', 'rocketreach', 'urlscan', 'zoomeye'}
+    url_sources = {'apis-guru', 'bevigil', 'builtwith', 'gitlab', 'intelx', 'rocketreach', 'urlscan', 'zoomeye'}
 
     assert {spec.name for spec in SOURCE_SPECS.values() if ResultRoute.URLS in spec.routes} == url_sources
     assert {route.name for route in ResultRoute} == {
@@ -81,6 +84,7 @@ def test_every_url_source_uses_one_route() -> None:
 
 def test_every_url_adapter_uses_one_getter() -> None:
     adapters = (
+        apisguru.SearchApisGuru,
         bevigil.SearchBeVigil,
         builtwith.SearchBuiltWith,
         gitlabsearch.SearchGitlab,

--- a/tests/test_all_source_orchestration.py
+++ b/tests/test_all_source_orchestration.py
@@ -294,6 +294,7 @@ async def test_all_schedules_each_passive_catalog_source_once_and_reports_result
     assert findings[('hostname', 'sub.example.test')]['sources']
     assert findings[('email', 'user@example.test')]['sources']
     assert findings[('url', 'https://sub.example.test/evidence')]['sources'] == [
+        'apis-guru',
         'bevigil',
         'builtwith',
         'gitlab',

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -81,8 +81,8 @@ def test_readme_matches_declared_source_contracts() -> None:
     declared = _declared_source_contracts()
 
     assert '| Source | Subdomains | Emails | IPs | ASNs | URLs | People | Breaches |' in readme
-    assert len(declared) == 56
-    assert len(documented) == 56
+    assert len(declared) == 57
+    assert len(documented) == 57
     assert documented == declared
     assert {'securitytrails', 'shodaninternetdb'}.isdisjoint(documented)
 

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -26,6 +26,7 @@ from aiomultiprocess import Pool
 
 from theHarvester.discovery import (
     api_endpoints,
+    apisguru,
     arquivo,
     baidusearch,
     bevigil,
@@ -907,7 +908,14 @@ async def start(
             output_logger.info(f'\n[*] Target: {word} \n')
 
             for engineitem in engines:
-                if engineitem == 'arquivo':
+                if engineitem == 'apis-guru':
+                    try:
+                        apis_guru_search = apisguru.SearchApisGuru(word, limit)
+                        stor_lst.append(store(apis_guru_search, engineitem))
+                    except Exception as e:
+                        show_default_error_message(engineitem, word, e)
+
+                elif engineitem == 'arquivo':
                     try:
                         arquivo_search = arquivo.SearchArquivo(word, limit)
                         stor_lst.append(store(arquivo_search, engineitem))

--- a/theHarvester/discovery/apisguru.py
+++ b/theHarvester/discovery/apisguru.py
@@ -1,0 +1,373 @@
+import asyncio
+import re
+from email.errors import HeaderParseError
+from email.headerregistry import Address
+from ipaddress import ip_address
+from itertools import islice
+from urllib.parse import unquote, urlsplit, urlunsplit
+
+from theHarvester.lib.core import AsyncFetcher, FetcherResponse, ResponseStreamError
+from theHarvester.lib.hostnames import normalize_scoped_hostname
+
+
+class SearchApisGuru:
+    DIRECTORY_ROOT = 'https://api.apis.guru/v2'
+    MAX_DIRECTORY_ENTRIES = 1000
+    MAX_SPEC_ITEMS = 1000
+    MAX_RESULTS_PER_ROUTE = 1000
+    MAX_URL_LENGTH = 4096
+    REQUEST_TIMEOUT = 60
+    MAX_RUNTIME_SECONDS = 600
+
+    def __init__(self, word: str, limit: int) -> None:
+        self.word = self._domain(word)
+        self.result_limit = max(0, min(limit, self.MAX_RESULTS_PER_ROUTE))
+        self.totalhosts: set[str] = set()
+        self.totalemails: set[str] = set()
+        self.urls: set[str] = set()
+        self.proxy = False
+        self.execution_status: str | None = None
+        self.stop_reason: str | None = None
+        self.result_limit_reached = False
+
+    @staticmethod
+    def _domain(value: str) -> str:
+        candidate = value.strip().lower().rstrip('.')
+        if not candidate.isascii():
+            return ''
+        labels = candidate.split('.')
+        try:
+            ip_address(candidate)
+        except ValueError:
+            pass
+        else:
+            return ''
+        if (
+            not candidate
+            or len(labels) < 2
+            or len(candidate) > 253
+            or any(
+                not label
+                or len(label) > 63
+                or label.startswith('-')
+                or label.endswith('-')
+                or re.fullmatch(r'[a-z0-9-]+', label) is None
+                for label in labels
+            )
+        ):
+            return ''
+        return candidate
+
+    def _has_results(self) -> bool:
+        return any(host != self.word for host in self.totalhosts) or bool(self.totalemails or self.urls)
+
+    def _stop(self, status: str, reason: str) -> None:
+        self.execution_status = 'partial' if self._has_results() else status
+        self.stop_reason = reason
+
+    async def _fetch(self, url: str) -> FetcherResponse | None:
+        try:
+            return await AsyncFetcher.fetch_json(
+                url=url,
+                proxy=self.proxy,
+                request_timeout=self.REQUEST_TIMEOUT,
+            )
+        except asyncio.CancelledError:
+            self._stop('failed', 'cancelled')
+            raise
+        except ResponseStreamError as error:
+            self._stop('failed', error.reason)
+            return None
+
+    def _matches_target(self, value: object) -> bool:
+        if not isinstance(value, str):
+            return False
+        domain = self._domain(value)
+        return bool(domain and normalize_scoped_hostname(domain, self.word))
+
+    def _retain(self, values: set[str], value: str) -> None:
+        if value not in values and len(values) >= self.result_limit:
+            self.result_limit_reached = True
+        else:
+            values.add(value)
+
+    def _add_host(self, value: str) -> None:
+        try:
+            parsed = urlsplit(f'//{value.strip()}')
+            parsed.port
+        except ValueError:
+            return
+        if parsed.username is not None or parsed.password is not None or parsed.path or parsed.query or parsed.fragment:
+            return
+        hostname = normalize_scoped_hostname(self._domain(parsed.hostname or ''), self.word)
+        if hostname is not None and hostname != self.word:
+            self._retain(self.totalhosts, hostname)
+
+    def _add_url(self, value: object) -> None:
+        if not isinstance(value, str):
+            return
+        if len(value) > self.MAX_URL_LENGTH or any(character.isspace() or not character.isprintable() for character in value):
+            return
+        try:
+            parsed = urlsplit(value.strip())
+            port = parsed.port
+        except ValueError:
+            return
+        if parsed.scheme.lower() not in {'http', 'https'} or parsed.hostname is None:
+            return
+        if parsed.username is not None or parsed.password is not None:
+            return
+        hostname = normalize_scoped_hostname(self._domain(parsed.hostname), self.word)
+        if hostname is None:
+            return
+        self._add_host(hostname)
+        if '{' in value or '}' in value:
+            return
+        netloc = f'{hostname}:{port}' if port is not None else hostname
+        normalized_url = urlunsplit((parsed.scheme.lower(), netloc, parsed.path, '', ''))
+        self._retain(self.urls, normalized_url)
+
+    def _add_email(self, value: object) -> None:
+        if not isinstance(value, str) or value.count('@') != 1:
+            return
+        candidate = value.strip().lower()
+        try:
+            candidate_length = len(candidate.encode('utf-8'))
+        except UnicodeEncodeError:
+            return
+        if candidate_length > 254:
+            return
+        try:
+            address = Address(addr_spec=candidate)
+        except (HeaderParseError, ValueError):
+            return
+        if len(address.username.encode('utf-8')) > 64:
+            return
+        normalized_domain = normalize_scoped_hostname(self._domain(address.domain), self.word)
+        if address.username and normalized_domain:
+            normalized_email = Address(username=address.username, domain=normalized_domain).addr_spec
+            self._retain(self.totalemails, normalized_email)
+
+    def _parse_spec(self, spec: dict) -> bool:
+        malformed = not isinstance(spec.get('openapi') or spec.get('swagger'), str)
+        host = spec.get('host')
+        schemes = spec.get('schemes')
+        base_path = spec.get('basePath')
+        if 'host' in spec and not isinstance(host, str):
+            malformed = True
+        if 'schemes' in spec and not isinstance(schemes, list):
+            malformed = True
+        if 'basePath' in spec and (not isinstance(base_path, str) or not base_path.startswith('/')):
+            malformed = True
+        if isinstance(host, str):
+            self._add_host(host)
+        if isinstance(host, str) and isinstance(schemes, list):
+            path = base_path if isinstance(base_path, str) and base_path.startswith('/') else ''
+            if len(schemes) > self.MAX_SPEC_ITEMS:
+                self.result_limit_reached = True
+            for scheme in islice(schemes, self.MAX_SPEC_ITEMS):
+                if isinstance(scheme, str) and scheme.lower() in {'http', 'https'}:
+                    self._add_url(f'{scheme.lower()}://{host}{path}')
+                elif not isinstance(scheme, str):
+                    malformed = True
+
+        servers = spec.get('servers')
+        if isinstance(servers, list):
+            if len(servers) > self.MAX_SPEC_ITEMS:
+                self.result_limit_reached = True
+            for server in islice(servers, self.MAX_SPEC_ITEMS):
+                if not isinstance(server, dict):
+                    malformed = True
+                elif not isinstance(server.get('url'), str):
+                    malformed = True
+                else:
+                    self._add_url(server.get('url'))
+        elif 'servers' in spec:
+            malformed = True
+
+        info = spec.get('info')
+        if isinstance(info, dict):
+            contact = info.get('contact')
+            if isinstance(contact, dict):
+                if 'email' in contact and not isinstance(contact.get('email'), str):
+                    malformed = True
+                if 'url' in contact and not isinstance(contact.get('url'), str):
+                    malformed = True
+                self._add_email(contact.get('email'))
+                self._add_url(contact.get('url'))
+            elif 'contact' in info:
+                malformed = True
+            if 'termsOfService' in info and not isinstance(info.get('termsOfService'), str):
+                malformed = True
+            self._add_url(info.get('termsOfService'))
+        elif 'info' in spec:
+            malformed = True
+
+        external_docs = spec.get('externalDocs')
+        if isinstance(external_docs, dict):
+            if 'url' in external_docs and not isinstance(external_docs.get('url'), str):
+                malformed = True
+            self._add_url(external_docs.get('url'))
+        elif 'externalDocs' in spec:
+            malformed = True
+        return malformed
+
+    @classmethod
+    def _spec_url(cls, value: object) -> str | None:
+        if (
+            not isinstance(value, str)
+            or len(value) > cls.MAX_URL_LENGTH
+            or any(character.isspace() or not character.isprintable() for character in value)
+        ):
+            return None
+        try:
+            parsed = urlsplit(value)
+            port = parsed.port
+        except ValueError:
+            return None
+        decoded_path = unquote(parsed.path)
+        if '\\' in decoded_path or any(part in {'.', '..'} for part in decoded_path.split('/')):
+            return None
+        if (
+            parsed.scheme != 'https'
+            or parsed.hostname != 'api.apis.guru'
+            or port not in {None, 443}
+            or parsed.username is not None
+            or parsed.password is not None
+            or not decoded_path.startswith('/v2/specs/')
+            or not decoded_path.endswith('.json')
+            or parsed.query
+            or parsed.fragment
+        ):
+            return None
+        return value
+
+    async def do_search(self) -> None:
+        if not self.word:
+            self._stop('failed', 'invalid-target')
+            return
+        directory_response = await self._fetch(f'{self.DIRECTORY_ROOT}/{self.word}.json')
+        if directory_response is None:
+            if self.execution_status is None:
+                self._stop('failed', 'transport-error')
+            return
+        if directory_response.status == 404:
+            self.execution_status = 'completed'
+            self.stop_reason = 'no-results'
+            return
+        if directory_response.status == 429:
+            self._stop('rate-limited', 'http-429')
+            return
+        if directory_response.status in {401, 403}:
+            self._stop('failed', 'access-denied')
+            return
+        if not 200 <= directory_response.status < 300:
+            self._stop('failed', f'http-{directory_response.status}')
+            return
+        if not isinstance(directory_response.body, dict):
+            self._stop('failed', 'invalid-response')
+            return
+
+        directory = directory_response.body.get('apis', directory_response.body)
+        if not isinstance(directory, dict):
+            self._stop('failed', 'invalid-response')
+            return
+
+        directory_limit_reached = len(directory) > self.MAX_DIRECTORY_ENTRIES
+        spec_urls: list[str] = []
+        malformed = False
+        seen_spec_urls: set[str] = set()
+        for api_id, api in islice(directory.items(), self.MAX_DIRECTORY_ENTRIES):
+            if not isinstance(api_id, str):
+                continue
+            provider_domain = api_id.partition(':')[0]
+            provider_matches = self._matches_target(provider_domain)
+            if not isinstance(api, dict):
+                malformed = provider_matches or malformed
+                continue
+            version = api
+            if 'swaggerUrl' not in version:
+                preferred = api.get('preferred')
+                versions = api.get('versions')
+                if not isinstance(preferred, str) or not isinstance(versions, dict):
+                    malformed = provider_matches or malformed
+                    continue
+                selected_version = versions.get(preferred)
+                if not isinstance(selected_version, dict):
+                    malformed = provider_matches or malformed
+                    continue
+                version = selected_version
+            info = version.get('info')
+            provider_name = info.get('x-providerName') if isinstance(info, dict) else None
+            if not provider_matches and not self._matches_target(provider_name):
+                continue
+            if not isinstance(info, dict):
+                malformed = True
+            if spec_url := self._spec_url(version.get('swaggerUrl')):
+                if spec_url not in seen_spec_urls:
+                    seen_spec_urls.add(spec_url)
+                    spec_urls.append(spec_url)
+            else:
+                malformed = True
+
+        spec_failure: str | None = None
+        for spec_url in spec_urls:
+            spec_response = await self._fetch(spec_url)
+            if spec_response is None:
+                if self.execution_status is None:
+                    self._stop('failed', 'transport-error')
+                elif self.stop_reason in {'invalid-response', 'response-limit'}:
+                    spec_failure = spec_failure or self.stop_reason
+                    continue
+                return
+            if spec_response.status == 429:
+                self._stop('rate-limited', 'http-429')
+                return
+            if spec_response.status in {401, 403}:
+                self._stop('failed', 'access-denied')
+                return
+            if spec_response.status in {404, 410}:
+                spec_failure = spec_failure or f'http-{spec_response.status}'
+                continue
+            if 400 <= spec_response.status < 500:
+                self._stop('failed', f'http-{spec_response.status}')
+                return
+            if not 200 <= spec_response.status < 300:
+                self._stop('failed', f'http-{spec_response.status}')
+                return
+            if not isinstance(spec_response.body, dict):
+                malformed = True
+                continue
+            malformed = self._parse_spec(spec_response.body) or malformed
+
+        if malformed:
+            self._stop('failed', 'invalid-response')
+        elif spec_failure is not None:
+            self._stop('failed', spec_failure)
+        elif self.result_limit_reached:
+            self._stop('failed', 'result-limit')
+        elif directory_limit_reached:
+            self._stop('failed', 'directory-entry-limit')
+        else:
+            self.execution_status = 'completed'
+            self.stop_reason = None if self._has_results() else 'no-results'
+
+    async def get_hostnames(self) -> set[str]:
+        return self.totalhosts
+
+    async def get_emails(self) -> set[str]:
+        return self.totalemails
+
+    async def get_urls(self) -> set[str]:
+        return self.urls
+
+    async def process(self, proxy: bool = False) -> None:
+        self.proxy = proxy
+        self.execution_status = None
+        self.stop_reason = None
+        self.result_limit_reached = False
+        try:
+            async with asyncio.timeout(self.MAX_RUNTIME_SECONDS):
+                await self.do_search()
+        except TimeoutError:
+            self._stop('failed', 'runtime-limit')

--- a/theHarvester/discovery/apisguru.py
+++ b/theHarvester/discovery/apisguru.py
@@ -11,6 +11,16 @@ from theHarvester.lib.hostnames import normalize_scoped_hostname
 
 
 class SearchApisGuru:
+    """Collect target-scoped API metadata from the public APIs.guru directory.
+
+    Results include descendant hostnames, contact emails, concrete API base URLs,
+    and related in-scope URLs. The adapter does not resolve IP addresses or expand
+    OpenAPI paths into operation endpoints. It checks up to 1,000 matching specs
+    for up to ten minutes; ``--limit`` caps stored results, not spec traversal.
+    The shared fetcher caps each JSON response at 16 MiB. Oversized specs are
+    skipped and leave the source marked partial.
+    """
+
     DIRECTORY_ROOT = 'https://api.apis.guru/v2'
     MAX_DIRECTORY_ENTRIES = 1000
     MAX_SPEC_ITEMS = 1000

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -400,6 +400,7 @@ class Core:
     def get_supportedengines() -> list[str]:
         """Returns a list of supported search engines."""
         return [
+            'apis-guru',
             'arquivo',
             'baidu',
             'bevigil',

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -90,6 +90,7 @@ def _spec(
 
 
 _SPECS = (
+    _spec('apis-guru', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS, ResultRoute.URLS),
     _spec('arquivo', ResultRoute.SUBDOMAINS),
     _spec('baidu', ResultRoute.SUBDOMAINS, ResultRoute.EMAILS),
     _spec('bevigil', ResultRoute.SUBDOMAINS, ResultRoute.URLS),


### PR DESCRIPTION
## Summary

- add `apis-guru` as a keyless P0 passive source
- request the exact target-domain APIs.guru v2 directory entry
- support current direct records and legacy preferred-version maps
- traverse every matching preferred OpenAPI specification within hard 1,000-entry and 10-minute ceilings
- retain target-scoped hostnames, contact emails, and concrete HTTP(S) URLs, while `--limit` bounds retained results per output type without truncating catalog traversal
- preserve concrete hostnames from templated server paths without emitting those non-concrete URLs

## Result contract

The source emits ordinary `hostname`, `email`, and `url` findings. It does not emit IP addresses.

Concrete OpenAPI 2 host/scheme/base-path combinations and OpenAPI 3 server URLs are retained. Target-scoped contact, terms-of-service, and external-document URLs are also retained, so URL findings are flat references rather than typed API endpoints. Operation paths, HTTP methods, authentication declarations, version provenance, and richer API relationships remain deferred.

These are target-scoped references declared by provider metadata. They do not establish ownership, liveness, authorization, or current assessment scope.

## Safety and failure behavior

- every request stays on canonical HTTPS `api.apis.guru` v2 endpoints; redirects are disabled
- described APIs are parsed as metadata and are never invoked
- each JSON response is capped at 16 MiB by the shared provider transport
- one run is capped at 1,000 directory entries, 10 minutes, 1,000 items per specification collection, and `min(--limit, 1000)` retained findings per output type
- stale 404/410, malformed, or oversized individual specifications are skipped so later specifications can still contribute results; the final source status remains partial
- transport failures, 401/403, other provider-wide 4xx, 429, 5xx, cancellation, and the whole-run deadline stop traversal
- malformed, credential-bearing, path-traversing, external, and noncanonical specification URLs are rejected
- target validation rejects IP, dotless, path-bearing, malformed, and non-ASCII-confusable inputs

## Provider-only recall benchmark

Only `api.apis.guru` was contacted. Redirects were disabled; no target host or described API received traffic.

| Target catalog | Preferred specs | Scoped hostnames | Scoped URLs | Emails | Provider cost |
| --- | ---: | ---: | ---: | ---: | --- |
| `googleapis.com` | 281 | 266 | 280 | 0 | 282 requests, 43.33 MB, 114.05 s |
| `twilio.com` | 44 | 38 | 38 | 1 | 45 requests, 5.59 MB, 19.05 s |
| `adyen.com` | 25 | 11 | 24 | 2 | 26 requests, 3.92 MB, 10.56 s |
| `amadeus.com` | 32 | 1 | 3 | 0 | 33 requests, 2.58 MB, 12.69 s |

For Google, the former five-spec cap returned only 5 hostnames and 5 URLs, about 1.8% of the full catalog URL yield. A 100-spec cap still retained only 97 hostnames and 100 URLs. This is why traversal now covers the complete matching catalog rather than substituting another arbitrary fixed request cap.

Two Microsoft Graph specifications are larger than the shared response ceiling (about 33.7 MB and 74.1 MB). The ceiling remains unchanged; those individual documents are skipped and the source continues with a truthful partial outcome.

## Verification

- `uv run pytest -q tests/discovery/test_apisguru.py`: 49 passed
- `uv run pytest -q`: 1,050 passed, 6 skipped, 23 deselected
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy theHarvester`
- `git diff --check`

Provider references:

- https://apis.guru/api-doc
- https://github.com/APIs-guru/openapi-directory
