### PR TITLE
baidusearch: remove forced @ (%40) prefix from Baidu query

### DIFF
--- a/tests/discovery/test_baidusearch.py
+++ b/tests/discovery/test_baidusearch.py
@@ -29,9 +29,9 @@ class TestBaiduSearch:
         await search.process(proxy=True)
 
         expected_urls = [
-            "https://www.baidu.com/s?wd=%40example.com&pn=0&oq=example.com",
-            "https://www.baidu.com/s?wd=%40example.com&pn=10&oq=example.com",
-            "https://www.baidu.com/s?wd=%40example.com&pn=20&oq=example.com",
+            "https://www.baidu.com/s?wd=example.com&pn=0&oq=example.com",
+            "https://www.baidu.com/s?wd=example.com&pn=10&oq=example.com",
+            "https://www.baidu.com/s?wd=example.com&pn=20&oq=example.com",
         ]
         assert called["urls"] == expected_urls
         assert called["proxy"] is True
@@ -64,6 +64,6 @@ class TestBaiduSearch:
 
         # For limit=20, range(0, 20, 10) yields 0 and 10 only (20 is excluded)
         assert captured["urls"] == [
-            "https://www.baidu.com/s?wd=%40example.com&pn=0&oq=example.com",
-            "https://www.baidu.com/s?wd=%40example.com&pn=10&oq=example.com",
+            "https://www.baidu.com/s?wd=example.com&pn=0&oq=example.com",
+            "https://www.baidu.com/s?wd=example.com&pn=10&oq=example.com",
         ]

--- a/theHarvester/discovery/baidusearch.py
+++ b/theHarvester/discovery/baidusearch.py
@@ -13,7 +13,7 @@ class SearchBaidu:
 
     async def do_search(self) -> None:
         headers = {'Host': self.hostname, 'User-agent': Core.get_user_agent()}
-        base_url = f'https://{self.server}/s?wd=%40{self.word}&pn=xx&oq={self.word}'
+        base_url = f'https://{self.server}/s?wd={self.word}&pn=xx&oq={self.word}'
         urls = [base_url.replace('xx', str(num)) for num in range(0, self.limit, 10) if num <= self.limit]
         responses = await AsyncFetcher.fetch_all(urls, headers=headers, proxy=self.proxy)
         for response in responses:


### PR DESCRIPTION
## Summary

Contributes to #2403 (Baidu module broken). The module hardcodes `%40` (the `@` symbol) into the search query (`wd=%40{word}`), which is not valid Baidu syntax and turns every query into a different search than intended. Fixes the query string to issue a plain `wd={word}` search.

This is the minimal "query string fix" from the issue; it complements the playwright-based rework the maintainer is considering, and is a strict improvement on its own.

## Changes

- `theHarvester/discovery/baidusearch.py`: drop the forced `%40` prefix from `wd=`.
- `tests/discovery/test_baidusearch.py`: update expected URLs to match the fixed query string.

## Verification

- `pytest tests/discovery/test_baidusearch.py` -> 2 passed
- `ruff check theHarvester/discovery/baidusearch.py` -> All checks passed