### PR TITLE
Add bounded provider response streaming

### DIFF
--- a/tests/discovery/test_dnsdb.py
+++ b/tests/discovery/test_dnsdb.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 
 import pytest
@@ -16,58 +17,29 @@ def _install_response(
     stream_error: Exception | None = None,
 ) -> dict[str, object]:
     requested: dict[str, object] = {}
-    lines_left = list(lines)
-
-    class FakeContent:
-        def __aiter__(self) -> FakeContent:
-            return self
-
-        async def __anext__(self) -> bytes:
-            if not lines_left:
-                if stream_error is not None:
-                    raise stream_error
-                raise StopAsyncIteration
-            return lines_left.pop(0)
 
     class FakeResponse:
         def __init__(self) -> None:
             self.status = status
+            self.headers: dict[str, str] = {}
 
-        content = FakeContent()
+        async def __aiter__(self):
+            for line in lines:
+                yield line.decode()
+            if stream_error is not None:
+                raise stream_error
 
-        async def __aenter__(self) -> FakeResponse:
-            return self
+    @contextlib.asynccontextmanager
+    async def fake_stream_records(url: str, **kwargs: object):
+        requested['url'] = url
+        requested['stream'] = kwargs
+        yield FakeResponse()
 
-        async def __aexit__(self, *_args: object) -> None:
-            return None
+    async def private_transport_is_not_a_public_seam(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError('DNSDB must use AsyncFetcher.stream_records')
 
-    class FakeSession:
-        def get(self, url: str, **kwargs: object) -> FakeResponse:
-            requested['url'] = url
-            requested['request'] = kwargs
-            return FakeResponse()
-
-        async def __aenter__(self) -> FakeSession:
-            return self
-
-        async def __aexit__(self, *_args: object) -> None:
-            return None
-
-    async def fake_build_session(
-        headers: dict[str, str],
-        timeout: object,
-        proxy_url: str | None = None,
-        proxy_type: str | None = None,
-    ) -> FakeSession:
-        requested['session'] = {
-            'headers': headers,
-            'timeout': timeout,
-            'proxy_url': proxy_url,
-            'proxy_type': proxy_type,
-        }
-        return FakeSession()
-
-    monkeypatch.setattr(dnsdb.AsyncFetcher, '_build_session', fake_build_session)
+    monkeypatch.setattr(dnsdb.AsyncFetcher, 'stream_records', fake_stream_records)
+    monkeypatch.setattr(dnsdb.AsyncFetcher, '_build_session', private_transport_is_not_a_public_seam)
     return requested
 
 
@@ -98,13 +70,16 @@ async def test_process_collects_normalized_in_scope_rrset_owners(monkeypatch: py
 
     assert await search.get_hostnames() == {'api.example.com'}
     assert requested['url'] == 'https://api.dnsdb.info/dnsdb/v2/lookup/rrset/name/*.example.com?limit=0'
-    session_options = requested['session']
-    assert isinstance(session_options, dict)
-    assert session_options['headers'] == {
+    stream_options = requested['stream']
+    assert isinstance(stream_options, dict)
+    assert stream_options['headers'] == {
         'Accept': 'application/x-ndjson',
         'User-Agent': f'theHarvester/{dnsdb.__version__}',
         'X-API-Key': 'dnsdb-test-key',
     }
+    assert stream_options['framing'] == 'ndjson'
+    assert stream_options['follow_redirects'] is False
+    assert stream_options['request_timeout'] == 120
 
 
 @pytest.mark.asyncio
@@ -126,9 +101,9 @@ async def test_process_uses_configured_proxy_when_enabled(monkeypatch: pytest.Mo
 
     await dnsdb.SearchDNSDB('example.com').process(True)
 
-    request_options = requested['request']
-    assert isinstance(request_options, dict)
-    assert request_options['proxy'] == 'http://proxy.example:8080'
+    stream_options = requested['stream']
+    assert isinstance(stream_options, dict)
+    assert stream_options['proxy'] is True
 
 
 @pytest.mark.asyncio
@@ -176,7 +151,7 @@ async def test_process_preserves_partial_results_on_midstream_timeout(
             b'{"cond":"begin"}\n',
             b'{"obj":{"rrname":"first.example.com."}}\n',
         ),
-        stream_error=TimeoutError(),
+        stream_error=dnsdb.ResponseStreamError('transport-error'),
     )
 
     search = dnsdb.SearchDNSDB('example.com')

--- a/tests/lib/test_core.py
+++ b/tests/lib/test_core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import Any
@@ -165,6 +166,18 @@ def test_read_config_copies_default_to_home(name: str, capsys):
 _DEFAULT_JSON = object()
 
 
+class DummyContent:
+    def __init__(self, chunks: tuple[bytes, ...], error: BaseException | None = None):
+        self.chunks = chunks
+        self.error = error
+
+    async def iter_any(self):
+        for chunk in self.chunks:
+            yield chunk
+        if self.error is not None:
+            raise self.error
+
+
 class DummyResponse:
     def __init__(
         self,
@@ -172,11 +185,14 @@ class DummyResponse:
         json_value: Any = _DEFAULT_JSON,
         status: int = 200,
         headers: dict[str, str] | None = None,
+        chunks: tuple[bytes, ...] | None = None,
+        stream_error: BaseException | None = None,
     ):
         self.text_value = text_value
         self.json_value = {'ok': True} if json_value is _DEFAULT_JSON else json_value
         self.status = status
         self.headers = headers or {}
+        self.content = DummyContent(chunks if chunks is not None else (text_value.encode(),), stream_error)
 
     async def __aenter__(self):
         return self
@@ -229,6 +245,35 @@ class DummySession:
 
 def reset_dummy_sessions() -> None:
     DummySession.instances.clear()
+
+
+def install_stream_response(
+    monkeypatch,
+    *,
+    chunks: tuple[bytes, ...],
+    status: int = 200,
+    headers: dict[str, str] | None = None,
+    error: BaseException | None = None,
+) -> None:
+    reset_dummy_sessions()
+    monkeypatch.setattr(core_module.aiohttp, 'ClientSession', DummySession)
+    monkeypatch.setattr(core_module.ssl, 'create_default_context', lambda cafile=None: 'ssl-context')
+    monkeypatch.setattr(core_module.certifi, 'where', lambda: '/tmp/cacert.pem')
+
+    def request_stream(self, method: str, url: str, **kwargs):
+        self.requests.append((method, url, kwargs))
+        return DummyResponse(status=status, headers=headers, chunks=chunks, stream_error=error)
+
+    monkeypatch.setattr(DummySession, 'request', request_stream)
+
+
+async def collect_default_stream(lines: list[str]) -> None:
+    async with AsyncFetcher.stream_records(
+        'https://provider.example/stream',
+        framing='ndjson',
+    ) as response:
+        async for record in response:
+            lines.append(record)
 
 
 async def fake_sleep(_seconds: float) -> None:
@@ -330,6 +375,281 @@ async def test_fetch_can_include_buffered_response_metadata(monkeypatch) -> None
         status=429,
         headers={'retry-after': '60', 'x-ratelimit-remaining': '0'},
     )
+
+
+@pytest.mark.asyncio
+async def test_stream_records_yields_fragmented_utf8_records_and_response_metadata(monkeypatch) -> None:
+    install_stream_response(
+        monkeypatch,
+        chunks=(b'first\ncaf\xc3', b'\xa9\nlast'),
+        status=206,
+        headers={'X-Stream': 'ready'},
+    )
+
+    async with AsyncFetcher.stream_records(
+        'https://provider.example/stream',
+        framing='ndjson',
+        params={'q': 'example.com'},
+        follow_redirects=False,
+    ) as response:
+        lines = [line async for line in response]
+        assert response.status == 206
+        assert response.headers == {'x-stream': 'ready'}
+
+    assert lines == ['first', 'café', 'last']
+    assert DummySession.instances[0].closed is True
+    assert DummySession.instances[0].requests == [
+        (
+            'GET',
+            'https://provider.example/stream',
+            {
+                'ssl': 'ssl-context',
+                'allow_redirects': False,
+                'params': {'q': 'example.com'},
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_records_frames_fragmented_sse_events(monkeypatch) -> None:
+    install_stream_response(
+        monkeypatch,
+        chunks=(
+            b'event: matches\r\n',
+            b'data: [{"type":"content"}]\r',
+            b'\n\r\n',
+            b'event: done\n',
+            b'data: {}\n\n',
+        ),
+    )
+
+    async with AsyncFetcher.stream_records(
+        'https://provider.example/stream',
+        framing='sse',
+    ) as response:
+        records = [record async for record in response]
+
+    assert records == [
+        'event: matches\ndata: [{"type":"content"}]',
+        'event: done\ndata: {}',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_records_normalizes_tls_setup_failure(monkeypatch) -> None:
+    def fail_tls_setup(*_args, **_kwargs):
+        raise core_module.ssl.SSLError('TLS unavailable')
+
+    monkeypatch.setattr(
+        AsyncFetcher,
+        '_ssl_context',
+        staticmethod(fail_tls_setup),
+    )
+
+    with pytest.raises(core_module.ResponseStreamError) as raised:
+        await collect_default_stream([])
+
+    assert raised.value.reason == 'transport-error'
+
+
+@pytest.mark.asyncio
+async def test_stream_records_does_not_rewrite_consumer_exceptions(monkeypatch) -> None:
+    install_stream_response(monkeypatch, chunks=(b'ok\n',))
+
+    with pytest.raises(PermissionError, match='provider denied access'):
+        async with AsyncFetcher.stream_records(
+            'https://provider.example/stream',
+            framing='ndjson',
+        ):
+            raise PermissionError('provider denied access')
+
+    assert DummySession.instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_stream_records_uses_resolved_http_proxy_without_redirects(monkeypatch) -> None:
+    install_stream_response(monkeypatch, chunks=(b'ok\n',))
+
+    async def fake_connector(*_args, **_kwargs):
+        return 'proxy-connector'
+
+    monkeypatch.setattr(AsyncFetcher, '_create_connector', fake_connector)
+
+    async with AsyncFetcher.stream_records(
+        'https://provider.example/stream',
+        framing='ndjson',
+        proxy='http://proxy.example:8080',
+    ) as response:
+        assert [record async for record in response] == ['ok']
+
+    session = DummySession.instances[0]
+    assert session.connector == 'proxy-connector'
+    assert session.requests == [
+        (
+            'GET',
+            'https://provider.example/stream',
+            {
+                'ssl': 'ssl-context',
+                'allow_redirects': False,
+                'proxy': 'http://proxy.example:8080',
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_records_rejects_second_iteration(monkeypatch) -> None:
+    install_stream_response(monkeypatch, chunks=(b'one\ntwo\n',))
+
+    async with AsyncFetcher.stream_records(
+        'https://provider.example/stream',
+        framing='ndjson',
+    ) as response:
+        iterator = response.__aiter__()
+        assert await anext(iterator) == 'one'
+        with pytest.raises(RuntimeError, match='only be consumed once'):
+            response.__aiter__()
+        await iterator.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stream_records_rejects_incomplete_sse_after_complete_prefix(monkeypatch) -> None:
+    install_stream_response(
+        monkeypatch,
+        chunks=(b'event: progress\ndata: {}\n\nevent: matches\ndata: []',),
+    )
+    records: list[str] = []
+
+    with pytest.raises(core_module.ResponseStreamError) as raised:
+        async with AsyncFetcher.stream_records(
+            'https://provider.example/stream',
+            framing='sse',
+        ) as response:
+            async for record in response:
+                records.append(record)
+
+    assert records == ['event: progress\ndata: {}']
+    assert raised.value.reason == 'invalid-response'
+
+
+@pytest.mark.asyncio
+async def test_stream_records_preserves_complete_prefix_before_response_limit(monkeypatch) -> None:
+    install_stream_response(monkeypatch, chunks=(b'one\n', b'two\n', b'x'))
+    monkeypatch.setattr(core_module, 'MAX_STREAM_RESPONSE_BYTES', 8)
+    lines: list[str] = []
+
+    with pytest.raises(core_module.ResponseStreamError) as raised:
+        await collect_default_stream(lines)
+
+    assert lines == ['one', 'two']
+    assert raised.value.reason == 'response-limit'
+    assert DummySession.instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_stream_records_rejects_oversized_record_after_complete_prefix(monkeypatch) -> None:
+    install_stream_response(monkeypatch, chunks=(b'ok\n123', b'456\n'))
+    monkeypatch.setattr(core_module, 'MAX_STREAM_RECORD_BYTES', 5)
+    lines: list[str] = []
+
+    with pytest.raises(core_module.ResponseStreamError) as raised:
+        await collect_default_stream(lines)
+
+    assert lines == ['ok']
+    assert raised.value.reason == 'response-limit'
+
+
+@pytest.mark.asyncio
+async def test_stream_records_accepts_record_at_limit_with_split_crlf(monkeypatch) -> None:
+    install_stream_response(monkeypatch, chunks=(b'abc\r', b'\n'))
+    monkeypatch.setattr(core_module, 'MAX_STREAM_RECORD_BYTES', 3)
+    records: list[str] = []
+
+    await collect_default_stream(records)
+
+    assert records == ['abc']
+
+
+@pytest.mark.asyncio
+async def test_stream_records_bounds_complete_sse_event_across_many_lines(monkeypatch) -> None:
+    install_stream_response(monkeypatch, chunks=(b'a\nb\nc\n\n',))
+    monkeypatch.setattr(core_module, 'MAX_STREAM_RECORD_BYTES', 5)
+
+    async with AsyncFetcher.stream_records(
+        'https://provider.example/stream',
+        framing='sse',
+    ) as response:
+        records = [record async for record in response]
+
+    assert records == ['a\nb\nc']
+
+
+@pytest.mark.asyncio
+async def test_stream_records_reports_invalid_utf8_after_complete_prefix(monkeypatch) -> None:
+    install_stream_response(monkeypatch, chunks=(b'ok\n', b'\xff\n'))
+    lines: list[str] = []
+
+    with pytest.raises(core_module.ResponseStreamError) as raised:
+        await collect_default_stream(lines)
+
+    assert lines == ['ok']
+    assert raised.value.reason == 'invalid-response'
+
+
+@pytest.mark.asyncio
+async def test_stream_records_reports_transport_failure_after_complete_prefix(monkeypatch) -> None:
+    install_stream_response(monkeypatch, chunks=(b'ok\n',), error=TimeoutError())
+    lines: list[str] = []
+
+    with pytest.raises(core_module.ResponseStreamError) as raised:
+        await collect_default_stream(lines)
+
+    assert lines == ['ok']
+    assert raised.value.reason == 'transport-error'
+    assert DummySession.instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_stream_records_reports_connection_failure_and_closes_session(monkeypatch) -> None:
+    install_stream_response(monkeypatch, chunks=())
+
+    def failed_request(self, method: str, url: str, **kwargs):
+        self.requests.append((method, url, kwargs))
+        raise core_module.aiohttp.ClientConnectionError('unavailable')
+
+    monkeypatch.setattr(DummySession, 'request', failed_request)
+
+    with pytest.raises(core_module.ResponseStreamError) as raised:
+        await collect_default_stream([])
+
+    assert raised.value.reason == 'transport-error'
+    assert DummySession.instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_stream_records_reports_session_creation_failure(monkeypatch) -> None:
+    async def failed_build_session(*_args: object, **_kwargs: object):
+        raise core_module.aiohttp.ClientConnectionError('unavailable')
+
+    monkeypatch.setattr(AsyncFetcher, '_build_session', failed_build_session)
+
+    with pytest.raises(core_module.ResponseStreamError) as raised:
+        await collect_default_stream([])
+
+    assert raised.value.reason == 'transport-error'
+
+
+@pytest.mark.asyncio
+async def test_stream_records_propagates_cancellation_and_closes_session(monkeypatch) -> None:
+    cancelled = asyncio.CancelledError()
+    install_stream_response(monkeypatch, chunks=(), error=cancelled)
+
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await collect_default_stream([])
+
+    assert raised.value is cancelled
+    assert DummySession.instances[0].closed is True
 
 
 @pytest.mark.asyncio

--- a/tests/lib/test_core.py
+++ b/tests/lib/test_core.py
@@ -536,7 +536,7 @@ async def test_stream_records_rejects_incomplete_sse_after_complete_prefix(monke
 @pytest.mark.asyncio
 async def test_stream_records_preserves_complete_prefix_before_response_limit(monkeypatch) -> None:
     install_stream_response(monkeypatch, chunks=(b'one\n', b'two\n', b'x'))
-    monkeypatch.setattr(core_module, 'MAX_STREAM_RESPONSE_BYTES', 8)
+    monkeypatch.setattr(core_module, 'MAX_PROVIDER_STREAM_BYTES', 8)
     lines: list[str] = []
 
     with pytest.raises(core_module.ResponseStreamError) as raised:
@@ -647,6 +647,131 @@ async def test_stream_records_propagates_cancellation_and_closes_session(monkeyp
 
     with pytest.raises(asyncio.CancelledError) as raised:
         await collect_default_stream([])
+
+    assert raised.value is cancelled
+    assert DummySession.instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_fetch_json_reads_bounded_fragmented_utf8_without_redirects(monkeypatch) -> None:
+    install_stream_response(
+        monkeypatch,
+        chunks=(b'{"name":"caf\xc3', b'\xa9"}'),
+        headers={'X-Provider': 'ready'},
+    )
+
+    result = await AsyncFetcher.fetch_json(
+        'https://provider.example/data',
+        params={'asn': '64500'},
+        headers={'Api-Key': 'secret'},
+        request_timeout=30,
+    )
+
+    assert result == FetcherResponse(
+        body={'name': 'café'},
+        status=200,
+        headers={'x-provider': 'ready'},
+    )
+    assert DummySession.instances[0].closed is True
+    assert DummySession.instances[0].requests == [
+        (
+            'GET',
+            'https://provider.example/data',
+            {
+                'ssl': 'ssl-context',
+                'allow_redirects': False,
+                'params': {'asn': '64500'},
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_json_accepts_body_at_shared_limit(monkeypatch) -> None:
+    install_stream_response(monkeypatch, chunks=(b'{"a":1}',))
+    monkeypatch.setattr(core_module, 'MAX_PROVIDER_JSON_BYTES', 7)
+
+    result = await AsyncFetcher.fetch_json('https://provider.example/data')
+
+    assert result.body == {'a': 1}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('headers', [None, {'Content-Length': '1'}])
+async def test_fetch_json_rejects_body_over_shared_limit(monkeypatch, headers: dict[str, str] | None) -> None:
+    install_stream_response(monkeypatch, chunks=(b'{"a":1}', b' '), headers=headers)
+    monkeypatch.setattr(core_module, 'MAX_PROVIDER_JSON_BYTES', 7)
+
+    with pytest.raises(core_module.ResponseStreamError) as raised:
+        await AsyncFetcher.fetch_json('https://provider.example/data')
+
+    assert raised.value.reason == 'response-limit'
+    assert DummySession.instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_fetch_json_rejects_declared_oversized_body(monkeypatch) -> None:
+    install_stream_response(monkeypatch, chunks=(b'{"a":1}',), headers={'Content-Length': '8'})
+    monkeypatch.setattr(core_module, 'MAX_PROVIDER_JSON_BYTES', 7)
+
+    with pytest.raises(core_module.ResponseStreamError) as raised:
+        await AsyncFetcher.fetch_json('https://provider.example/data')
+
+    assert raised.value.reason == 'response-limit'
+
+
+@pytest.mark.asyncio
+async def test_fetch_json_preserves_non_success_status_without_parsing_body(monkeypatch) -> None:
+    install_stream_response(
+        monkeypatch,
+        chunks=(b'<html>limited</html>',),
+        status=429,
+        headers={'Retry-After': '60'},
+    )
+
+    result = await AsyncFetcher.fetch_json('https://provider.example/data')
+
+    assert result == FetcherResponse(body=None, status=429, headers={'retry-after': '60'})
+
+
+@pytest.mark.asyncio
+async def test_fetch_json_returns_none_for_no_content(monkeypatch) -> None:
+    install_stream_response(monkeypatch, chunks=(), status=204)
+
+    result = await AsyncFetcher.fetch_json('https://provider.example/data')
+
+    assert result == FetcherResponse(body=None, status=204, headers={})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('chunks', [(b'\xff',), (b'{',), (b'{"value":NaN}',)])
+async def test_fetch_json_rejects_invalid_utf8_or_json(monkeypatch, chunks: tuple[bytes, ...]) -> None:
+    install_stream_response(monkeypatch, chunks=chunks)
+
+    with pytest.raises(core_module.ResponseStreamError) as raised:
+        await AsyncFetcher.fetch_json('https://provider.example/data')
+
+    assert raised.value.reason == 'invalid-response'
+
+
+@pytest.mark.asyncio
+async def test_fetch_json_reports_transport_failure_and_closes_session(monkeypatch) -> None:
+    install_stream_response(monkeypatch, chunks=(), error=TimeoutError())
+
+    with pytest.raises(core_module.ResponseStreamError) as raised:
+        await AsyncFetcher.fetch_json('https://provider.example/data')
+
+    assert raised.value.reason == 'transport-error'
+    assert DummySession.instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_fetch_json_propagates_cancellation_and_closes_session(monkeypatch) -> None:
+    cancelled = asyncio.CancelledError()
+    install_stream_response(monkeypatch, chunks=(), error=cancelled)
+
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await AsyncFetcher.fetch_json('https://provider.example/data')
 
     assert raised.value is cancelled
     assert DummySession.instances[0].closed is True

--- a/theHarvester/discovery/dnsdb.py
+++ b/theHarvester/discovery/dnsdb.py
@@ -4,11 +4,9 @@ import json
 import logging
 from urllib.parse import quote
 
-import aiohttp
-
 from theHarvester import __version__
 from theHarvester.discovery.constants import MissingKey
-from theHarvester.lib.core import AsyncFetcher, Core
+from theHarvester.lib.core import AsyncFetcher, Core, ResponseStreamError
 
 logger = logging.getLogger(__name__)
 
@@ -53,47 +51,51 @@ class SearchDNSDB:
             'User-Agent': f'theHarvester/{__version__}',
             'X-API-Key': self.key,
         }
-        timeout = aiohttp.ClientTimeout(total=120)
-        proxy_url, proxy_type = AsyncFetcher._resolve_proxy(self.proxy)
+        async with AsyncFetcher.stream_records(
+            url,
+            framing='ndjson',
+            headers=headers,
+            proxy=self.proxy,
+            # Never forward the provider credential to a redirect target.
+            follow_redirects=False,
+            request_timeout=120,
+        ) as response:
+            if response.status == 429:
+                raise ConnectionError('DNSDB rate limit reached')
+            if response.status in {401, 403}:
+                raise PermissionError('DNSDB authentication failed')
+            if response.status == 503:
+                raise ConnectionError('DNSDB concurrent connection limit exceeded')
+            if response.status != 200:
+                raise ConnectionError(f'DNSDB returned HTTP {response.status}')
 
-        async with await AsyncFetcher._build_session(headers, timeout, proxy_url, proxy_type) as session:
-            async with session.get(url, proxy=proxy_url if proxy_type == 'http' else None) as response:
-                if response.status == 429:
-                    raise ConnectionError('DNSDB rate limit reached')
-                if response.status in {401, 403}:
-                    raise PermissionError('DNSDB authentication failed')
-                if response.status == 503:
-                    raise ConnectionError('DNSDB concurrent connection limit exceeded')
-                if response.status != 200:
-                    raise ConnectionError(f'DNSDB returned HTTP {response.status}')
-
-                first_record = True
-                async for line in response.content:
-                    try:
-                        record = json.loads(line)
-                    except (UnicodeDecodeError, json.JSONDecodeError):
-                        logger.info('DNSDB returned malformed NDJSON; partial results were preserved.')
+            first_record = True
+            async for line in response:
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.info('DNSDB returned malformed NDJSON; partial results were preserved.')
+                    return
+                if not isinstance(record, dict):
+                    logger.info('DNSDB returned an invalid stream record; partial results were preserved.')
+                    return
+                if first_record:
+                    first_record = False
+                    if record.get('cond') != 'begin':
+                        logger.info('DNSDB stream did not begin correctly; no results were accepted.')
                         return
-                    if not isinstance(record, dict):
-                        logger.info('DNSDB returned an invalid stream record; partial results were preserved.')
-                        return
-                    if first_record:
-                        first_record = False
-                        if record.get('cond') != 'begin':
-                            logger.info('DNSDB stream did not begin correctly; no results were accepted.')
-                            return
-                        continue
+                    continue
 
-                    condition = record.get('cond')
-                    if condition in {'succeeded', 'limited', 'failed'}:
-                        if condition != 'succeeded':
-                            logger.info(f'DNSDB stream ended with {condition}; partial results were preserved.')
-                        return
-                    obj = record.get('obj')
-                    if isinstance(obj, dict) and (hostname := self._hostname(obj.get('rrname'))):
-                        self.totalhosts.add(hostname)
+                condition = record.get('cond')
+                if condition in {'succeeded', 'limited', 'failed'}:
+                    if condition != 'succeeded':
+                        logger.info(f'DNSDB stream ended with {condition}; partial results were preserved.')
+                    return
+                obj = record.get('obj')
+                if isinstance(obj, dict) and (hostname := self._hostname(obj.get('rrname'))):
+                    self.totalhosts.add(hostname)
 
-                logger.info('DNSDB stream ended without a terminal condition; partial results were preserved.')
+            logger.info('DNSDB stream ended without a terminal condition; partial results were preserved.')
 
     async def get_hostnames(self) -> set[str]:
         return self.totalhosts
@@ -102,5 +104,5 @@ class SearchDNSDB:
         self.proxy = proxy
         try:
             await self.do_search()
-        except (aiohttp.ClientError, TimeoutError) as error:
+        except ResponseStreamError as error:
             logger.info(f'DNSDB request failed with {type(error).__name__}; partial results were preserved.')

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json as stdlib_json
 import logging
 import random
 import re
@@ -33,7 +34,8 @@ CONFIG_DIRS = [
     Path('/etc/theHarvester/'),
     Path('/usr/local/etc/theHarvester/'),
 ]
-MAX_STREAM_RESPONSE_BYTES = 64 * 1024 * 1024
+MAX_PROVIDER_STREAM_BYTES = 64 * 1024 * 1024
+MAX_PROVIDER_JSON_BYTES = 16 * 1024 * 1024
 MAX_STREAM_RECORD_BYTES = 10 * 1024 * 1024
 _STREAM_LINE_END = re.compile(rb'[\r\n]')
 
@@ -52,6 +54,27 @@ class FetcherResponse:
     body: Any
     status: int
     headers: dict[str, str]
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f'invalid JSON constant: {value}')
+
+
+async def _bounded_response_chunks(content: Any, byte_limit: int) -> AsyncIterator[bytes]:
+    bytes_read = 0
+    try:
+        async for chunk in content.iter_any():
+            remaining = byte_limit - bytes_read
+            accepted = chunk[:remaining]
+            bytes_read += len(accepted)
+            if accepted:
+                yield accepted
+            if len(accepted) != len(chunk):
+                raise ResponseStreamError('response-limit')
+    except ResponseStreamError:
+        raise
+    except (aiohttp.ClientError, TimeoutError, OSError) as error:
+        raise ResponseStreamError('transport-error') from error
 
 
 @dataclass
@@ -77,36 +100,27 @@ class TextRecordResponse:
 
     async def _byte_lines(self) -> AsyncIterator[tuple[bytes, bool]]:
         pending = bytearray()
-        bytes_read = 0
-        try:
-            async for chunk in self._content.iter_any():
-                remaining = MAX_STREAM_RESPONSE_BYTES - bytes_read
-                accepted = chunk[:remaining]
-                bytes_read += len(accepted)
-                pending.extend(accepted)
-                start = 0
-                while start < len(pending):
-                    line_end = _STREAM_LINE_END.search(pending, start)
-                    if line_end is None:
-                        break
-                    separator = line_end.start()
-                    if pending[separator] == ord('\r') and separator + 1 == len(pending):
-                        break
-                    terminator_bytes = 2 if pending[separator : separator + 2] == b'\r\n' else 1
-                    line = bytes(pending[start:separator])
-                    if len(line) > MAX_STREAM_RECORD_BYTES:
-                        raise ResponseStreamError('response-limit')
-                    start = separator + terminator_bytes
-                    yield line, True
-                if start:
-                    del pending[:start]
-                pending_bytes = len(pending) - (1 if pending.endswith(b'\r') else 0)
-                if pending_bytes > MAX_STREAM_RECORD_BYTES:
+        async for chunk in _bounded_response_chunks(self._content, MAX_PROVIDER_STREAM_BYTES):
+            pending.extend(chunk)
+            start = 0
+            while start < len(pending):
+                line_end = _STREAM_LINE_END.search(pending, start)
+                if line_end is None:
+                    break
+                separator = line_end.start()
+                if pending[separator] == ord('\r') and separator + 1 == len(pending):
+                    break
+                terminator_bytes = 2 if pending[separator : separator + 2] == b'\r\n' else 1
+                line = bytes(pending[start:separator])
+                if len(line) > MAX_STREAM_RECORD_BYTES:
                     raise ResponseStreamError('response-limit')
-                if len(accepted) != len(chunk):
-                    raise ResponseStreamError('response-limit')
-        except (aiohttp.ClientError, TimeoutError, OSError) as error:
-            raise ResponseStreamError('transport-error') from error
+                start = separator + terminator_bytes
+                yield line, True
+            if start:
+                del pending[:start]
+            pending_bytes = len(pending) - (1 if pending.endswith(b'\r') else 0)
+            if pending_bytes > MAX_STREAM_RECORD_BYTES:
+                raise ResponseStreamError('response-limit')
         if pending:
             if pending[-1] == ord('\r'):
                 yield bytes(pending[:-1]), True
@@ -798,25 +812,16 @@ class AsyncFetcher:
 
     @classmethod
     @contextlib.asynccontextmanager
-    async def stream_records(
+    async def _open_get_response(
         cls,
         url: str,
         *,
-        framing: StreamFraming,
         params: Sized = '',
         proxy: str | bool | None = '',
         headers: dict[str, str] | None = None,
         follow_redirects: bool = False,
         request_timeout: int = 60,
-    ) -> AsyncIterator[TextRecordResponse]:
-        """Stream bounded UTF-8 NDJSON lines or complete SSE events.
-
-        The returned response is single-use. Redirects are disabled unless the
-        caller explicitly opts in, and transport/body failures use
-        ``ResponseStreamError`` while cancellation and consumer errors pass through.
-        """
-        if framing not in {'ndjson', 'sse'}:
-            raise ValueError(f'unsupported stream framing: {framing}')
+    ) -> AsyncIterator[aiohttp.ClientResponse]:
         try:
             ssl_arg = cls._ssl_context()
             proxy_url, proxy_type = cls._resolve_proxy(proxy)
@@ -843,14 +848,84 @@ class AsyncFetcher:
                     response = await stack.enter_async_context(session.request('GET', url, **request_kwargs))
                 except (aiohttp.ClientError, TimeoutError, OSError, ssl.SSLError, ValueError) as error:
                     raise ResponseStreamError('transport-error') from error
-                yield TextRecordResponse(
-                    status=response.status,
-                    headers={name.lower(): value for name, value in response.headers.items()},
-                    _content=response.content,
-                    _framing=framing,
-                )
+                yield response
         finally:
             await session.close()
+
+    @classmethod
+    async def fetch_json(
+        cls,
+        url: str,
+        *,
+        params: Sized = '',
+        proxy: str | bool | None = '',
+        headers: dict[str, str] | None = None,
+        request_timeout: int = 60,
+    ) -> FetcherResponse:
+        """Fetch one bounded JSON response without following redirects."""
+        async with cls._open_get_response(
+            url,
+            params=params,
+            proxy=proxy,
+            headers=headers,
+            follow_redirects=False,
+            request_timeout=request_timeout,
+        ) as response:
+            response_headers = {name.lower(): value for name, value in response.headers.items()}
+            if not 200 <= response.status < 300 or response.status == 204:
+                return FetcherResponse(body=None, status=response.status, headers=response_headers)
+            try:
+                if int(response_headers.get('content-length', '0')) > MAX_PROVIDER_JSON_BYTES:
+                    raise ResponseStreamError('response-limit')
+            except ValueError:
+                pass
+            body = bytearray()
+            async for chunk in _bounded_response_chunks(response.content, MAX_PROVIDER_JSON_BYTES):
+                body.extend(chunk)
+            try:
+                text = body.decode('utf-8')
+                if not text.strip():
+                    raise ValueError('empty JSON response')
+                parsed = stdlib_json.loads(text, parse_constant=_reject_json_constant)
+            except (UnicodeDecodeError, ValueError, RecursionError) as error:
+                raise ResponseStreamError('invalid-response') from error
+            return FetcherResponse(body=parsed, status=response.status, headers=response_headers)
+
+    @classmethod
+    @contextlib.asynccontextmanager
+    async def stream_records(
+        cls,
+        url: str,
+        *,
+        framing: StreamFraming,
+        params: Sized = '',
+        proxy: str | bool | None = '',
+        headers: dict[str, str] | None = None,
+        follow_redirects: bool = False,
+        request_timeout: int = 60,
+    ) -> AsyncIterator[TextRecordResponse]:
+        """Stream bounded UTF-8 NDJSON lines or complete SSE events.
+
+        The returned response is single-use. Redirects are disabled unless the
+        caller explicitly opts in, and transport/body failures use
+        ``ResponseStreamError`` while cancellation and consumer errors pass through.
+        """
+        if framing not in {'ndjson', 'sse'}:
+            raise ValueError(f'unsupported stream framing: {framing}')
+        async with cls._open_get_response(
+            url,
+            params=params,
+            proxy=proxy,
+            headers=headers,
+            follow_redirects=follow_redirects,
+            request_timeout=request_timeout,
+        ) as response:
+            yield TextRecordResponse(
+                status=response.status,
+                headers={name.lower(): value for name, value in response.headers.items()},
+                _content=response.content,
+                _framing=framing,
+            )
 
     @staticmethod
     async def takeover_fetch(

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -4,10 +4,11 @@ import asyncio
 import contextlib
 import logging
 import random
+import re
 import ssl
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import aiohttp
 import certifi
@@ -22,7 +23,7 @@ from theHarvester.lib.output import output_logger
 from theHarvester.lib.source_catalog import resolve_sources
 
 if TYPE_CHECKING:
-    from collections.abc import Sized
+    from collections.abc import AsyncIterator, Sized
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,18 @@ CONFIG_DIRS = [
     Path('/etc/theHarvester/'),
     Path('/usr/local/etc/theHarvester/'),
 ]
+MAX_STREAM_RESPONSE_BYTES = 64 * 1024 * 1024
+MAX_STREAM_RECORD_BYTES = 10 * 1024 * 1024
+_STREAM_LINE_END = re.compile(rb'[\r\n]')
+
+StreamErrorReason = Literal['invalid-response', 'response-limit', 'transport-error']
+StreamFraming = Literal['ndjson', 'sse']
+
+
+class ResponseStreamError(Exception):
+    def __init__(self, reason: StreamErrorReason) -> None:
+        self.reason = reason
+        super().__init__(reason)
 
 
 @dataclass(frozen=True)
@@ -39,6 +52,90 @@ class FetcherResponse:
     body: Any
     status: int
     headers: dict[str, str]
+
+
+@dataclass
+class TextRecordResponse:
+    status: int
+    headers: dict[str, str]
+    _content: Any
+    _framing: StreamFraming
+    _started: bool = False
+
+    def __aiter__(self) -> AsyncIterator[str]:
+        if self._started:
+            raise RuntimeError('response records can only be consumed once')
+        self._started = True
+        return self._records()
+
+    @staticmethod
+    def _decode(line: bytes | bytearray) -> str:
+        try:
+            return bytes(line).decode('utf-8')
+        except UnicodeDecodeError as error:
+            raise ResponseStreamError('invalid-response') from error
+
+    async def _byte_lines(self) -> AsyncIterator[tuple[bytes, bool]]:
+        pending = bytearray()
+        bytes_read = 0
+        try:
+            async for chunk in self._content.iter_any():
+                remaining = MAX_STREAM_RESPONSE_BYTES - bytes_read
+                accepted = chunk[:remaining]
+                bytes_read += len(accepted)
+                pending.extend(accepted)
+                start = 0
+                while start < len(pending):
+                    line_end = _STREAM_LINE_END.search(pending, start)
+                    if line_end is None:
+                        break
+                    separator = line_end.start()
+                    if pending[separator] == ord('\r') and separator + 1 == len(pending):
+                        break
+                    terminator_bytes = 2 if pending[separator : separator + 2] == b'\r\n' else 1
+                    line = bytes(pending[start:separator])
+                    if len(line) > MAX_STREAM_RECORD_BYTES:
+                        raise ResponseStreamError('response-limit')
+                    start = separator + terminator_bytes
+                    yield line, True
+                if start:
+                    del pending[:start]
+                pending_bytes = len(pending) - (1 if pending.endswith(b'\r') else 0)
+                if pending_bytes > MAX_STREAM_RECORD_BYTES:
+                    raise ResponseStreamError('response-limit')
+                if len(accepted) != len(chunk):
+                    raise ResponseStreamError('response-limit')
+        except (aiohttp.ClientError, TimeoutError, OSError) as error:
+            raise ResponseStreamError('transport-error') from error
+        if pending:
+            if pending[-1] == ord('\r'):
+                yield bytes(pending[:-1]), True
+            else:
+                yield bytes(pending), False
+
+    async def _records(self) -> AsyncIterator[str]:
+        if self._framing == 'ndjson':
+            async for line, _terminated in self._byte_lines():
+                yield self._decode(line)
+            return
+
+        record = bytearray()
+        async for line, terminated in self._byte_lines():
+            if not terminated:
+                raise ResponseStreamError('invalid-response')
+            if not line:
+                if record:
+                    yield self._decode(record)
+                    record.clear()
+                continue
+            added_bytes = len(line) + (1 if record else 0)
+            if len(record) + added_bytes > MAX_STREAM_RECORD_BYTES:
+                raise ResponseStreamError('response-limit')
+            if record:
+                record.append(ord('\n'))
+            record.extend(line)
+        if record:
+            raise ResponseStreamError('invalid-response')
 
 
 class Core:
@@ -698,6 +795,62 @@ class AsyncFetcher:
                     await session.close()
         except (aiohttp.ClientError, TimeoutError, OSError, ssl.SSLError, UnicodeDecodeError, ValueError):
             return None if include_metadata else ''
+
+    @classmethod
+    @contextlib.asynccontextmanager
+    async def stream_records(
+        cls,
+        url: str,
+        *,
+        framing: StreamFraming,
+        params: Sized = '',
+        proxy: str | bool | None = '',
+        headers: dict[str, str] | None = None,
+        follow_redirects: bool = False,
+        request_timeout: int = 60,
+    ) -> AsyncIterator[TextRecordResponse]:
+        """Stream bounded UTF-8 NDJSON lines or complete SSE events.
+
+        The returned response is single-use. Redirects are disabled unless the
+        caller explicitly opts in, and transport/body failures use
+        ``ResponseStreamError`` while cancellation and consumer errors pass through.
+        """
+        if framing not in {'ndjson', 'sse'}:
+            raise ValueError(f'unsupported stream framing: {framing}')
+        try:
+            ssl_arg = cls._ssl_context()
+            proxy_url, proxy_type = cls._resolve_proxy(proxy)
+            session = await cls._build_session(
+                cls._default_headers(headers),
+                cls._request_timeout(request_timeout),
+                proxy_url,
+                proxy_type,
+                ssl_arg,
+            )
+        except (aiohttp.ClientError, TimeoutError, OSError, ssl.SSLError, ValueError) as error:
+            raise ResponseStreamError('transport-error') from error
+        try:
+            request_kwargs: dict[str, Any] = {
+                'ssl': ssl_arg,
+                'allow_redirects': follow_redirects,
+            }
+            if proxy_url and proxy_type == 'http':
+                request_kwargs['proxy'] = proxy_url
+            if params != '':
+                request_kwargs['params'] = params
+            async with contextlib.AsyncExitStack() as stack:
+                try:
+                    response = await stack.enter_async_context(session.request('GET', url, **request_kwargs))
+                except (aiohttp.ClientError, TimeoutError, OSError, ssl.SSLError, ValueError) as error:
+                    raise ResponseStreamError('transport-error') from error
+                yield TextRecordResponse(
+                    status=response.status,
+                    headers={name.lower(): value for name, value in response.headers.items()},
+                    _content=response.content,
+                    _framing=framing,
+                )
+        finally:
+            await session.close()
 
     @staticmethod
     async def takeover_fetch(


### PR DESCRIPTION
## Summary

- add a public `AsyncFetcher.stream_records()` interface for bounded NDJSON lines and complete SSE events
- add `AsyncFetcher.fetch_json()` for bounded strict-UTF-8 JSON without exposing a caller-selected `max_bytes` parameter
- enforce transport-level ceilings before buffering: 64 MiB for response streams, 10 MiB per record, and 16 MiB for buffered JSON
- migrate DNSDB away from private fetcher session helpers while preserving partial records and HTTP status behavior
- disable redirects for provider requests so credentials and provider-only traffic cannot cross an origin boundary

## Why

DNSDB already needed incremental NDJSON transport, Sourcegraph needs incremental SSE framing, and RouteViews needs bounded JSON. Keeping byte accounting, proxy/TLS/session cleanup, strict decoding, and cancellation behavior in one deep transport module prevents every adapter from rebuilding the same error ladder and avoids a one-source `max_bytes` argument on the legacy buffered fetch API.

This is the shared transport foundation for #2524 and the RouteViews follow-up.

## Bounds and behavior

- `stream_records()` owns HTTP session/proxy/TLS/timeout cleanup, total bytes, record bytes, UTF-8, line/SSE framing, and cancellation propagation
- provider modules continue to own provider-specific HTTP statuses, event names, JSON shapes, scope projection, and outcome semantics
- `fetch_json()` disables redirects, returns metadata for non-2xx responses without parsing their bodies, rejects invalid UTF-8/JSON/NaN, and has no public byte-limit knob
- the 16 MiB buffered-JSON ceiling is a conservative provisional shared default, not an empirically calibrated universal provider threshold; it bounds simultaneous bytes, decoded text, and parsed-object amplification, and callers may report partial when oversized payloads are rejected

## Verification

- `pytest`: 958 passed, 6 skipped, 23 deselected
- focused stream, DNSDB, and JSON transport tests: 79 passed
- `ruff check .`
- `ruff format --check .`
- `mypy theHarvester`
- `git diff --check`
- final Standards, Spec, and security reviews: no findings

All provider responses are mocked. No live provider or target traffic was used for verification.
