### PR TITLE
Add typed ASN-prefix routing evidence

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -62,6 +62,22 @@ _Avoid_: Virtual-host result, vhost result
 One canonical IPv4 or IPv6 address merged result.
 _Avoid_: IP-address result, resolved host
 
+**Network prefix result**:
+One canonical IPv4 or IPv6 CIDR merged result retained as external relationship evidence. It is never promoted into the authorized target scope or used as an active-discovery seed without a separate scope decision.
+_Avoid_: Owned netblock, in-scope range, registered network
+
+**Observed route origin**:
+A provider's time-bound assertion that one ASN originates one network prefix. It records routing evidence, not registration, ownership, or authorization.
+_Avoid_: Owned by, registered to, authorized origin
+
+**BGP route observation**:
+One collector and peer's time-bound view of a route, preserving its peer address, peer ASN, AS path, and communities as provider evidence attached to an observed route origin.
+_Avoid_: Network ownership, authoritative route
+
+**RPKI validation observation**:
+A provider's time-bound validation state for one ASN-prefix route origin: valid, invalid, or not found. It reports route-origin authorization evidence, not registration, ownership, reachability, or target scope.
+_Avoid_: Valid network, trusted ASN, owned prefix
+
 **URL result**:
 One normalized URL merged result. Source and action origins identify how it was found; provider-specific URL categories are not separate result kinds.
 _Avoid_: Interesting URL, LinkedIn link, API endpoint result

--- a/docs/adr/0004-keep-network-evidence-typed-and-external.md
+++ b/docs/adr/0004-keep-network-evidence-typed-and-external.md
@@ -1,0 +1,23 @@
+# Keep network evidence typed and external to target scope
+
+Status: accepted
+
+## Decision
+
+Represent routing evidence with a closed set of typed observations attached to a canonical network-prefix result: observed route origin, per-peer BGP route, and RPKI validation. Preserve the existing scalar ASN result alongside those observations.
+
+Every prefix record is explicitly marked `external-relationship`. Routing evidence never implies registration, ownership, authorized target scope, or permission for active discovery. The model therefore has no generic relationship type and no `owns` or `registered_to` fields.
+
+Persist the structured observations in the existing `results.details_json` column, advance the semantic database version to 9, and project the same nested records through JSONL and the API. No table alteration is needed. A normalized relationship table is deferred until a concrete cross-run query requires it.
+
+## Why
+
+Observed BGP origin, one peer's route view, and RPKI authorization answer different questions and have different timestamps and provenance. Flattening them into an ASN or a generic graph edge would erase those distinctions and could incorrectly turn third-party routing data into target-scope authority.
+
+The existing result-details seam already preserves structured virtual-host evidence and can round-trip these prefix observations without a schema migration. That is the smallest durable foundation for a later provider action.
+
+## Consequences
+
+Provider actions must emit a canonical prefix result, its scalar origin ASN, matching prefix action provenance, and an observed-origin record before adding BGP-route or RPKI observations. Per-peer ASNs and AS-path members remain evidence fields rather than promoted results. A future provider integration can enrich known ASN or prefix evidence without joining passive source selection or expanding active scope.
+
+One prefix may carry at most 10,000 observations and 8 MiB of serialized details. These persistence limits fit beneath the existing 10 MiB JSONL import envelope and are independent of provider-response transport budgets.

--- a/docs/adr/0004-keep-network-evidence-typed-and-external.md
+++ b/docs/adr/0004-keep-network-evidence-typed-and-external.md
@@ -8,7 +8,7 @@ Represent routing evidence with a closed set of typed observations attached to a
 
 Every prefix record is explicitly marked `external-relationship`. Routing evidence never implies registration, ownership, authorized target scope, or permission for active discovery. The model therefore has no generic relationship type and no `owns` or `registered_to` fields.
 
-Persist the structured observations in the existing `results.details_json` column, advance the semantic database version to 9, and project the same nested records through JSONL and the API. No table alteration is needed. A normalized relationship table is deferred until a concrete cross-run query requires it.
+Persist the structured observations in the existing `results.details_json` column within the unreleased schema version 8 and project the same nested records through JSONL and the API. No additional version bump or table alteration is needed. A normalized relationship table is deferred until a concrete cross-run query requires it.
 
 ## Why
 

--- a/tests/e2e/test_harvestview.py
+++ b/tests/e2e/test_harvestview.py
@@ -1003,11 +1003,17 @@ def test_harvestview_can_import_and_analyze_fixture_evidence_through_the_real_ui
             for index, source in enumerate(ordered_sources)
         ],
         'results': [
-            {
-                'type': result_type,
-                'value': '192.0.2.10' if result_type == 'ip' else f'{result_type}.example.com',
-                'sources': [ordered_sources[index]['name']] if index < 3 else [],
-            }
+                {
+                    'type': result_type,
+                    'value': (
+                        '192.0.2.10'
+                        if result_type == 'ip'
+                        else 'AS64500'
+                        if result_type == 'asn'
+                        else f'{result_type}.example.com'
+                    ),
+                    'sources': [ordered_sources[index]['name']] if index < 3 else [],
+                }
             for index, result_type in enumerate(('hostname', 'ip', 'asn', 'email', 'url', 'framework', 'person', 'language'))
         ]
         + [

--- a/tests/lib/test_api_v1.py
+++ b/tests/lib/test_api_v1.py
@@ -94,6 +94,67 @@ def _vhost_jsonl_result(*, target: str = 'example.test', value: str = 'admin.exa
     )
 
 
+def _network_jsonl_result() -> str:
+    summary = {
+        'type': 'summary',
+        'run_id': 'b4e1e2d3-cc10-42fa-b66e-ebacfe3acaa2',
+        'target': 'example.test',
+        'started_at': '2026-08-11T12:00:00Z',
+        'completed_at': '2026-08-11T12:01:00Z',
+        'evidence_status': 'complete',
+        'result_count': 2,
+        'counts': {'asn': 1, 'prefix': 1},
+        'action_executions': [
+            {
+                'action': 'routeviews',
+                'status': 'completed',
+                'duration_ms': 1,
+                'result_count': 1,
+                'error_type': None,
+                'stop_reason': None,
+            }
+        ],
+    }
+    prefix = {
+        'type': 'prefix',
+        'value': '203.0.113.0/24',
+        'scope': 'external-relationship',
+        'sources': [],
+        'actions': ['routeviews'],
+        'observations': [
+            {
+                'type': 'observed-origin',
+                'action': 'routeviews',
+                'origin_asn': 'AS64500',
+                'collected_at': '2026-08-11T12:01:00Z',
+            },
+            {
+                'type': 'bgp-route',
+                'action': 'routeviews',
+                'origin_asn': 'AS64500',
+                'collector': 'route-views.test',
+                'peer_asn': 'AS64496',
+                'peer_address': '192.0.2.7',
+                'as_path': '64496 64500',
+                'communities': '',
+                'observed_at': '2026-08-11T12:00:00Z',
+                'collected_at': '2026-08-11T12:01:00Z',
+            },
+            {
+                'type': 'rpki-validation',
+                'action': 'routeviews',
+                'origin_asn': 'AS64500',
+                'state': 'valid',
+                'observed_at': '2026-08-11T12:00:00Z',
+                'collected_at': '2026-08-11T12:01:00Z',
+            },
+        ],
+    }
+    return '\n'.join(
+        (json.dumps(summary), json.dumps({'type': 'asn', 'value': 'AS64500', 'sources': []}), json.dumps(prefix), '')
+    )
+
+
 @pytest.mark.parametrize(
     ('finding_type', 'finding_fields'),
     [
@@ -314,6 +375,7 @@ def test_openapi_explains_scope_and_execution_controls(tmp_path, monkeypatch) ->
         'value',
         'sources',
         'actions',
+        'scope',
         'observations',
     }
     assert 'VirtualHostResult' not in schema['components']['schemas']
@@ -818,6 +880,73 @@ def test_api_jsonl_round_trip_preserves_grouped_virtual_host_observations(tmp_pa
     assert json.loads(exported.text.splitlines()[1]) == expected
     assert reimported.status_code == 201
     assert reimported.json()['results'] == [expected]
+
+
+def test_api_jsonl_round_trip_preserves_structured_network_evidence(tmp_path, monkeypatch) -> None:
+    from theHarvester.lib.api import api
+
+    monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
+    monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
+    monkeypatch.setenv('THEHARVESTER_RUN_WORKER', 'disabled')
+    headers = {'X-API-Key': 'test-key'}
+    expected = [json.loads(line) for line in _network_jsonl_result().splitlines()[1:]]
+    expected[0]['actions'] = []
+
+    with TestClient(api.app, client=('127.0.0.20', 50000)) as client:
+        imported = client.post(
+            '/api/v1/runs/import',
+            params={'filename': 'network.jsonl'},
+            headers=headers,
+            content=_network_jsonl_result(),
+        )
+        assert imported.status_code == 201, imported.text
+        exported = client.get(f'/api/v1/runs/{imported.json()["run_id"]}/export', headers=headers)
+        reimported = client.post(
+            '/api/v1/runs/import',
+            params={'filename': 'network-round-trip.jsonl'},
+            headers=headers,
+            content=exported.content,
+        )
+
+    assert imported.json()['results'] == expected
+    assert imported.json()['result_count'] == 2
+    assert [json.loads(line) for line in exported.text.splitlines()[1:]] == [
+        {key: value for key, value in expected[0].items() if key != 'actions'},
+        expected[1],
+    ]
+    assert reimported.status_code == 201
+    assert reimported.json()['results'] == expected
+
+
+@pytest.mark.parametrize(
+    ('field', 'value'),
+    [
+        ('sources', 'sourcegraph'),
+        ('sources', ['']),
+        ('actions', 'routeviews'),
+        ('actions', ['']),
+    ],
+)
+def test_api_evidence_rejects_invalid_network_producers(field: str, value: object) -> None:
+    from fastapi import HTTPException
+
+    from theHarvester.lib.api.run_evidence import validate_evidence
+
+    records = [json.loads(line) for line in _network_jsonl_result().splitlines()]
+    evidence = {
+        'target': records[0]['target'],
+        'status': records[0]['evidence_status'],
+        'started_at': records[0]['started_at'],
+        'completed_at': records[0]['completed_at'],
+        'results': records[1:],
+        'source_executions': [],
+        'action_executions': records[0]['action_executions'],
+        'artifacts': [],
+    }
+    evidence['results'][1][field] = value
+
+    with pytest.raises(HTTPException, match='Network evidence producers must be arrays of non-empty strings'):
+        validate_evidence(evidence)
 
 
 @pytest.mark.parametrize(

--- a/tests/lib/test_completed_persistence.py
+++ b/tests/lib/test_completed_persistence.py
@@ -17,6 +17,12 @@ from theHarvester.lib.database import (
     _sqlite_has_wal_reset_fix,
     dispose_sqlite_databases,
 )
+from theHarvester.lib.network_evidence import (
+    BgpRouteObservation,
+    PrefixOriginObservation,
+    RpkiValidationObservation,
+    network_observation_details,
+)
 from theHarvester.lib.virtual_host import VirtualHostObservation
 
 RELEASED_COMPLETED_SCHEMA = """
@@ -134,6 +140,13 @@ SCHEMA_V7_EVIDENCE_STATUS = (
     + """
 ALTER TABLE runs ADD COLUMN evidence_status TEXT;
 PRAGMA user_version = 7;
+"""
+)
+SCHEMA_V8_STRUCTURED_DETAILS = (
+    SCHEMA_V7_EVIDENCE_STATUS
+    + """
+ALTER TABLE results ADD COLUMN details_json TEXT;
+PRAGMA user_version = 8;
 """
 )
 
@@ -261,10 +274,10 @@ async def test_newer_schema_is_rejected_without_changing_journal_mode(tmp_path) 
     database = tmp_path / 'stash.sqlite'
     store = ResultStore(database)
     with sqlite3.connect(database) as db:
-        db.execute('PRAGMA user_version = 9')
+        db.execute('PRAGMA user_version = 10')
         original_journal_mode = db.execute('PRAGMA journal_mode').fetchone()[0]
 
-    with pytest.raises(RuntimeError, match='schema version 9 is newer than supported version 8'):
+    with pytest.raises(RuntimeError, match='schema version 10 is newer than supported version 9'):
         await store.initialize()
 
     with sqlite3.connect(database) as db:
@@ -396,7 +409,7 @@ async def test_structured_vhost_evidence_round_trips_in_the_results_table(tmp_pa
             'SELECT COUNT(*) FROM result_origins WHERE run_id = ?',
             (str(result.run_id),),
         ).fetchone()[0]
-    assert schema_version == 8
+    assert schema_version == 9
     assert stored_result[:2] == ('hostname', 'admin.example.com')
     assert json.loads(stored_result[2]) == [
         {key: value for key, value in observation.to_record().items() if key not in {'type', 'hostname'}}
@@ -404,6 +417,68 @@ async def test_structured_vhost_evidence_round_trips_in_the_results_table(tmp_pa
     ]
     assert executions == [('action', 'vhost', 1), ('source', 'crtsh', 1)]
     assert origin_count == 2
+
+
+@pytest.mark.asyncio
+async def test_structured_network_evidence_round_trips_in_the_results_table(tmp_path) -> None:
+    database = tmp_path / 'stash.sqlite'
+    store = ResultStore(database)
+    await store.initialize()
+    collected_at = datetime(2026, 8, 11, 12, 1, tzinfo=UTC)
+    observed_at = datetime(2026, 8, 11, 12, 0, tzinfo=UTC)
+    network_observations = (
+        PrefixOriginObservation('routeviews', '198.51.100.7/24', 64500, collected_at),
+        BgpRouteObservation(
+            'routeviews',
+            '198.51.100.0/24',
+            'AS64500',
+            'route-views.test',
+            64496,
+            '192.0.2.7',
+            '64496 64500',
+            '',
+            observed_at,
+            collected_at,
+        ),
+        RpkiValidationObservation(
+            'routeviews',
+            '198.51.100.0/24',
+            64500,
+            'not-found',
+            observed_at,
+            collected_at,
+        ),
+    )
+    result = CompletedResult.finish(
+        run_id=UUID('6db84c57-e459-4a5a-95c5-1c231a160ba6'),
+        target='example.com',
+        started_at=observed_at,
+        completed_at=collected_at,
+        groups={'asn': ['AS64500']},
+        active_evidence=ActiveEvidence(
+            executions=(
+                ActionExecution.finish(
+                    action='routeviews',
+                    status='completed',
+                    duration_ms=15,
+                    groups={'prefix': ['198.51.100.0/24']},
+                ),
+            )
+        ),
+        network_observations=network_observations,
+    )
+
+    await store.save_run(result)
+
+    assert await store.load_run(result.run_id) == result
+    with sqlite3.connect(database) as db:
+        schema_version = db.execute('PRAGMA user_version').fetchone()[0]
+        stored_details = db.execute(
+            "SELECT details_json FROM results WHERE run_id = ? AND kind = 'prefix'",
+            (str(result.run_id),),
+        ).fetchone()[0]
+    assert schema_version == 9
+    assert json.loads(stored_details) == network_observation_details(network_observations)
 
 
 @pytest.mark.asyncio
@@ -472,7 +547,7 @@ async def test_schema_v7_migrates_vhost_collision_without_losing_references(tmp_
     assert execution == ('vhost', 1)
     assert origins == [(0, 0)]
     assert artifacts == [(0, 0, 'screenshots/admin.example.com.png')]
-    assert schema_version == 8
+    assert schema_version == 9
 
 
 @pytest.mark.asyncio
@@ -531,6 +606,78 @@ async def test_loading_malformed_vhost_details_fails_closed(tmp_path, details_js
         db.commit()
 
     with pytest.raises(ResultStoreError, match='virtual-host details'):
+        await store.load_run(result.run_id)
+
+
+@pytest.mark.asyncio
+async def test_loading_vhost_details_without_vhost_provenance_preserves_compatibility_error(tmp_path) -> None:
+    database = tmp_path / 'stash.sqlite'
+    store = ResultStore(database)
+    await store.initialize()
+    result = CompletedResult.finish(
+        target='example.com',
+        started_at=datetime(2026, 8, 9, 12, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 8, 9, 12, 1, tzinfo=UTC),
+        groups={},
+        active_evidence=ActiveEvidence(
+            executions=(
+                ActionExecution.finish(
+                    action='vhost',
+                    status='completed',
+                    duration_ms=1,
+                    groups={'hostname': ['admin.example.com']},
+                ),
+            )
+        ),
+        virtual_hosts=(vhost_observation('http://192.0.2.10', status=200, control_status=404),),
+    )
+    await store.save_run(result)
+    with sqlite3.connect(database) as db:
+        db.execute('DELETE FROM result_origins WHERE run_id = ?', (str(result.run_id),))
+        db.commit()
+
+    with pytest.raises(
+        ResultStoreError,
+        match='Persisted virtual-host details require hostname results with vhost provenance',
+    ):
+        await store.load_run(result.run_id)
+
+
+@pytest.mark.asyncio
+async def test_loading_oversized_network_details_fails_before_json_decode(tmp_path, monkeypatch) -> None:
+    database = tmp_path / 'stash.sqlite'
+    store = ResultStore(database)
+    await store.initialize()
+    collected_at = datetime(2026, 8, 11, 12, 1, tzinfo=UTC)
+    result = CompletedResult.finish(
+        target='example.com',
+        started_at=datetime(2026, 8, 11, 12, 0, tzinfo=UTC),
+        completed_at=collected_at,
+        groups={'asn': ['AS64500']},
+        active_evidence=ActiveEvidence(
+            executions=(
+                ActionExecution.finish(
+                    action='routeviews',
+                    status='completed',
+                    duration_ms=1,
+                    groups={'prefix': ['192.0.2.0/24']},
+                ),
+            )
+        ),
+        network_observations=(
+            PrefixOriginObservation('routeviews', '192.0.2.0/24', 'AS64500', collected_at),
+        ),
+    )
+    await store.save_run(result)
+    with sqlite3.connect(database) as db:
+        db.execute(
+            'UPDATE results SET details_json = ? WHERE run_id = ? AND kind = ?',
+            ('[]', str(result.run_id), 'prefix'),
+        )
+        db.commit()
+    monkeypatch.setattr('theHarvester.lib.network_evidence.MAX_NETWORK_DETAILS_BYTES', 1)
+
+    with pytest.raises(ResultStoreError, match='Persisted network details are invalid'):
         await store.load_run(result.run_id)
 
 
@@ -813,7 +960,7 @@ async def test_current_schema_reopens_without_running_legacy_migration(tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_schema_v2_upgrades_to_v8_without_rewriting_existing_rows(tmp_path) -> None:
+async def test_schema_v2_upgrades_to_v9_without_rewriting_existing_rows(tmp_path) -> None:
     database = tmp_path / 'stash.sqlite'
     run_id = UUID('251d4047-190b-4a4d-9c4e-9eed3f23c8c7')
     with sqlite3.connect(database) as db:
@@ -857,8 +1004,59 @@ async def test_schema_v2_upgrades_to_v8_without_rewriting_existing_rows(tmp_path
         observations=(ResultObservation('crtsh', 'hostname', 'api.example.com'),),
     )
     with sqlite3.connect(database) as db:
-        assert db.execute('PRAGMA user_version').fetchone()[0] == 8
+        assert db.execute('PRAGMA user_version').fetchone()[0] == 9
         assert db.execute('SELECT COUNT(*) FROM artifacts').fetchone()[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_schema_v8_merges_bare_and_prefixed_asns_without_losing_provenance_or_details(tmp_path) -> None:
+    database = tmp_path / 'stash.sqlite'
+    run_id = UUID('59a257b4-0542-41d0-a1a2-363e86441753')
+    vhost = vhost_observation('http://192.0.2.10', status=200, control_status=404)
+    with sqlite3.connect(database) as db:
+        db.executescript(SCHEMA_V8_STRUCTURED_DETAILS)
+        db.execute(
+            'INSERT INTO runs (run_id, target, started_at, completed_at) VALUES (?, ?, ?, ?)',
+            (str(run_id), 'example.com', '2026-08-09T12:00:00+00:00', '2026-08-09T12:01:00+00:00'),
+        )
+        db.executemany(
+            'INSERT INTO results (run_id, position, kind, value, details_json) VALUES (?, ?, ?, ?, ?)',
+            [
+                (str(run_id), 0, 'asn', '15133', None),
+                (str(run_id), 1, 'asn', 'AS15133', None),
+                (
+                    str(run_id),
+                    2,
+                    'hostname',
+                    'admin.example.com',
+                    json.dumps([{key: value for key, value in vhost.to_record().items() if key not in {'type', 'hostname'}}]),
+                ),
+            ],
+        )
+        db.executemany(
+            'INSERT INTO executions '
+            '(run_id, position, producer_kind, name, status, duration_ms, result_count) '
+            'VALUES (?, ?, ?, ?, ?, ?, ?)',
+            [
+                (str(run_id), 0, 'source', 'criminalip', 'completed', 1.0, 2),
+                (str(run_id), 1, 'action', 'vhost', 'completed', 1.0, 1),
+            ],
+        )
+        db.executemany(
+            'INSERT INTO result_origins (run_id, result_position, execution_position) VALUES (?, ?, ?)',
+            [(str(run_id), 0, 0), (str(run_id), 1, 0), (str(run_id), 2, 1)],
+        )
+
+    store = ResultStore(database)
+    await store.initialize()
+    loaded = await store.load_run(run_id)
+
+    assert loaded.results == (('asn', 'AS15133'), ('hostname', 'admin.example.com'))
+    assert loaded.source_executions == (SourceExecution('criminalip', 'completed', 1.0, 1),)
+    assert loaded.observations == (ResultObservation('criminalip', 'asn', 'AS15133'),)
+    assert loaded.virtual_hosts == (vhost,)
+    with sqlite3.connect(database) as db:
+        assert db.execute('PRAGMA user_version').fetchone()[0] == 9
 
 
 @pytest.mark.asyncio
@@ -894,7 +1092,7 @@ async def test_schema_v6_adds_nullable_evidence_status_without_rewriting_executi
     assert loaded.status == 'partial'
     assert stored_status is None
     assert 'evidence_status' in run_columns
-    assert schema_version == 8
+    assert schema_version == 9
 
 
 @pytest.mark.asyncio
@@ -983,7 +1181,7 @@ async def test_schema_v4_merges_deprecated_url_kinds_without_losing_origins(tmp_
     assert screenshot.artifacts[0].subject_kind == 'url'
     assert screenshot.artifacts[0].subject_value == target_url
     with sqlite3.connect(database) as db:
-        assert db.execute('PRAGMA user_version').fetchone()[0] == 8
+        assert db.execute('PRAGMA user_version').fetchone()[0] == 9
         assert db.execute('SELECT DISTINCT kind FROM legacy_observations').fetchall() == [('url',)]
         assert db.execute('SELECT result_count FROM executions WHERE name = ?', ('api-scan',)).fetchone()[0] == 1
 
@@ -1061,7 +1259,7 @@ async def test_schema_v5_merges_ip_address_into_ip_without_losing_provenance_or_
     assert screenshot.artifacts[0].subject_kind == 'ip'
     assert screenshot.artifacts[0].subject_value == address
     with sqlite3.connect(database) as db:
-        assert db.execute('PRAGMA user_version').fetchone()[0] == 8
+        assert db.execute('PRAGMA user_version').fetchone()[0] == 9
         assert db.execute('SELECT kind, value FROM results').fetchall() == [('ip', address)]
         assert db.execute('SELECT execution_position FROM result_origins ORDER BY execution_position').fetchall() == [
             (0,),
@@ -1109,7 +1307,7 @@ async def test_released_results_migrate_to_legacy_observations(tmp_path) -> None
         ('/api/v1', 'url'),
         ('admin@example.com', 'email'),
     ]
-    assert schema_version == 8
+    assert schema_version == 9
 
 
 @pytest.mark.asyncio
@@ -1258,7 +1456,7 @@ async def test_schema_v1_observations_upgrade_without_losing_rows(tmp_path) -> N
         schema_version = db.execute('PRAGMA user_version').fetchone()[0]
     assert 'discovery_observations' not in tables
     assert rows == [('example.com', 'api.example.com', 'hostname', 'crtsh')]
-    assert schema_version == 8
+    assert schema_version == 9
 
 
 @pytest.mark.asyncio

--- a/tests/lib/test_completed_persistence.py
+++ b/tests/lib/test_completed_persistence.py
@@ -142,6 +142,8 @@ ALTER TABLE runs ADD COLUMN evidence_status TEXT;
 PRAGMA user_version = 7;
 """
 )
+
+
 def completed_result(run_id: str = 'f047261c-0afb-4e18-89d5-28a7d977f51f') -> CompletedResult:
     return CompletedResult.finish(
         run_id=UUID(run_id),
@@ -473,6 +475,41 @@ async def test_structured_network_evidence_round_trips_in_the_results_table(tmp_
 
 
 @pytest.mark.asyncio
+async def test_loading_prefix_details_with_vhost_provenance_fails_closed(tmp_path) -> None:
+    database = tmp_path / 'stash.sqlite'
+    store = ResultStore(database)
+    await store.initialize()
+    collected_at = datetime(2026, 8, 11, 12, 1, tzinfo=UTC)
+    result = CompletedResult.finish(
+        target='example.com',
+        started_at=collected_at,
+        completed_at=collected_at,
+        groups={'asn': ['AS64500']},
+        active_evidence=ActiveEvidence(
+            executions=(
+                ActionExecution.finish(
+                    action='routeviews',
+                    status='completed',
+                    duration_ms=1,
+                    groups={'prefix': ['198.51.100.0/24']},
+                ),
+            )
+        ),
+        network_observations=(PrefixOriginObservation('routeviews', '198.51.100.0/24', 'AS64500', collected_at),),
+    )
+    await store.save_run(result)
+    with sqlite3.connect(database) as db:
+        db.execute(
+            "UPDATE executions SET name = 'vhost' WHERE run_id = ? AND name = 'routeviews'",
+            (str(result.run_id),),
+        )
+        db.commit()
+
+    with pytest.raises(ResultStoreError, match=r'Persisted virtual-host details are missing: 198\.51\.100\.0/24'):
+        await store.load_run(result.run_id)
+
+
+@pytest.mark.asyncio
 async def test_schema_v7_migrates_vhost_collision_without_losing_references(tmp_path) -> None:
     database = tmp_path / 'stash.sqlite'
     run_id = UUID('750ab571-778d-490e-b760-70394d936eb4')
@@ -655,9 +692,7 @@ async def test_loading_oversized_network_details_fails_before_json_decode(tmp_pa
                 ),
             )
         ),
-        network_observations=(
-            PrefixOriginObservation('routeviews', '192.0.2.0/24', 'AS64500', collected_at),
-        ),
+        network_observations=(PrefixOriginObservation('routeviews', '192.0.2.0/24', 'AS64500', collected_at),),
     )
     await store.save_run(result)
     with sqlite3.connect(database) as db:

--- a/tests/lib/test_completed_persistence.py
+++ b/tests/lib/test_completed_persistence.py
@@ -142,15 +142,6 @@ ALTER TABLE runs ADD COLUMN evidence_status TEXT;
 PRAGMA user_version = 7;
 """
 )
-SCHEMA_V8_STRUCTURED_DETAILS = (
-    SCHEMA_V7_EVIDENCE_STATUS
-    + """
-ALTER TABLE results ADD COLUMN details_json TEXT;
-PRAGMA user_version = 8;
-"""
-)
-
-
 def completed_result(run_id: str = 'f047261c-0afb-4e18-89d5-28a7d977f51f') -> CompletedResult:
     return CompletedResult.finish(
         run_id=UUID(run_id),
@@ -274,10 +265,10 @@ async def test_newer_schema_is_rejected_without_changing_journal_mode(tmp_path) 
     database = tmp_path / 'stash.sqlite'
     store = ResultStore(database)
     with sqlite3.connect(database) as db:
-        db.execute('PRAGMA user_version = 10')
+        db.execute('PRAGMA user_version = 9')
         original_journal_mode = db.execute('PRAGMA journal_mode').fetchone()[0]
 
-    with pytest.raises(RuntimeError, match='schema version 10 is newer than supported version 9'):
+    with pytest.raises(RuntimeError, match='schema version 9 is newer than supported version 8'):
         await store.initialize()
 
     with sqlite3.connect(database) as db:
@@ -409,7 +400,7 @@ async def test_structured_vhost_evidence_round_trips_in_the_results_table(tmp_pa
             'SELECT COUNT(*) FROM result_origins WHERE run_id = ?',
             (str(result.run_id),),
         ).fetchone()[0]
-    assert schema_version == 9
+    assert schema_version == 8
     assert stored_result[:2] == ('hostname', 'admin.example.com')
     assert json.loads(stored_result[2]) == [
         {key: value for key, value in observation.to_record().items() if key not in {'type', 'hostname'}}
@@ -477,7 +468,7 @@ async def test_structured_network_evidence_round_trips_in_the_results_table(tmp_
             "SELECT details_json FROM results WHERE run_id = ? AND kind = 'prefix'",
             (str(result.run_id),),
         ).fetchone()[0]
-    assert schema_version == 9
+    assert schema_version == 8
     assert json.loads(stored_details) == network_observation_details(network_observations)
 
 
@@ -547,7 +538,7 @@ async def test_schema_v7_migrates_vhost_collision_without_losing_references(tmp_
     assert execution == ('vhost', 1)
     assert origins == [(0, 0)]
     assert artifacts == [(0, 0, 'screenshots/admin.example.com.png')]
-    assert schema_version == 9
+    assert schema_version == 8
 
 
 @pytest.mark.asyncio
@@ -960,7 +951,7 @@ async def test_current_schema_reopens_without_running_legacy_migration(tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_schema_v2_upgrades_to_v9_without_rewriting_existing_rows(tmp_path) -> None:
+async def test_schema_v2_upgrades_to_v8_without_rewriting_existing_rows(tmp_path) -> None:
     database = tmp_path / 'stash.sqlite'
     run_id = UUID('251d4047-190b-4a4d-9c4e-9eed3f23c8c7')
     with sqlite3.connect(database) as db:
@@ -1004,59 +995,8 @@ async def test_schema_v2_upgrades_to_v9_without_rewriting_existing_rows(tmp_path
         observations=(ResultObservation('crtsh', 'hostname', 'api.example.com'),),
     )
     with sqlite3.connect(database) as db:
-        assert db.execute('PRAGMA user_version').fetchone()[0] == 9
+        assert db.execute('PRAGMA user_version').fetchone()[0] == 8
         assert db.execute('SELECT COUNT(*) FROM artifacts').fetchone()[0] == 0
-
-
-@pytest.mark.asyncio
-async def test_schema_v8_merges_bare_and_prefixed_asns_without_losing_provenance_or_details(tmp_path) -> None:
-    database = tmp_path / 'stash.sqlite'
-    run_id = UUID('59a257b4-0542-41d0-a1a2-363e86441753')
-    vhost = vhost_observation('http://192.0.2.10', status=200, control_status=404)
-    with sqlite3.connect(database) as db:
-        db.executescript(SCHEMA_V8_STRUCTURED_DETAILS)
-        db.execute(
-            'INSERT INTO runs (run_id, target, started_at, completed_at) VALUES (?, ?, ?, ?)',
-            (str(run_id), 'example.com', '2026-08-09T12:00:00+00:00', '2026-08-09T12:01:00+00:00'),
-        )
-        db.executemany(
-            'INSERT INTO results (run_id, position, kind, value, details_json) VALUES (?, ?, ?, ?, ?)',
-            [
-                (str(run_id), 0, 'asn', '15133', None),
-                (str(run_id), 1, 'asn', 'AS15133', None),
-                (
-                    str(run_id),
-                    2,
-                    'hostname',
-                    'admin.example.com',
-                    json.dumps([{key: value for key, value in vhost.to_record().items() if key not in {'type', 'hostname'}}]),
-                ),
-            ],
-        )
-        db.executemany(
-            'INSERT INTO executions '
-            '(run_id, position, producer_kind, name, status, duration_ms, result_count) '
-            'VALUES (?, ?, ?, ?, ?, ?, ?)',
-            [
-                (str(run_id), 0, 'source', 'criminalip', 'completed', 1.0, 2),
-                (str(run_id), 1, 'action', 'vhost', 'completed', 1.0, 1),
-            ],
-        )
-        db.executemany(
-            'INSERT INTO result_origins (run_id, result_position, execution_position) VALUES (?, ?, ?)',
-            [(str(run_id), 0, 0), (str(run_id), 1, 0), (str(run_id), 2, 1)],
-        )
-
-    store = ResultStore(database)
-    await store.initialize()
-    loaded = await store.load_run(run_id)
-
-    assert loaded.results == (('asn', 'AS15133'), ('hostname', 'admin.example.com'))
-    assert loaded.source_executions == (SourceExecution('criminalip', 'completed', 1.0, 1),)
-    assert loaded.observations == (ResultObservation('criminalip', 'asn', 'AS15133'),)
-    assert loaded.virtual_hosts == (vhost,)
-    with sqlite3.connect(database) as db:
-        assert db.execute('PRAGMA user_version').fetchone()[0] == 9
 
 
 @pytest.mark.asyncio
@@ -1092,7 +1032,7 @@ async def test_schema_v6_adds_nullable_evidence_status_without_rewriting_executi
     assert loaded.status == 'partial'
     assert stored_status is None
     assert 'evidence_status' in run_columns
-    assert schema_version == 9
+    assert schema_version == 8
 
 
 @pytest.mark.asyncio
@@ -1181,7 +1121,7 @@ async def test_schema_v4_merges_deprecated_url_kinds_without_losing_origins(tmp_
     assert screenshot.artifacts[0].subject_kind == 'url'
     assert screenshot.artifacts[0].subject_value == target_url
     with sqlite3.connect(database) as db:
-        assert db.execute('PRAGMA user_version').fetchone()[0] == 9
+        assert db.execute('PRAGMA user_version').fetchone()[0] == 8
         assert db.execute('SELECT DISTINCT kind FROM legacy_observations').fetchall() == [('url',)]
         assert db.execute('SELECT result_count FROM executions WHERE name = ?', ('api-scan',)).fetchone()[0] == 1
 
@@ -1259,7 +1199,7 @@ async def test_schema_v5_merges_ip_address_into_ip_without_losing_provenance_or_
     assert screenshot.artifacts[0].subject_kind == 'ip'
     assert screenshot.artifacts[0].subject_value == address
     with sqlite3.connect(database) as db:
-        assert db.execute('PRAGMA user_version').fetchone()[0] == 9
+        assert db.execute('PRAGMA user_version').fetchone()[0] == 8
         assert db.execute('SELECT kind, value FROM results').fetchall() == [('ip', address)]
         assert db.execute('SELECT execution_position FROM result_origins ORDER BY execution_position').fetchall() == [
             (0,),
@@ -1307,7 +1247,7 @@ async def test_released_results_migrate_to_legacy_observations(tmp_path) -> None
         ('/api/v1', 'url'),
         ('admin@example.com', 'email'),
     ]
-    assert schema_version == 9
+    assert schema_version == 8
 
 
 @pytest.mark.asyncio
@@ -1456,7 +1396,7 @@ async def test_schema_v1_observations_upgrade_without_losing_rows(tmp_path) -> N
         schema_version = db.execute('PRAGMA user_version').fetchone()[0]
     assert 'discovery_observations' not in tables
     assert rows == [('example.com', 'api.example.com', 'hostname', 'crtsh')]
-    assert schema_version == 9
+    assert schema_version == 8
 
 
 @pytest.mark.asyncio

--- a/tests/lib/test_completed_result.py
+++ b/tests/lib/test_completed_result.py
@@ -8,6 +8,8 @@ import pytest
 from theHarvester.lib.active_evidence import ActionExecution, ActionObservation, ActiveEvidence, ArtifactReference
 from theHarvester.lib.completed_result import CompletedResult, ResultObservation, SourceExecution, parse_result_jsonl
 from theHarvester.lib.network_evidence import (
+    MAX_NETWORK_DETAILS_BYTES,
+    MAX_NETWORK_OBSERVATIONS_PER_PREFIX,
     BgpRouteObservation,
     NetworkEvidenceAccumulator,
     NetworkEvidenceLimitError,
@@ -631,6 +633,18 @@ def test_network_evidence_accumulator_owns_incremental_deduplication_and_limits(
             )
         )
     assert len(accumulator.observations()) == 1
+
+
+@pytest.mark.parametrize(
+    'limits',
+    [
+        {'max_observations_per_prefix': MAX_NETWORK_OBSERVATIONS_PER_PREFIX + 1},
+        {'max_details_bytes': MAX_NETWORK_DETAILS_BYTES + 1},
+    ],
+)
+def test_network_evidence_accumulator_cannot_exceed_the_persisted_envelope(limits: dict[str, int]) -> None:
+    with pytest.raises(ValueError, match='persisted envelope'):
+        NetworkEvidenceAccumulator(**limits)
 
 
 def test_jsonl_rejects_excessive_json_nesting() -> None:

--- a/tests/lib/test_completed_result.py
+++ b/tests/lib/test_completed_result.py
@@ -9,6 +9,8 @@ from theHarvester.lib.active_evidence import ActionExecution, ActionObservation,
 from theHarvester.lib.completed_result import CompletedResult, ResultObservation, SourceExecution, parse_result_jsonl
 from theHarvester.lib.network_evidence import (
     BgpRouteObservation,
+    NetworkEvidenceAccumulator,
+    NetworkEvidenceLimitError,
     PrefixOriginObservation,
     RpkiValidationObservation,
     network_observation_details,
@@ -607,6 +609,28 @@ def test_network_details_reject_conflicting_rpki_states() -> None:
 
     with pytest.raises(ValueError, match='conflicting RPKI states'):
         parse_network_observation_details('192.0.2.0/24', details)
+
+
+def test_network_evidence_accumulator_owns_incremental_deduplication_and_limits() -> None:
+    collected_at = datetime(2026, 8, 11, 12, 1, tzinfo=UTC)
+    accumulator = NetworkEvidenceAccumulator(max_observations_per_prefix=1)
+
+    assert accumulator.add(PrefixOriginObservation('routeviews', '192.0.2.0/24', 'AS64500', collected_at))
+    assert not accumulator.add(
+        PrefixOriginObservation('routeviews', '192.0.2.0/24', 'AS64500', collected_at + timedelta(seconds=1))
+    )
+    with pytest.raises(NetworkEvidenceLimitError, match='too many observations'):
+        accumulator.add(
+            RpkiValidationObservation(
+                'routeviews',
+                '192.0.2.0/24',
+                'AS64500',
+                'valid',
+                collected_at,
+                collected_at,
+            )
+        )
+    assert len(accumulator.observations()) == 1
 
 
 def test_jsonl_rejects_excessive_json_nesting() -> None:

--- a/tests/lib/test_completed_result.py
+++ b/tests/lib/test_completed_result.py
@@ -1,5 +1,5 @@
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID
 
@@ -7,6 +7,14 @@ import pytest
 
 from theHarvester.lib.active_evidence import ActionExecution, ActionObservation, ActiveEvidence, ArtifactReference
 from theHarvester.lib.completed_result import CompletedResult, ResultObservation, SourceExecution, parse_result_jsonl
+from theHarvester.lib.network_evidence import (
+    BgpRouteObservation,
+    PrefixOriginObservation,
+    RpkiValidationObservation,
+    network_observation_details,
+    parse_network_observation_details,
+    parse_network_observation_json,
+)
 from theHarvester.lib.virtual_host import VirtualHostObservation
 
 
@@ -321,6 +329,433 @@ def test_completed_result_groups_structured_vhost_evidence_by_hostname() -> None
         ],
     }
     assert parsed_findings == records[1:]
+
+
+def test_completed_result_groups_canonical_network_evidence_by_prefix() -> None:
+    collected_at = datetime(2026, 8, 11, 12, 1, tzinfo=UTC)
+    observed_at = datetime(2026, 8, 11, 12, 0, tzinfo=UTC)
+    origin = PrefixOriginObservation('routeviews', '192.0.2.7/24', '64500', collected_at)
+    route = BgpRouteObservation(
+        'routeviews',
+        '192.0.2.7/24',
+        64500,
+        'route-views.test',
+        'AS64496',
+        '2001:db8::1',
+        ' 64496 64500 ',
+        ' 64496:100 64500:200 ',
+        observed_at,
+        collected_at,
+    )
+    validation = RpkiValidationObservation(
+        'routeviews',
+        '192.0.2.0/24',
+        'as64500',
+        'valid',
+        observed_at,
+        collected_at,
+    )
+    result = CompletedResult.finish(
+        target='example.com',
+        started_at=observed_at,
+        completed_at=collected_at,
+        groups={'asn': ['64500']},
+        active_evidence=ActiveEvidence(
+            executions=(
+                ActionExecution.finish(
+                    action='routeviews',
+                    status='completed',
+                    duration_ms=12.5,
+                    groups={'prefix': ['192.0.2.7/24']},
+                ),
+            )
+        ),
+        network_observations=(validation, route, origin, route),
+    )
+
+    records = [json.loads(line) for line in result.jsonl().splitlines()]
+    _summary, parsed_findings = parse_result_jsonl(result.jsonl())
+
+    assert result.results == (('asn', 'AS64500'), ('prefix', '192.0.2.0/24'))
+    assert result.active_evidence.executions[0].observations == (ActionObservation('prefix', '192.0.2.0/24'),)
+    assert result.network_observations == (origin, route, validation)
+    assert route.as_path == ' 64496 64500 '
+    assert route.communities == ' 64496:100 64500:200 '
+    assert records[1:] == [
+        {'sources': [], 'type': 'asn', 'value': 'AS64500'},
+        {
+            'actions': ['routeviews'],
+            'observations': [
+                {
+                    'action': 'routeviews',
+                    'collected_at': '2026-08-11T12:01:00Z',
+                    'origin_asn': 'AS64500',
+                    'type': 'observed-origin',
+                },
+                {
+                    'action': 'routeviews',
+                    'as_path': ' 64496 64500 ',
+                    'collected_at': '2026-08-11T12:01:00Z',
+                    'collector': 'route-views.test',
+                    'communities': ' 64496:100 64500:200 ',
+                    'observed_at': '2026-08-11T12:00:00Z',
+                    'origin_asn': 'AS64500',
+                    'peer_address': '2001:db8::1',
+                    'peer_asn': 'AS64496',
+                    'type': 'bgp-route',
+                },
+                {
+                    'action': 'routeviews',
+                    'collected_at': '2026-08-11T12:01:00Z',
+                    'observed_at': '2026-08-11T12:00:00Z',
+                    'origin_asn': 'AS64500',
+                    'state': 'valid',
+                    'type': 'rpki-validation',
+                },
+            ],
+            'scope': 'external-relationship',
+            'sources': [],
+            'type': 'prefix',
+            'value': '192.0.2.0/24',
+        },
+    ]
+    assert parsed_findings == [{**records[1], 'actions': []}, records[2]]
+
+
+def test_bgp_route_rejects_provider_time_after_collection() -> None:
+    collected_at = datetime(2026, 8, 11, 12, 0, tzinfo=UTC)
+
+    with pytest.raises(ValueError, match='observed_at must not be later than collected_at'):
+        BgpRouteObservation(
+            'routeviews',
+            '192.0.2.0/24',
+            'AS64500',
+            'route-views.test',
+            'AS64496',
+            '2001:db8::1',
+            '64496 64500',
+            '',
+            datetime(2026, 8, 11, 12, 1, tzinfo=UTC),
+            collected_at,
+        )
+
+
+def test_rpki_validation_rejects_provider_time_after_collection() -> None:
+    collected_at = datetime(2026, 8, 11, 12, 0, tzinfo=UTC)
+
+    with pytest.raises(ValueError, match='observed_at must not be later than collected_at'):
+        RpkiValidationObservation(
+            'routeviews',
+            '192.0.2.0/24',
+            'AS64500',
+            'valid',
+            datetime(2026, 8, 11, 12, 1, tzinfo=UTC),
+            collected_at,
+        )
+
+
+def test_network_observation_rejects_non_utf8_text() -> None:
+    collected_at = datetime(2026, 8, 11, 12, 0, tzinfo=UTC)
+
+    with pytest.raises(ValueError, match='collector is invalid'):
+        BgpRouteObservation(
+            'routeviews',
+            '192.0.2.0/24',
+            'AS64500',
+            '\ud800',
+            'AS64496',
+            '2001:db8::1',
+            '64496 64500',
+            '',
+            collected_at,
+            collected_at,
+        )
+
+
+@pytest.mark.parametrize(
+    ('field', 'value'),
+    [
+        ('collector', 'route\x00views'),
+        ('collector', 'route\x1bviews'),
+        ('as_path', '64496\x00 64500'),
+        ('communities', '64500:1\x1b'),
+    ],
+)
+def test_network_observation_rejects_control_characters(field: str, value: str) -> None:
+    collected_at = datetime(2026, 8, 11, 12, 0, tzinfo=UTC)
+    fields = {
+        'collector': 'route-views.test',
+        'as_path': '64496 64500',
+        'communities': '',
+    }
+    fields[field] = value
+
+    with pytest.raises(ValueError, match=f'{field.replace("_", " ").replace("as path", "AS path")} is invalid'):
+        BgpRouteObservation(
+            'routeviews',
+            '192.0.2.0/24',
+            'AS64500',
+            fields['collector'],
+            'AS64496',
+            '2001:db8::1',
+            fields['as_path'],
+            fields['communities'],
+            collected_at,
+            collected_at,
+        )
+
+
+@pytest.mark.parametrize('value', ['fe80::%eth0/64', 'fe80::%?q/64', 'fe80::%\ud800/64', 'fe80::%bad\n/64'])
+def test_network_prefix_rejects_ipv6_scope_identifiers(value: str) -> None:
+    with pytest.raises(ValueError, match='must not contain an IPv6 scope identifier'):
+        PrefixOriginObservation(
+            'routeviews',
+            value,
+            'AS64500',
+            datetime(2026, 8, 11, 12, 0, tzinfo=UTC),
+        )
+
+
+@pytest.mark.parametrize('value', ['fe80::1%eth0', 'fe80::1%?q', 'fe80::1%\ud800'])
+def test_network_peer_rejects_ipv6_scope_identifiers(value: str) -> None:
+    collected_at = datetime(2026, 8, 11, 12, 0, tzinfo=UTC)
+
+    with pytest.raises(ValueError, match='must not contain an IPv6 scope identifier'):
+        BgpRouteObservation(
+            'routeviews',
+            '2001:db8::/32',
+            'AS64500',
+            'route-views.test',
+            'AS64496',
+            value,
+            '64496 64500',
+            '',
+            collected_at,
+            collected_at,
+        )
+
+
+def test_completed_result_rejects_collection_outside_run_window() -> None:
+    started_at = datetime(2026, 8, 11, 12, 0, tzinfo=UTC)
+    completed_at = datetime(2026, 8, 11, 12, 1, tzinfo=UTC)
+    origin = PrefixOriginObservation('routeviews', '192.0.2.0/24', 'AS64500', completed_at + timedelta(seconds=1))
+
+    with pytest.raises(ValueError, match='collection time must fall within the completed run'):
+        CompletedResult.finish(
+            target='example.com',
+            started_at=started_at,
+            completed_at=completed_at,
+            groups={'asn': ['AS64500']},
+            active_evidence=ActiveEvidence(
+                executions=(
+                    ActionExecution.finish(
+                        action='routeviews',
+                        status='completed',
+                        duration_ms=1,
+                        groups={'prefix': ['192.0.2.0/24']},
+                    ),
+                )
+            ),
+            network_observations=(origin,),
+        )
+
+
+def test_network_details_reject_excessive_observation_count(monkeypatch) -> None:
+    monkeypatch.setattr('theHarvester.lib.network_evidence.MAX_NETWORK_OBSERVATIONS_PER_PREFIX', 1)
+    details = [
+        {
+            'type': 'observed-origin',
+            'action': 'routeviews',
+            'origin_asn': f'AS{64500 + index}',
+            'collected_at': '2026-08-11T12:01:00Z',
+        }
+        for index in range(2)
+    ]
+
+    with pytest.raises(ValueError, match='too many observations'):
+        parse_network_observation_details('192.0.2.0/24', details)
+
+
+def test_network_details_reject_excessive_serialized_size(monkeypatch) -> None:
+    collected_at = datetime(2026, 8, 11, 12, 0, tzinfo=UTC)
+    origin = PrefixOriginObservation('routeviews', '192.0.2.0/24', 'AS64500', collected_at)
+    monkeypatch.setattr('theHarvester.lib.network_evidence.MAX_NETWORK_DETAILS_BYTES', 1)
+
+    with pytest.raises(ValueError, match='serialized size limit'):
+        network_observation_details((origin,))
+
+
+def test_network_json_rejects_utf8_byte_size_before_decoding(monkeypatch) -> None:
+    monkeypatch.setattr('theHarvester.lib.network_evidence.MAX_NETWORK_DETAILS_BYTES', 5)
+
+    with pytest.raises(ValueError, match='serialized size limit'):
+        parse_network_observation_json('192.0.2.0/24', '["é"]')
+
+
+def test_network_details_reject_conflicting_rpki_states() -> None:
+    details = [
+        {
+            'type': 'rpki-validation',
+            'action': 'routeviews',
+            'origin_asn': 'AS64500',
+            'state': state,
+            'observed_at': '2026-08-11T12:00:00Z',
+            'collected_at': f'2026-08-11T12:01:0{index}Z',
+        }
+        for index, state in enumerate(('valid', 'invalid'))
+    ]
+
+    with pytest.raises(ValueError, match='conflicting RPKI states'):
+        parse_network_observation_details('192.0.2.0/24', details)
+
+
+def test_jsonl_rejects_excessive_json_nesting() -> None:
+    payload = '{"type":"summary"}\n{"type":"asn","value":' + '[' * 100_000 + '0' + ']' * 100_000 + '}'
+
+    with pytest.raises(ValueError, match='not valid JSONL'):
+        parse_result_jsonl(payload)
+
+
+def test_querying_an_existing_prefix_remains_one_action_result() -> None:
+    completed_at = datetime(2026, 8, 11, 12, 1, tzinfo=UTC)
+    result = CompletedResult.finish(
+        target='example.com',
+        started_at=completed_at,
+        completed_at=completed_at,
+        groups={'prefix': ['192.0.2.0/24']},
+        active_evidence=ActiveEvidence(
+            executions=(
+                ActionExecution.finish(
+                    action='routeviews',
+                    status='completed',
+                    duration_ms=1,
+                    groups={'prefix': ['192.0.2.7/24']},
+                ),
+            )
+        ),
+    )
+
+    assert result.results == (('prefix', '192.0.2.0/24'),)
+    assert result.active_evidence.executions[0].result_count == 1
+    assert result.evidence_dict()['results'] == [
+        {
+            'type': 'prefix',
+            'value': '192.0.2.0/24',
+            'scope': 'external-relationship',
+            'sources': [],
+            'actions': ['routeviews'],
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ('field', 'value', 'message'),
+    [
+        ('scope', 'in-scope', 'prefix scope'),
+        ('owns', True, 'known type'),
+        ('registered_to', 'Example Organization', 'known type'),
+    ],
+)
+def test_jsonl_rejects_network_scope_inflation_and_ownership_claims(
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    finding = {
+        'type': 'prefix',
+        'value': '192.0.2.0/24',
+        'scope': 'external-relationship',
+        'sources': [],
+        'actions': ['routeviews'],
+        'observations': [
+            {
+                'type': 'observed-origin',
+                'action': 'routeviews',
+                'origin_asn': 'AS64500',
+                'collected_at': '2026-08-11T12:01:00Z',
+            }
+        ],
+    }
+    finding[field] = value
+    payload = '\n'.join((json.dumps({'type': 'summary'}), json.dumps(finding)))
+
+    with pytest.raises(ValueError, match=message):
+        parse_result_jsonl(payload)
+
+
+@pytest.mark.parametrize(
+    ('finding', 'message'),
+    [
+        (
+            {
+                'type': 'prefix',
+                'value': '192.0.2.7/24',
+                'scope': 'external-relationship',
+                'sources': [],
+                'actions': [],
+            },
+            'canonical prefix',
+        ),
+    ],
+)
+def test_jsonl_rejects_noncanonical_network_result_values(finding: dict[str, object], message: str) -> None:
+    payload = '\n'.join((json.dumps({'type': 'summary'}), json.dumps(finding)))
+
+    with pytest.raises(ValueError, match=message):
+        parse_result_jsonl(payload)
+
+
+def test_jsonl_normalizes_legacy_bare_asn_value() -> None:
+    payload = '\n'.join(
+        (
+            json.dumps({'type': 'summary'}),
+            json.dumps({'type': 'asn', 'value': '64500', 'sources': ['criminalip'], 'actions': []}),
+        )
+    )
+
+    _summary, findings = parse_result_jsonl(payload)
+
+    assert findings == [{'type': 'asn', 'value': 'AS64500', 'sources': ['criminalip'], 'actions': []}]
+
+
+@pytest.mark.parametrize(
+    'observation',
+    [
+        {
+            'type': [],
+            'action': 'routeviews',
+            'origin_asn': 'AS64500',
+            'collected_at': '2026-08-11T12:01:00Z',
+        },
+        {
+            'type': 'rpki-validation',
+            'action': 'routeviews',
+            'origin_asn': 'AS64500',
+            'state': [],
+            'observed_at': '2026-08-11T12:00:00Z',
+            'collected_at': '2026-08-11T12:01:00Z',
+        },
+    ],
+)
+def test_jsonl_rejects_non_string_network_discriminators(observation: dict[str, object]) -> None:
+    payload = '\n'.join(
+        (
+            json.dumps({'type': 'summary'}),
+            json.dumps(
+                {
+                    'type': 'prefix',
+                    'value': '192.0.2.0/24',
+                    'scope': 'external-relationship',
+                    'sources': [],
+                    'actions': ['routeviews'],
+                    'observations': [observation],
+                }
+            ),
+        )
+    )
+
+    with pytest.raises(ValueError, match='invalid network observations'):
+        parse_result_jsonl(payload)
 
 
 def test_completed_result_rejects_structured_vhost_without_vhost_action_provenance() -> None:

--- a/tests/lib/test_completed_result.py
+++ b/tests/lib/test_completed_result.py
@@ -650,7 +650,7 @@ def test_network_evidence_accumulator_cannot_exceed_the_persisted_envelope(limit
 def test_jsonl_rejects_excessive_json_nesting() -> None:
     payload = '{"type":"summary"}\n{"type":"asn","value":' + '[' * 100_000 + '0' + ']' * 100_000 + '}'
 
-    with pytest.raises(ValueError, match='not valid JSONL'):
+    with pytest.raises(ValueError, match=r'not valid JSONL|JSONL findings must contain'):
         parse_result_jsonl(payload)
 
 

--- a/tests/lib/test_run_backend.py
+++ b/tests/lib/test_run_backend.py
@@ -215,7 +215,7 @@ def test_api_lifecycle_and_terminal_evidence_share_the_sqlalchemy_database(tmp_p
         schema_version = db.execute('PRAGMA user_version').fetchone()[0]
     assert evidence_run_id == lifecycle_run_id
     assert stored_target == 'example.test'
-    assert schema_version == 8
+    assert schema_version == 9
     assert 'import aiosqlite' not in inspect.getsource(run_store_module)
 
 

--- a/tests/lib/test_run_backend.py
+++ b/tests/lib/test_run_backend.py
@@ -215,7 +215,7 @@ def test_api_lifecycle_and_terminal_evidence_share_the_sqlalchemy_database(tmp_p
         schema_version = db.execute('PRAGMA user_version').fetchone()[0]
     assert evidence_run_id == lifecycle_run_id
     assert stored_target == 'example.test'
-    assert schema_version == 9
+    assert schema_version == 8
     assert 'import aiosqlite' not in inspect.getsource(run_store_module)
 
 

--- a/theHarvester/lib/active_evidence.py
+++ b/theHarvester/lib/active_evidence.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Self
 
 from theHarvester.lib.evidence_types import EXECUTION_STATUSES, RESULT_KINDS, ExecutionStatus, ResultKind, format_utc
+from theHarvester.lib.result_values import normalize_result_value
 
 
 @dataclass(frozen=True, order=True, slots=True)
@@ -18,6 +19,7 @@ class ActionObservation:
             raise ValueError('screenshots must be stored as artifacts, not results')
         if not isinstance(self.value, str) or not self.value.strip():
             raise ValueError('action observation value must be a non-empty string')
+        object.__setattr__(self, 'value', normalize_result_value(self.kind, self.value))
 
 
 @dataclass(frozen=True, order=True, slots=True)

--- a/theHarvester/lib/api/run_evidence.py
+++ b/theHarvester/lib/api/run_evidence.py
@@ -9,6 +9,11 @@ from fastapi import HTTPException, status
 
 from theHarvester.lib.completed_result import parse_result_jsonl, parse_virtual_host_details, virtual_host_details
 from theHarvester.lib.evidence_types import EVIDENCE_STATUSES
+from theHarvester.lib.network_evidence import (
+    network_observation_details,
+    parse_network_observation_details,
+)
+from theHarvester.lib.result_values import normalize_prefix
 
 from .run_models import _normalize_target
 
@@ -96,6 +101,42 @@ def validate_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail='vhost is not a result type; use hostname with virtual-host observations',
             )
+        if result.get('type') == 'prefix':
+            allowed_keys = {'type', 'value', 'sources', 'actions', 'scope', 'observations'}
+            if set(result) - allowed_keys:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail='Network evidence contains unsupported fields',
+                )
+            result_value = result.get('value')
+            if not isinstance(result_value, str) or result.get('scope') != 'external-relationship':
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail='Network evidence requires a canonical prefix with external-relationship scope',
+                )
+            sources = result.get('sources', [])
+            actions = result.get('actions', [])
+            if (
+                not isinstance(sources, list)
+                or any(not isinstance(source, str) or not source.strip() for source in sources)
+                or not isinstance(actions, list)
+                or any(not isinstance(action, str) or not action.strip() for action in actions)
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail='Network evidence producers must be arrays of non-empty strings',
+                )
+            try:
+                if normalize_prefix(result_value) != result_value:
+                    raise ValueError('network evidence result value must be a canonical prefix')
+                if 'observations' in result:
+                    network_observations = parse_network_observation_details(result_value, result.get('observations'))
+                    result['observations'] = network_observation_details(network_observations)
+            except ValueError as error:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
+            result['sources'] = sorted(set(sources))
+            result['actions'] = sorted(set(actions))
+            continue
         if 'observations' not in result:
             continue
         if result.get('type') != 'hostname':
@@ -134,7 +175,7 @@ def validate_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
                 detail='Virtual-host evidence must identify a hostname',
             )
         try:
-            observations = parse_virtual_host_details(result_value, details)
+            vhost_observations = parse_virtual_host_details(result_value, details)
         except ValueError as error:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
         target = str(evidence['target'])
@@ -147,12 +188,15 @@ def validate_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail='Virtual-host evidence requires a hostname target scope',
             )
-        if any(observation.hostname == target or not observation.hostname.endswith(f'.{target}') for observation in observations):
+        if any(
+            observation.hostname == target or not observation.hostname.endswith(f'.{target}')
+            for observation in vhost_observations
+        ):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail='Virtual-host evidence must be a strict descendant of the run target',
             )
         result['sources'] = sorted(set(sources))
         result['actions'] = sorted(set(actions))
-        result['observations'] = virtual_host_details(observations)
+        result['observations'] = virtual_host_details(vhost_observations)
     return evidence

--- a/theHarvester/lib/api/run_models.py
+++ b/theHarvester/lib/api/run_models.py
@@ -312,6 +312,41 @@ class VirtualHostObservationResponse(BaseModel):
     reflection_normalized: bool
 
 
+class PrefixOriginObservationResponse(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    type: Literal['observed-origin']
+    action: str
+    origin_asn: str
+    collected_at: str
+
+
+class BgpRouteObservationResponse(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    type: Literal['bgp-route']
+    action: str
+    origin_asn: str
+    collector: str
+    peer_asn: str
+    peer_address: str
+    as_path: str
+    communities: str
+    observed_at: str
+    collected_at: str
+
+
+class RpkiValidationObservationResponse(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    type: Literal['rpki-validation']
+    action: str
+    origin_asn: str
+    state: Literal['valid', 'invalid', 'not-found']
+    observed_at: str
+    collected_at: str
+
+
 class NormalizedResult(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
@@ -319,15 +354,33 @@ class NormalizedResult(BaseModel):
     value: str
     sources: list[str] = Field(default_factory=list)
     actions: list[str] = Field(default_factory=list)
-    observations: list[VirtualHostObservationResponse] | None = Field(default=None, min_length=1)
+    scope: Literal['external-relationship'] | None = None
+    observations: (
+        list[
+            VirtualHostObservationResponse
+            | PrefixOriginObservationResponse
+            | BgpRouteObservationResponse
+            | RpkiValidationObservationResponse
+        ]
+        | None
+    ) = Field(default=None, min_length=1)
 
     @model_validator(mode='after')
     def validate_result(self) -> Self:
         if self.type == 'vhost':
             raise ValueError('vhost is not a result type; use hostname with virtual-host observations')
-        if self.observations is not None:
+        if self.type == 'prefix':
+            if self.scope != 'external-relationship':
+                raise ValueError('Prefix results must have external-relationship scope')
+            if self.observations is not None:
+                from theHarvester.lib.network_evidence import parse_network_observation_details
+
+                parse_network_observation_details(self.value, [details.model_dump() for details in self.observations])
+        elif self.scope is not None:
+            raise ValueError('Only prefix results have relationship scope')
+        elif self.observations is not None:
             if self.type != 'hostname':
-                raise ValueError('Virtual-host observations belong to hostname results')
+                raise ValueError('Structured observations belong to hostname or prefix results')
             parse_virtual_host_details(self.value, [details.model_dump() for details in self.observations])
         return self
 

--- a/theHarvester/lib/api/run_projection.py
+++ b/theHarvester/lib/api/run_projection.py
@@ -38,10 +38,12 @@ def normalized_results(evidence: dict[str, Any] | None) -> list[dict[str, Any]]:
                 'sources': sorted({str(source) for source in item.get('sources', [])}),
                 'actions': sorted({str(action) for action in item.get('actions', [])}),
             }
-            if item.get('type') == 'hostname' and item.get('observations'):
+            if item.get('type') in {'hostname', 'prefix'} and item.get('observations'):
                 result['observations'] = [
                     dict(observation) for observation in item.get('observations', []) if isinstance(observation, dict)
                 ]
+            if item.get('type') == 'prefix':
+                result['scope'] = str(item.get('scope', ''))
             results.append(result)
     return results
 

--- a/theHarvester/lib/api/run_store.py
+++ b/theHarvester/lib/api/run_store.py
@@ -17,6 +17,7 @@ from theHarvester.lib.completed_result import (
 )
 from theHarvester.lib.database import DuplicateRunError, ResultStore, ResultStoreError, RunLifecycleStore
 from theHarvester.lib.evidence_types import EXECUTION_STATUSES, EvidenceStatus, ExecutionStatus, ResultKind
+from theHarvester.lib.network_evidence import NetworkObservation, parse_network_observation_details
 
 from .run_artifacts import RunPaths, read_child_evidence
 from .run_models import RunRequest, _normalize_target, utc_now
@@ -51,12 +52,15 @@ def _completed_result(
     source_counts: Counter[str] = Counter()
     action_groups: dict[str, dict[ResultKind, set[str]]] = defaultdict(lambda: defaultdict(set))
     virtual_hosts: list[VirtualHostObservation] = []
+    network_observations: list[NetworkObservation] = []
     for item in results:
         kind = cast('ResultKind', str(item['type']))
         value = str(item['value'])
         groups[kind].add(value)
         if kind == 'hostname' and item.get('observations'):
             virtual_hosts.extend(parse_virtual_host_details(value, item.get('observations')))
+        elif kind == 'prefix' and item.get('observations'):
+            network_observations.extend(parse_network_observation_details(value, item.get('observations')))
         for source in set(item.get('sources', [])):
             source_name = str(source)
             source_origins.add(ResultObservation(source_name, kind, value))
@@ -142,6 +146,7 @@ def _completed_result(
         observations=sorted(source_origins),
         active_evidence=active_evidence,
         virtual_hosts=virtual_hosts,
+        network_observations=network_observations,
         evidence_status=(
             cast('EvidenceStatus', str(evidence['status']))
             if evidence.get('status') is not None and not execution_status_is_authoritative

--- a/theHarvester/lib/completed_result.py
+++ b/theHarvester/lib/completed_result.py
@@ -16,6 +16,16 @@ from theHarvester.lib.evidence_types import (
     ResultKind,
     format_utc,
 )
+from theHarvester.lib.network_evidence import (
+    BgpRouteObservation,
+    NetworkObservation,
+    PrefixOriginObservation,
+    RpkiValidationObservation,
+    canonical_network_observations,
+    network_observation_details,
+    parse_network_observation_details,
+)
+from theHarvester.lib.result_values import normalize_result_value
 from theHarvester.lib.virtual_host import VirtualHostObservation, normalize_virtual_host_hostname
 
 
@@ -55,7 +65,7 @@ def parse_result_jsonl(payload: bytes | str) -> tuple[dict[str, object], list[di
     try:
         text = payload.decode('utf-8') if isinstance(payload, bytes) else payload
         records = [json.loads(line) for line in text.splitlines() if line.strip()]
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as error:
         raise ValueError('result file is not valid JSONL') from error
     if any(not isinstance(record, dict) for record in records):
         raise ValueError('JSONL records must be objects')
@@ -70,8 +80,10 @@ def parse_result_jsonl(payload: bytes | str) -> tuple[dict[str, object], list[di
         actions = record.get('actions', [])
         result_kind = record.get('type')
         allowed_keys = {'type', 'value', 'sources', 'actions'}
-        if result_kind == 'hostname' and 'observations' in record:
+        if result_kind in {'hostname', 'prefix'} and 'observations' in record:
             allowed_keys.add('observations')
+        if result_kind == 'prefix':
+            allowed_keys.add('scope')
         if (
             set(record) - allowed_keys
             or result_kind not in RESULT_KINDS
@@ -83,6 +95,17 @@ def parse_result_jsonl(payload: bytes | str) -> tuple[dict[str, object], list[di
             or any(not isinstance(action, str) or not action.strip() for action in actions)
         ):
             raise ValueError('JSONL findings must contain a known type, non-empty value, and producer names')
+        result_value = record['value']
+        try:
+            normalized_result_value = normalize_result_value(result_kind, result_value)
+            if result_kind == 'prefix' and normalized_result_value != result_value:
+                raise ValueError('prefix result is not canonical')
+        except ValueError as error:
+            label = 'ASN' if result_kind == 'asn' else 'prefix'
+            raise ValueError(f'JSONL findings must use a canonical {label} value') from error
+        record['value'] = normalized_result_value
+        if result_kind == 'prefix' and record.get('scope') != 'external-relationship':
+            raise ValueError('JSONL prefix scope must be external-relationship')
         record['sources'] = sorted(set(sources))
         record['actions'] = sorted(set(actions))
         if result_kind == 'hostname' and 'observations' in record:
@@ -91,6 +114,12 @@ def parse_result_jsonl(payload: bytes | str) -> tuple[dict[str, object], list[di
             except ValueError as error:
                 raise ValueError(f'JSONL hostname has invalid virtual-host observations: {error}') from error
             record['observations'] = virtual_host_details(observations)
+        elif result_kind == 'prefix' and 'observations' in record:
+            try:
+                network_observations = parse_network_observation_details(result_value, record.get('observations'))
+            except ValueError as error:
+                raise ValueError(f'JSONL prefix has invalid network observations: {error}') from error
+            record['observations'] = network_observation_details(network_observations)
     return summary, findings
 
 
@@ -107,6 +136,7 @@ class ResultObservation:
             raise ValueError(f'unknown observation kind: {self.kind}')
         if not isinstance(self.value, str) or not self.value.strip():
             raise ValueError('observation value must be a non-empty string')
+        object.__setattr__(self, 'value', normalize_result_value(self.kind, self.value))
 
 
 @dataclass(frozen=True, slots=True)
@@ -171,6 +201,7 @@ class CompletedResult:
     observations: tuple[ResultObservation, ...] = ()
     active_evidence: ActiveEvidence = field(default_factory=ActiveEvidence)
     virtual_hosts: tuple[VirtualHostObservation, ...] = ()
+    network_observations: tuple[NetworkObservation, ...] = ()
     evidence_status: EvidenceStatus | None = None
 
     def __post_init__(self) -> None:
@@ -188,6 +219,8 @@ class CompletedResult:
             raise ValueError('results must contain known kinds and non-empty string values')
         if self.results != tuple(sorted(set(self.results))):
             raise ValueError('results must be deduplicated and sorted')
+        if any(normalize_result_value(kind, value) != value for kind, value in self.results):
+            raise ValueError('results must contain canonical values')
         if self.observations != tuple(sorted(set(self.observations))):
             raise ValueError('observations must be deduplicated and sorted')
         result_set = set(self.results)
@@ -241,6 +274,40 @@ class CompletedResult:
         }
         if vhost_action_results != structured_vhost_results:
             raise ValueError('structured virtual-host evidence must exactly match vhost action provenance')
+        sorted_network_observations = canonical_network_observations(self.network_observations)
+        if self.network_observations != sorted_network_observations:
+            raise ValueError('network observations must be deduplicated and sorted')
+        if any(
+            observation.collected_at < self.started_at or observation.collected_at > self.completed_at
+            for observation in self.network_observations
+        ):
+            raise ValueError('network observation collection time must fall within the completed run')
+        action_results = {
+            (action, observation.kind, observation.value) for action, observation in self.active_evidence.observations
+        }
+        origin_observations = {
+            (observation.action, observation.prefix, observation.origin_asn)
+            for observation in self.network_observations
+            if isinstance(observation, PrefixOriginObservation)
+        }
+        for network_observation in self.network_observations:
+            if ('prefix', network_observation.prefix) not in result_set or (
+                'asn',
+                network_observation.origin_asn,
+            ) not in result_set:
+                raise ValueError('network observation must reference completed prefix and ASN results')
+            if (network_observation.action, 'prefix', network_observation.prefix) not in action_results:
+                raise ValueError('network observation must reference matching action prefix provenance')
+            if (
+                isinstance(network_observation, BgpRouteObservation | RpkiValidationObservation)
+                and (
+                    network_observation.action,
+                    network_observation.prefix,
+                    network_observation.origin_asn,
+                )
+                not in origin_observations
+            ):
+                raise ValueError('BGP route and RPKI observations require matching observed-origin evidence')
         if self.evidence_status is not None and self.evidence_status not in EVIDENCE_STATUSES:
             raise ValueError('evidence status must be complete, partial, or failed')
 
@@ -257,6 +324,7 @@ class CompletedResult:
         observations: Iterable[ResultObservation] = (),
         active_evidence: ActiveEvidence | None = None,
         virtual_hosts: Iterable[VirtualHostObservation] = (),
+        network_observations: Iterable[NetworkObservation] = (),
         evidence_status: EvidenceStatus | None = None,
     ) -> Self:
         completed_active_evidence = active_evidence if active_evidence is not None else ActiveEvidence()
@@ -267,7 +335,8 @@ class CompletedResult:
             for value in values:
                 if not isinstance(value, str) or not value.strip():
                     raise ValueError('results must contain non-empty string values')
-                results.add((kind, value.strip()))
+                normalized_value = normalize_result_value(kind, value)
+                results.add((kind, normalized_value))
         for _action, action_observation in completed_active_evidence.observations:
             results.add((action_observation.kind, action_observation.value))
         completed_virtual_hosts = tuple(sorted(set(virtual_hosts), key=VirtualHostObservation.sort_key))
@@ -283,6 +352,7 @@ class CompletedResult:
             observations=tuple(sorted(set(observations))),
             active_evidence=completed_active_evidence,
             virtual_hosts=completed_virtual_hosts,
+            network_observations=canonical_network_observations(network_observations),
             evidence_status=evidence_status,
         )
 
@@ -342,6 +412,9 @@ class CompletedResult:
         vhosts_by_hostname: dict[str, list[VirtualHostObservation]] = {}
         for virtual_host in self.virtual_hosts:
             vhosts_by_hostname.setdefault(virtual_host.hostname, []).append(virtual_host)
+        network_by_prefix: dict[str, list[NetworkObservation]] = {}
+        for observation in self.network_observations:
+            network_by_prefix.setdefault(observation.prefix, []).append(observation)
         records: list[dict[str, object]] = []
         for kind, value in self.results:
             record: dict[str, object] = {
@@ -351,7 +424,11 @@ class CompletedResult:
             }
             if include_actions and (actions := actions_by_result.get((kind, value))):
                 record['actions'] = actions
+            if kind == 'prefix':
+                record['scope'] = 'external-relationship'
             if kind == 'hostname' and (virtual_hosts := vhosts_by_hostname.get(value)):
                 record['observations'] = virtual_host_details(virtual_hosts)
+            elif kind == 'prefix' and (network_observations := network_by_prefix.get(value)):
+                record['observations'] = network_observation_details(tuple(network_observations))
             records.append(record)
         return records

--- a/theHarvester/lib/database.py
+++ b/theHarvester/lib/database.py
@@ -49,6 +49,13 @@ from theHarvester.lib.completed_result import (
     parse_virtual_host_details,
     virtual_host_details,
 )
+from theHarvester.lib.network_evidence import (
+    NetworkObservation,
+    network_observation_details,
+    network_observation_sort_key,
+    parse_network_observation_json,
+)
+from theHarvester.lib.result_values import normalize_result_value
 from theHarvester.lib.virtual_host import VirtualHostObservation
 
 if TYPE_CHECKING:
@@ -56,7 +63,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 _DEFAULT_DATABASE = Path('~/.local/share/theHarvester/stash.sqlite').expanduser()
 
 _LEGACY_RESULT_KIND_RENAMES = {
@@ -259,13 +266,13 @@ def _sqlite_engine(database: str | Path) -> AsyncEngine:
 
 
 async def _canonicalize_result_kinds(connection: AsyncConnection) -> None:
-    """Merge result-kind aliases without losing provenance or artifact references."""
+    """Merge result aliases and canonicalize ASN values without losing provenance."""
     aliases = ', '.join(f"'{kind}'" for kind in sorted(_LEGACY_RESULT_KIND_RENAMES))
-    run_rows = await connection.exec_driver_sql(f'SELECT DISTINCT run_id FROM results WHERE kind IN ({aliases})')
+    run_rows = await connection.exec_driver_sql(f"SELECT DISTINCT run_id FROM results WHERE kind IN ({aliases}) OR kind = 'asn'")
     for (run_id,) in run_rows:
         result_rows = list(
             await connection.exec_driver_sql(
-                'SELECT position, kind, value FROM results WHERE run_id = ? ORDER BY position',
+                'SELECT position, kind, value, details_json FROM results WHERE run_id = ? ORDER BY position',
                 (run_id,),
             )
         )
@@ -283,12 +290,24 @@ async def _canonicalize_result_kinds(connection: AsyncConnection) -> None:
             )
         )
 
-        canonical_results = sorted(
-            {(_LEGACY_RESULT_KIND_RENAMES.get(kind, kind), value) for _position, kind, value in result_rows}
-        )
+        canonical_details: dict[tuple[str, str], str | None] = {}
+        for _position, kind, value, details_json in result_rows:
+            canonical_kind = _LEGACY_RESULT_KIND_RENAMES.get(kind, kind)
+            canonical_result = (canonical_kind, normalize_result_value(canonical_kind, value))
+            if canonical_result not in canonical_details or canonical_details[canonical_result] is None:
+                canonical_details[canonical_result] = details_json
+            elif details_json is not None and details_json != canonical_details[canonical_result]:
+                raise RuntimeError(f'Conflicting structured details for migrated result: {canonical_result[1]}')
+        canonical_results = sorted(canonical_details)
         new_positions = {result: position for position, result in enumerate(canonical_results)}
         old_positions = {
-            position: new_positions[(_LEGACY_RESULT_KIND_RENAMES.get(kind, kind), value)] for position, kind, value in result_rows
+            position: new_positions[
+                (
+                    _LEGACY_RESULT_KIND_RENAMES.get(kind, kind),
+                    normalize_result_value(_LEGACY_RESULT_KIND_RENAMES.get(kind, kind), value),
+                )
+            ]
+            for position, kind, value, _details_json in result_rows
         }
         canonical_origins = sorted(
             {(old_positions[result_position], execution_position) for result_position, execution_position in origin_rows}
@@ -299,8 +318,11 @@ async def _canonicalize_result_kinds(connection: AsyncConnection) -> None:
         await connection.exec_driver_sql('DELETE FROM results WHERE run_id = ?', (run_id,))
         if canonical_results:
             await connection.exec_driver_sql(
-                'INSERT INTO results (run_id, position, kind, value) VALUES (?, ?, ?, ?)',
-                [(run_id, position, kind, value) for position, (kind, value) in enumerate(canonical_results)],
+                'INSERT INTO results (run_id, position, kind, value, details_json) VALUES (?, ?, ?, ?, ?)',
+                [
+                    (run_id, position, kind, value, canonical_details[(kind, value)])
+                    for position, (kind, value) in enumerate(canonical_results)
+                ],
             )
         if canonical_origins:
             await connection.exec_driver_sql(
@@ -706,6 +728,9 @@ class ResultStore:
         vhosts_by_hostname: dict[str, list[VirtualHostObservation]] = {}
         for observation in result.virtual_hosts:
             vhosts_by_hostname.setdefault(observation.hostname, []).append(observation)
+        network_by_prefix: dict[str, list[NetworkObservation]] = {}
+        for network_observation in result.network_observations:
+            network_by_prefix.setdefault(network_observation.prefix, []).append(network_observation)
         async with self._session() as session:
             try:
                 session.add(
@@ -732,6 +757,13 @@ class ResultStore:
                                 sort_keys=True,
                             )
                             if kind == 'hostname' and value in vhosts_by_hostname
+                            else json.dumps(
+                                network_observation_details(tuple(network_by_prefix[value])),
+                                ensure_ascii=False,
+                                separators=(',', ':'),
+                                sort_keys=True,
+                            )
+                            if kind == 'prefix' and value in network_by_prefix
                             else None
                         ),
                     )
@@ -828,22 +860,35 @@ class ResultStore:
             row.result_position for row in origin_rows if row.execution_position in vhost_execution_positions
         }
         virtual_hosts: list[VirtualHostObservation] = []
+        network_observations: list[NetworkObservation] = []
         for result_row in rows:
             is_vhost_result = result_row.position in vhost_result_positions
             if is_vhost_result and (result_row.kind != 'hostname' or result_row.details_json is None):
                 raise ResultStoreError(f'Persisted virtual-host details are missing: {result_row.value}')
             if result_row.details_json is None:
                 continue
-            if result_row.kind != 'hostname' or not is_vhost_result:
+            if result_row.kind == 'hostname' and is_vhost_result:
+                try:
+                    details = json.loads(result_row.details_json)
+                    parsed_virtual_hosts = parse_virtual_host_details(result_row.value, details)
+                except (json.JSONDecodeError, ValueError) as error:
+                    raise ResultStoreError(f'Persisted virtual-host details are invalid: {result_row.value}') from error
+                if details != virtual_host_details(parsed_virtual_hosts):
+                    raise ResultStoreError(f'Persisted virtual-host details are not canonical: {result_row.value}')
+                virtual_hosts.extend(parsed_virtual_hosts)
+            elif result_row.kind == 'prefix' and not is_vhost_result:
+                try:
+                    parsed_network_observations = parse_network_observation_json(
+                        result_row.value,
+                        result_row.details_json,
+                    )
+                except ValueError as error:
+                    raise ResultStoreError(f'Persisted network details are invalid: {result_row.value}') from error
+                network_observations.extend(parsed_network_observations)
+            elif result_row.kind == 'hostname':
                 raise ResultStoreError('Persisted virtual-host details require hostname results with vhost provenance')
-            try:
-                details = json.loads(result_row.details_json)
-                parsed_virtual_hosts = parse_virtual_host_details(result_row.value, details)
-            except (json.JSONDecodeError, ValueError) as error:
-                raise ResultStoreError(f'Persisted virtual-host details are invalid: {result_row.value}') from error
-            if details != virtual_host_details(parsed_virtual_hosts):
-                raise ResultStoreError(f'Persisted virtual-host details are not canonical: {result_row.value}')
-            virtual_hosts.extend(parsed_virtual_hosts)
+            else:
+                raise ResultStoreError('Persisted structured details require a supported result kind and provenance')
         unknown_producer_kinds = {row.producer_kind for row in execution_rows} - {'source', 'action'}
         if unknown_producer_kinds:
             raise ResultStoreError(f'Unknown persisted producer kind: {min(unknown_producer_kinds)}')
@@ -924,6 +969,7 @@ class ResultStore:
             observations=tuple(sorted(source_observations)),
             active_evidence=ActiveEvidence(executions=tuple(action_executions)),
             virtual_hosts=tuple(sorted(set(virtual_hosts), key=VirtualHostObservation.sort_key)),
+            network_observations=tuple(sorted(set(network_observations), key=network_observation_sort_key)),
             evidence_status=cast('EvidenceStatus', parent.evidence_status) if parent.evidence_status is not None else None,
         )
 

--- a/theHarvester/lib/database.py
+++ b/theHarvester/lib/database.py
@@ -55,7 +55,6 @@ from theHarvester.lib.network_evidence import (
     network_observation_sort_key,
     parse_network_observation_json,
 )
-from theHarvester.lib.result_values import normalize_result_value
 from theHarvester.lib.virtual_host import VirtualHostObservation
 
 if TYPE_CHECKING:
@@ -63,7 +62,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 8
 _DEFAULT_DATABASE = Path('~/.local/share/theHarvester/stash.sqlite').expanduser()
 
 _LEGACY_RESULT_KIND_RENAMES = {
@@ -266,13 +265,13 @@ def _sqlite_engine(database: str | Path) -> AsyncEngine:
 
 
 async def _canonicalize_result_kinds(connection: AsyncConnection) -> None:
-    """Merge result aliases and canonicalize ASN values without losing provenance."""
+    """Merge result-kind aliases without losing provenance or artifact references."""
     aliases = ', '.join(f"'{kind}'" for kind in sorted(_LEGACY_RESULT_KIND_RENAMES))
-    run_rows = await connection.exec_driver_sql(f"SELECT DISTINCT run_id FROM results WHERE kind IN ({aliases}) OR kind = 'asn'")
+    run_rows = await connection.exec_driver_sql(f'SELECT DISTINCT run_id FROM results WHERE kind IN ({aliases})')
     for (run_id,) in run_rows:
         result_rows = list(
             await connection.exec_driver_sql(
-                'SELECT position, kind, value, details_json FROM results WHERE run_id = ? ORDER BY position',
+                'SELECT position, kind, value FROM results WHERE run_id = ? ORDER BY position',
                 (run_id,),
             )
         )
@@ -290,24 +289,12 @@ async def _canonicalize_result_kinds(connection: AsyncConnection) -> None:
             )
         )
 
-        canonical_details: dict[tuple[str, str], str | None] = {}
-        for _position, kind, value, details_json in result_rows:
-            canonical_kind = _LEGACY_RESULT_KIND_RENAMES.get(kind, kind)
-            canonical_result = (canonical_kind, normalize_result_value(canonical_kind, value))
-            if canonical_result not in canonical_details or canonical_details[canonical_result] is None:
-                canonical_details[canonical_result] = details_json
-            elif details_json is not None and details_json != canonical_details[canonical_result]:
-                raise RuntimeError(f'Conflicting structured details for migrated result: {canonical_result[1]}')
-        canonical_results = sorted(canonical_details)
+        canonical_results = sorted(
+            {(_LEGACY_RESULT_KIND_RENAMES.get(kind, kind), value) for _position, kind, value in result_rows}
+        )
         new_positions = {result: position for position, result in enumerate(canonical_results)}
         old_positions = {
-            position: new_positions[
-                (
-                    _LEGACY_RESULT_KIND_RENAMES.get(kind, kind),
-                    normalize_result_value(_LEGACY_RESULT_KIND_RENAMES.get(kind, kind), value),
-                )
-            ]
-            for position, kind, value, _details_json in result_rows
+            position: new_positions[(_LEGACY_RESULT_KIND_RENAMES.get(kind, kind), value)] for position, kind, value in result_rows
         }
         canonical_origins = sorted(
             {(old_positions[result_position], execution_position) for result_position, execution_position in origin_rows}
@@ -318,11 +305,8 @@ async def _canonicalize_result_kinds(connection: AsyncConnection) -> None:
         await connection.exec_driver_sql('DELETE FROM results WHERE run_id = ?', (run_id,))
         if canonical_results:
             await connection.exec_driver_sql(
-                'INSERT INTO results (run_id, position, kind, value, details_json) VALUES (?, ?, ?, ?, ?)',
-                [
-                    (run_id, position, kind, value, canonical_details[(kind, value)])
-                    for position, (kind, value) in enumerate(canonical_results)
-                ],
+                'INSERT INTO results (run_id, position, kind, value) VALUES (?, ?, ?, ?)',
+                [(run_id, position, kind, value) for position, (kind, value) in enumerate(canonical_results)],
             )
         if canonical_origins:
             await connection.exec_driver_sql(

--- a/theHarvester/lib/database.py
+++ b/theHarvester/lib/database.py
@@ -846,12 +846,10 @@ class ResultStore:
         virtual_hosts: list[VirtualHostObservation] = []
         network_observations: list[NetworkObservation] = []
         for result_row in rows:
-            is_vhost_result = result_row.position in vhost_result_positions
-            if is_vhost_result and (result_row.kind != 'hostname' or result_row.details_json is None):
-                raise ResultStoreError(f'Persisted virtual-host details are missing: {result_row.value}')
-            if result_row.details_json is None:
-                continue
-            if result_row.kind == 'hostname' and is_vhost_result:
+            has_vhost_provenance = result_row.position in vhost_result_positions
+            if has_vhost_provenance:
+                if result_row.kind != 'hostname' or result_row.details_json is None:
+                    raise ResultStoreError(f'Persisted virtual-host details are missing: {result_row.value}')
                 try:
                     details = json.loads(result_row.details_json)
                     parsed_virtual_hosts = parse_virtual_host_details(result_row.value, details)
@@ -860,7 +858,10 @@ class ResultStore:
                 if details != virtual_host_details(parsed_virtual_hosts):
                     raise ResultStoreError(f'Persisted virtual-host details are not canonical: {result_row.value}')
                 virtual_hosts.extend(parsed_virtual_hosts)
-            elif result_row.kind == 'prefix' and not is_vhost_result:
+                continue
+            if result_row.details_json is None:
+                continue
+            if result_row.kind == 'prefix':
                 try:
                     parsed_network_observations = parse_network_observation_json(
                         result_row.value,

--- a/theHarvester/lib/evidence_types.py
+++ b/theHarvester/lib/evidence_types.py
@@ -17,6 +17,7 @@ ResultKind = Literal[
     'language',
     'linkedin-person',
     'person',
+    'prefix',
     'server',
     'screenshot',
     'shodan',

--- a/theHarvester/lib/network_evidence.py
+++ b/theHarvester/lib/network_evidence.py
@@ -209,8 +209,10 @@ class NetworkEvidenceAccumulator:
         max_observations_per_prefix: int = MAX_NETWORK_OBSERVATIONS_PER_PREFIX,
         max_details_bytes: int = MAX_NETWORK_DETAILS_BYTES,
     ) -> None:
-        if max_observations_per_prefix < 1 or max_details_bytes < 2:
-            raise ValueError('network evidence limits must be positive')
+        if not 1 <= max_observations_per_prefix <= MAX_NETWORK_OBSERVATIONS_PER_PREFIX or not (
+            2 <= max_details_bytes <= MAX_NETWORK_DETAILS_BYTES
+        ):
+            raise ValueError('network evidence limits must stay within the persisted envelope')
         self._max_observations_per_prefix = max_observations_per_prefix
         self._max_details_bytes = max_details_bytes
         self._observations: set[NetworkObservation] = set()

--- a/theHarvester/lib/network_evidence.py
+++ b/theHarvester/lib/network_evidence.py
@@ -178,6 +178,81 @@ class RpkiValidationObservation:
 type NetworkObservation = PrefixOriginObservation | BgpRouteObservation | RpkiValidationObservation
 
 
+class NetworkEvidenceLimitError(ValueError):
+    """Raised when one bounded network-evidence envelope is full."""
+
+
+def _network_observation_detail(observation: NetworkObservation) -> dict[str, object]:
+    record = observation.to_record()
+    return {key: value for key, value in record.items() if key != 'prefix'}
+
+
+def _encoded_detail_size(observation: NetworkObservation) -> int:
+    try:
+        return len(
+            json.dumps(_network_observation_detail(observation), ensure_ascii=False, separators=(',', ':')).encode('utf-8')
+        )
+    except (TypeError, ValueError, UnicodeEncodeError) as error:
+        raise ValueError('network evidence is not serializable') from error
+
+
+def _rpki_identity(observation: RpkiValidationObservation) -> tuple[object, ...]:
+    return observation.action, observation.prefix, observation.origin_asn, observation.observed_at
+
+
+class NetworkEvidenceAccumulator:
+    """Incrementally deduplicate network evidence within its persisted envelope."""
+
+    def __init__(
+        self,
+        *,
+        max_observations_per_prefix: int = MAX_NETWORK_OBSERVATIONS_PER_PREFIX,
+        max_details_bytes: int = MAX_NETWORK_DETAILS_BYTES,
+    ) -> None:
+        if max_observations_per_prefix < 1 or max_details_bytes < 2:
+            raise ValueError('network evidence limits must be positive')
+        self._max_observations_per_prefix = max_observations_per_prefix
+        self._max_details_bytes = max_details_bytes
+        self._observations: set[NetworkObservation] = set()
+        self._origin_identities: set[tuple[str, str, str]] = set()
+        self._rpki_states: dict[tuple[object, ...], RpkiState] = {}
+        self._prefix_counts: Counter[str] = Counter()
+        self._prefix_bytes: dict[str, int] = {}
+
+    def add(self, observation: NetworkObservation) -> bool:
+        if not isinstance(observation, (PrefixOriginObservation, BgpRouteObservation, RpkiValidationObservation)):
+            raise TypeError('network evidence contains an unsupported observation')
+        if isinstance(observation, PrefixOriginObservation):
+            origin_identity = observation.action, observation.prefix, str(observation.origin_asn)
+            if origin_identity in self._origin_identities:
+                return False
+        elif observation in self._observations:
+            return False
+        if isinstance(observation, RpkiValidationObservation):
+            identity = _rpki_identity(observation)
+            if (existing := self._rpki_states.get(identity)) is not None and existing != observation.state:
+                raise ValueError('network evidence contains conflicting RPKI states')
+
+        count = self._prefix_counts[observation.prefix] + 1
+        if count > self._max_observations_per_prefix:
+            raise NetworkEvidenceLimitError('network evidence contains too many observations for one prefix')
+        encoded_size = self._prefix_bytes.get(observation.prefix, 2) + _encoded_detail_size(observation) + bool(count - 1)
+        if encoded_size > self._max_details_bytes:
+            raise NetworkEvidenceLimitError('network evidence details exceed the serialized size limit')
+
+        self._observations.add(observation)
+        self._prefix_counts[observation.prefix] = count
+        self._prefix_bytes[observation.prefix] = encoded_size
+        if isinstance(observation, PrefixOriginObservation):
+            self._origin_identities.add(origin_identity)
+        elif isinstance(observation, RpkiValidationObservation):
+            self._rpki_states[identity] = observation.state
+        return True
+
+    def observations(self) -> tuple[NetworkObservation, ...]:
+        return canonical_network_observations(self._observations)
+
+
 def network_observation_sort_key(observation: NetworkObservation) -> tuple[object, ...]:
     type_order = {PrefixOriginObservation: 0, BgpRouteObservation: 1, RpkiValidationObservation: 2}
     record = observation.to_record()
@@ -199,12 +274,7 @@ def canonical_network_observations(observations: Iterable[NetworkObservation]) -
     for observation in canonical:
         if not isinstance(observation, RpkiValidationObservation):
             continue
-        identity = (
-            observation.action,
-            observation.prefix,
-            observation.origin_asn,
-            observation.observed_at,
-        )
+        identity = _rpki_identity(observation)
         if (existing := rpki_states.get(identity)) is not None and existing != observation.state:
             raise ValueError('network evidence contains conflicting RPKI states')
         rpki_states[identity] = observation.state
@@ -215,9 +285,8 @@ def network_observation_details(observations: Iterable[NetworkObservation]) -> l
     details: list[dict[str, object]] = []
     encoded_size = 2
     for observation in canonical_network_observations(observations):
-        record = observation.to_record()
-        detail = {key: value for key, value in record.items() if key != 'prefix'}
-        encoded_size += len(json.dumps(detail, ensure_ascii=False, separators=(',', ':')).encode('utf-8')) + bool(details)
+        detail = _network_observation_detail(observation)
+        encoded_size += _encoded_detail_size(observation) + bool(details)
         if encoded_size > MAX_NETWORK_DETAILS_BYTES:
             raise ValueError('network evidence details exceed the serialized size limit')
         details.append(detail)

--- a/theHarvester/lib/network_evidence.py
+++ b/theHarvester/lib/network_evidence.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import json
+import unicodedata
+from collections import Counter
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from ipaddress import ip_address
+from typing import TYPE_CHECKING, Literal, cast
+
+from theHarvester.lib.evidence_types import format_utc
+from theHarvester.lib.result_values import normalize_asn, normalize_prefix
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+RpkiState = Literal['valid', 'invalid', 'not-found']
+MAX_NETWORK_TEXT_LENGTH = 65_536
+MAX_NETWORK_OBSERVATIONS_PER_PREFIX = 10_000
+MAX_NETWORK_DETAILS_BYTES = 8 * 1024 * 1024
+
+
+def _normalize_ip(value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError('peer address must be a non-empty string')
+    if '%' in value:
+        raise ValueError('peer address must not contain an IPv6 scope identifier')
+    try:
+        return str(ip_address(value.strip()))
+    except ValueError as error:
+        raise ValueError('peer address must be a valid IPv4 or IPv6 address') from error
+
+
+def _normalize_name(value: str, label: str) -> str:
+    if not isinstance(value, str) or not (normalized := value.strip()):
+        raise ValueError(f'{label} must not be empty')
+    try:
+        normalized.encode('utf-8')
+    except UnicodeEncodeError as error:
+        raise ValueError(f'{label} is invalid') from error
+    if len(normalized) > 255 or any(unicodedata.category(character) == 'Cc' for character in normalized):
+        raise ValueError(f'{label} is invalid')
+    return normalized
+
+
+def _normalize_text(value: str, label: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f'{label} must be a string')
+    normalized = value.strip()
+    if not allow_empty and not normalized:
+        raise ValueError(f'{label} must not be empty')
+    try:
+        value.encode('utf-8')
+    except UnicodeEncodeError as error:
+        raise ValueError(f'{label} is invalid') from error
+    if len(value) > MAX_NETWORK_TEXT_LENGTH or any(unicodedata.category(character) == 'Cc' for character in value):
+        raise ValueError(f'{label} is invalid')
+    return value
+
+
+def _normalize_time(value: datetime, label: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f'{label} must be timezone-aware')
+    return value.astimezone(UTC)
+
+
+def _parse_time(value: object, label: str) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError(f'{label} must be an ISO-8601 UTC timestamp')
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ValueError(f'{label} must be an ISO-8601 UTC timestamp') from error
+    normalized = _normalize_time(parsed, label)
+    if format_utc(normalized) != value:
+        raise ValueError(f'{label} must be a canonical ISO-8601 UTC timestamp')
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class PrefixOriginObservation:
+    action: str
+    prefix: str
+    origin_asn: str | int
+    collected_at: datetime
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, 'action', _normalize_name(self.action, 'network observation action'))
+        object.__setattr__(self, 'prefix', normalize_prefix(self.prefix))
+        object.__setattr__(self, 'origin_asn', normalize_asn(self.origin_asn))
+        object.__setattr__(self, 'collected_at', _normalize_time(self.collected_at, 'collected_at'))
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            'type': 'observed-origin',
+            'action': self.action,
+            'prefix': self.prefix,
+            'origin_asn': self.origin_asn,
+            'collected_at': format_utc(self.collected_at),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BgpRouteObservation:
+    action: str
+    prefix: str
+    origin_asn: str | int
+    collector: str
+    peer_asn: str | int
+    peer_address: str
+    as_path: str
+    communities: str
+    observed_at: datetime
+    collected_at: datetime
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, 'action', _normalize_name(self.action, 'network observation action'))
+        object.__setattr__(self, 'prefix', normalize_prefix(self.prefix))
+        object.__setattr__(self, 'origin_asn', normalize_asn(self.origin_asn))
+        object.__setattr__(self, 'collector', _normalize_name(self.collector, 'collector'))
+        object.__setattr__(self, 'peer_asn', normalize_asn(self.peer_asn))
+        object.__setattr__(self, 'peer_address', _normalize_ip(self.peer_address))
+        object.__setattr__(self, 'as_path', _normalize_text(self.as_path, 'AS path'))
+        object.__setattr__(self, 'communities', _normalize_text(self.communities, 'communities', allow_empty=True))
+        object.__setattr__(self, 'observed_at', _normalize_time(self.observed_at, 'observed_at'))
+        object.__setattr__(self, 'collected_at', _normalize_time(self.collected_at, 'collected_at'))
+        if self.observed_at > self.collected_at:
+            raise ValueError('observed_at must not be later than collected_at')
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            'type': 'bgp-route',
+            'action': self.action,
+            'prefix': self.prefix,
+            'origin_asn': self.origin_asn,
+            'collector': self.collector,
+            'peer_asn': self.peer_asn,
+            'peer_address': self.peer_address,
+            'as_path': self.as_path,
+            'communities': self.communities,
+            'observed_at': format_utc(self.observed_at),
+            'collected_at': format_utc(self.collected_at),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RpkiValidationObservation:
+    action: str
+    prefix: str
+    origin_asn: str | int
+    state: RpkiState
+    observed_at: datetime
+    collected_at: datetime
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, 'action', _normalize_name(self.action, 'network observation action'))
+        object.__setattr__(self, 'prefix', normalize_prefix(self.prefix))
+        object.__setattr__(self, 'origin_asn', normalize_asn(self.origin_asn))
+        if not isinstance(self.state, str) or self.state not in {'valid', 'invalid', 'not-found'}:
+            raise ValueError('RPKI state must be valid, invalid, or not-found')
+        object.__setattr__(self, 'observed_at', _normalize_time(self.observed_at, 'observed_at'))
+        object.__setattr__(self, 'collected_at', _normalize_time(self.collected_at, 'collected_at'))
+        if self.observed_at > self.collected_at:
+            raise ValueError('observed_at must not be later than collected_at')
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            'type': 'rpki-validation',
+            'action': self.action,
+            'prefix': self.prefix,
+            'origin_asn': self.origin_asn,
+            'state': self.state,
+            'observed_at': format_utc(self.observed_at),
+            'collected_at': format_utc(self.collected_at),
+        }
+
+
+type NetworkObservation = PrefixOriginObservation | BgpRouteObservation | RpkiValidationObservation
+
+
+def network_observation_sort_key(observation: NetworkObservation) -> tuple[object, ...]:
+    type_order = {PrefixOriginObservation: 0, BgpRouteObservation: 1, RpkiValidationObservation: 2}
+    record = observation.to_record()
+    return (
+        observation.prefix,
+        observation.origin_asn,
+        observation.action,
+        type_order[type(observation)],
+        tuple((key, str(value)) for key, value in sorted(record.items())),
+    )
+
+
+def canonical_network_observations(observations: Iterable[NetworkObservation]) -> tuple[NetworkObservation, ...]:
+    canonical = tuple(sorted(set(observations), key=network_observation_sort_key))
+    counts = Counter(observation.prefix for observation in canonical)
+    if any(count > MAX_NETWORK_OBSERVATIONS_PER_PREFIX for count in counts.values()):
+        raise ValueError('network evidence contains too many observations for one prefix')
+    rpki_states: dict[tuple[object, ...], RpkiState] = {}
+    for observation in canonical:
+        if not isinstance(observation, RpkiValidationObservation):
+            continue
+        identity = (
+            observation.action,
+            observation.prefix,
+            observation.origin_asn,
+            observation.observed_at,
+        )
+        if (existing := rpki_states.get(identity)) is not None and existing != observation.state:
+            raise ValueError('network evidence contains conflicting RPKI states')
+        rpki_states[identity] = observation.state
+    return canonical
+
+
+def network_observation_details(observations: Iterable[NetworkObservation]) -> list[dict[str, object]]:
+    details: list[dict[str, object]] = []
+    encoded_size = 2
+    for observation in canonical_network_observations(observations):
+        record = observation.to_record()
+        detail = {key: value for key, value in record.items() if key != 'prefix'}
+        encoded_size += len(json.dumps(detail, ensure_ascii=False, separators=(',', ':')).encode('utf-8')) + bool(details)
+        if encoded_size > MAX_NETWORK_DETAILS_BYTES:
+            raise ValueError('network evidence details exceed the serialized size limit')
+        details.append(detail)
+    return details
+
+
+def parse_network_observation_json(prefix: str, payload: str) -> tuple[NetworkObservation, ...]:
+    if not isinstance(payload, str) or len(payload) > MAX_NETWORK_DETAILS_BYTES:
+        raise ValueError('network evidence details exceed the serialized size limit')
+    try:
+        encoded = payload.encode('utf-8')
+    except UnicodeEncodeError as error:
+        raise ValueError('network evidence details are not valid UTF-8') from error
+    if len(encoded) > MAX_NETWORK_DETAILS_BYTES:
+        raise ValueError('network evidence details exceed the serialized size limit')
+    try:
+        details = json.loads(payload)
+    except (json.JSONDecodeError, RecursionError) as error:
+        raise ValueError('network evidence details are not valid JSON') from error
+    return parse_network_observation_details(prefix, details)
+
+
+def parse_network_observation_details(prefix: str, details: object) -> tuple[NetworkObservation, ...]:
+    canonical_prefix = normalize_prefix(prefix)
+    if canonical_prefix != prefix:
+        raise ValueError('network evidence result value must be a canonical prefix')
+    if not isinstance(details, list) or not details:
+        raise ValueError('network evidence details must be a non-empty array')
+    if len(details) > MAX_NETWORK_OBSERVATIONS_PER_PREFIX:
+        raise ValueError('network evidence contains too many observations for one prefix')
+    observations: list[NetworkObservation] = []
+    keys_by_type = {
+        'observed-origin': {'type', 'action', 'origin_asn', 'collected_at'},
+        'bgp-route': {
+            'type',
+            'action',
+            'origin_asn',
+            'collector',
+            'peer_asn',
+            'peer_address',
+            'as_path',
+            'communities',
+            'observed_at',
+            'collected_at',
+        },
+        'rpki-validation': {'type', 'action', 'origin_asn', 'state', 'observed_at', 'collected_at'},
+    }
+    for detail in details:
+        if not isinstance(detail, dict):
+            raise ValueError('network evidence details must contain objects')
+        observation_type = detail.get('type')
+        if (
+            not isinstance(observation_type, str)
+            or observation_type not in keys_by_type
+            or set(detail) != keys_by_type[observation_type]
+        ):
+            raise ValueError('network evidence detail has unsupported fields')
+        if observation_type == 'observed-origin':
+            observation: NetworkObservation = PrefixOriginObservation(
+                action=detail['action'],
+                prefix=canonical_prefix,
+                origin_asn=detail['origin_asn'],
+                collected_at=_parse_time(detail['collected_at'], 'collected_at'),
+            )
+        elif observation_type == 'bgp-route':
+            observation = BgpRouteObservation(
+                action=detail['action'],
+                prefix=canonical_prefix,
+                origin_asn=detail['origin_asn'],
+                collector=detail['collector'],
+                peer_asn=detail['peer_asn'],
+                peer_address=detail['peer_address'],
+                as_path=detail['as_path'],
+                communities=detail['communities'],
+                observed_at=_parse_time(detail['observed_at'], 'observed_at'),
+                collected_at=_parse_time(detail['collected_at'], 'collected_at'),
+            )
+        else:
+            observation = RpkiValidationObservation(
+                action=detail['action'],
+                prefix=canonical_prefix,
+                origin_asn=detail['origin_asn'],
+                state=cast('RpkiState', detail['state']),
+                observed_at=_parse_time(detail['observed_at'], 'observed_at'),
+                collected_at=_parse_time(detail['collected_at'], 'collected_at'),
+            )
+        observations.append(observation)
+    canonical = canonical_network_observations(observations)
+    if details != network_observation_details(canonical):
+        raise ValueError('network evidence details must use canonical structured evidence')
+    return canonical

--- a/theHarvester/lib/result_values.py
+++ b/theHarvester/lib/result_values.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from ipaddress import ip_network
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from theHarvester.lib.evidence_types import ResultKind
+
+MAX_ASN = 4_294_967_295
+
+
+def normalize_asn(value: str | int) -> str:
+    if isinstance(value, bool) or not isinstance(value, str | int):
+        raise ValueError('ASN must be an integer or AS-prefixed integer')
+    text = str(value).strip()
+    if text[:2].casefold() == 'as':
+        text = text[2:]
+    if not text.isascii() or not text.isdecimal():
+        raise ValueError('ASN must be an integer or AS-prefixed integer')
+    number = int(text)
+    if not 0 <= number <= MAX_ASN:
+        raise ValueError(f'ASN must be between 0 and {MAX_ASN}')
+    return f'AS{number}'
+
+
+def normalize_prefix(value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError('network prefix must be a non-empty string')
+    if '%' in value:
+        raise ValueError('network prefix must not contain an IPv6 scope identifier')
+    try:
+        return str(ip_network(value.strip(), strict=False))
+    except ValueError as error:
+        raise ValueError('network prefix must be valid IPv4 or IPv6 CIDR') from error
+
+
+def normalize_result_value(kind: ResultKind | str, value: str) -> str:
+    normalized = value.strip()
+    if kind == 'asn':
+        return normalize_asn(normalized)
+    if kind == 'prefix':
+        return normalize_prefix(normalized)
+    return normalized


### PR DESCRIPTION
## Summary

- add canonical `prefix` results alongside existing canonical `AS<number>` results
- add typed observations for an observed route origin, one collector and peer's BGP route, and an RPKI validation state
- preserve network observations through `CompletedResult`, JSONL, REST projection and import/export, SQLite, and HarvestView
- centralize canonicalization, incremental deduplication, conflicting-RPKI rejection, and per-prefix persistence bounds

## Result and scope contract

Every prefix is explicitly marked `external-relationship`. Routing evidence does not establish registration, ownership, authorization, reachability, or target scope.

Observed origins, peer routes, and RPKI states remain separate typed observations because they answer different questions and carry different timestamps and provenance. This PR intentionally does not introduce a generic relationship graph or provider request.

The dependent RouteViews action is proposed separately in #2528.

## Schema and compatibility

SQLite remains at schema version 8.

No table or column is added. Prefix observations use the existing `results.details_json` field already introduced on the unreleased development branch, so there is no v8-to-v9 migration for users to perform.

- existing virtual-host structured details retain their prior contract
- one prefix may retain at most 10,000 observations and 8 MiB of canonical details
- timestamps must be timezone-aware and internally consistent
- contradictory RPKI states for the same assertion are rejected
- invalid UTF-8, control characters, oversized provider text, and IPv6 scope identifiers fail closed

## Verification

- `uv run pytest -q`: 1,000 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy theHarvester`
- `git diff --check`

Fixtures use RFC-reserved addresses and ASNs. Verification made no provider or target requests.
