### PR TITLE
Add route-aware --no-hosts result filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added sourced ASN organization attribution from URLScan, ONYPHE, and Shodan, linked to the exact hostname or IP evidence and retained in SQLite, JSONL, the API, CLI output, and HarvestView without claiming ownership or scope.
 - Added bounded RouteViews routing enrichment for exact discovered IPs with sourced ASN attribution, or explicit ASN, IP, and CIDR targets, retaining typed origin, BGP-route, and RPKI evidence as external relationships without expanding active scope.
+- Added route-aware `--no-hosts` and REST/HarvestView `no_hosts` filtering that skips hostname-only sources while retaining non-host evidence from mixed sources.
 - Added bounded, keyless `crt.name` composite-index discovery as a separate source alongside `crtsh`, retaining only descendant-hostname candidates from its streamed response.
 - Added bounded, keyless APIs.guru discovery through exact target-domain directory lookups, retaining only target-scoped hostnames, contact emails, and URLs from preferred OpenAPI specifications.
 - Added bounded virtual host discovery over harvested or operator-supplied literal-IP endpoints, with aligned HTTP `Host` and TLS SNI, synthetic unknown-host controls, hard request and runtime limits, and structured observations on canonical hostname results in JSONL, SQLite, the API, and HarvestView.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ uv run theHarvester -d example.com -b emails,urls,certspotter
 
 Capability selectors form a union and choose which sources run. They do not discard other result types returned by those sources. Available selectors are `subdomains`, `emails`, `ips`, `asns`, `urls`, `people`, and `breaches`. `-b all` runs every cataloged P0 passive source. P1 DNS and P2 direct sources require explicit selection.
 
+Exclude hostname results while retaining other result types:
+
+```bash
+uv run theHarvester -d example.com -b emails,ips,urls --no-hosts -f non-host-results
+```
+
+`--no-hosts` skips sources whose only declared route is `subdomains`. Mixed sources still run, but their hostname getter is not called; emails, IPs, URLs, ASNs, people, and breach names remain available. Hostname and virtual-host records are omitted from terminal, JSON, XML, JSONL, SQLite, API, and HarvestView output. The option cannot be combined with Shodan enrichment, DNS resolution/lookup/brute force/recursion, takeover checks, screenshots, or virtual-host discovery. Target-only API endpoint interaction remains available because it does not depend on harvested hostnames. HarvestView and `POST /api/v1/runs` expose the same option as `no_hosts`.
+
 Save JSON, XML, and JSONL reports:
 
 ```bash

--- a/tests/e2e/test_harvestview.py
+++ b/tests/e2e/test_harvestview.py
@@ -200,6 +200,7 @@ def test_harvestview_can_submit_overridable_execution_controls(
         'start': 25,
         'deadline_seconds': 86_400,
         'proxies': True,
+        'no_hosts': False,
         'dns_lookup': True,
         'dns_resolve': False,
         'dns_resolvers': ['192.0.2.53', '198.51.100.53', '203.0.113.53'],
@@ -222,6 +223,35 @@ def test_harvestview_can_submit_overridable_execution_controls(
         'vhost_concurrency': 5,
         'vhost_insecure': False,
     }
+
+
+def test_harvestview_submits_hostname_exclusion(harvestview_server_url: str, page: Page, browser_failures) -> None:
+    browser_failures.allow_response('POST', 503, '/api/v1/runs')
+    browser_failures.allow_console_error(
+        'Failed to load resource: the server responded with a status of 503 (Service Unavailable)'
+    )
+    captured: dict[str, object] = {}
+
+    def capture_submission(route: Route) -> None:
+        if route.request.method != 'POST':
+            route.continue_()
+            return
+        captured.update(route.request.post_data_json)
+        route.fulfill(status=503, json={'detail': 'Hostname exclusion captured'})
+
+    page.route(f'{harvestview_server_url}/api/v1/runs', capture_submission)
+    page.goto(f'{harvestview_server_url}/')
+    page.get_by_role('button', name='Start enumeration').first.click()
+    page.get_by_role('button', name='Clear', exact=True).click()
+    page.locator('#run-target').fill('example.com')
+    page.get_by_text('Advanced execution controls', exact=True).click()
+    page.locator('[name="no_hosts"]').check()
+    page.locator('[data-activity="P0"] input[value="bufferoverun"]').check()
+    page.locator('#submit-run-button').click()
+
+    expect(page.locator('#new-run-error')).to_have_text('Hostname exclusion captured')
+    assert captured['sources'] == ['bufferoverun']
+    assert captured['no_hosts'] is True
 
 
 def test_harvestview_requires_complete_inputs_for_a_vhost_only_run(

--- a/tests/lib/test_api_v1.py
+++ b/tests/lib/test_api_v1.py
@@ -421,6 +421,7 @@ def test_openapi_explains_scope_and_execution_controls(tmp_path, monkeypatch) ->
     assert 'prefix' not in properties['routeviews']['description']
     assert 'three resolver' in properties['dns_recursive_query_limit']['description']
     assert 'discovery sources' in properties['proxies']['description']
+    assert 'Exclude hostname results' in properties['no_hosts']['description']
     assert 'configured proxies' in properties['takeover']['description']
     assert 'take_over' not in properties
     assert 'endpoint paths' in properties['api_scan_paths']['description']

--- a/tests/lib/test_run_backend.py
+++ b/tests/lib/test_run_backend.py
@@ -853,6 +853,74 @@ def test_routeviews_child_receives_explicit_action_without_source_limit_controls
     assert received_options[0].limit == 9_999
 
 
+@pytest.mark.parametrize(
+    ('field', 'value', 'option'),
+    [
+        ('shodan', True, '--shodan'),
+        ('dns_resolve', True, '--dns-resolve'),
+        ('dns_lookup', True, '--dns-lookup'),
+        ('dns_brute', True, '--dns-brute'),
+        ('dns_recursive_depth', 1, '--dns-recursive-depth'),
+        ('takeover', True, '--take-over'),
+        ('screenshot', True, '--screenshot'),
+        ('vhost', True, '--vhost'),
+    ],
+)
+def test_no_hosts_rejects_hostname_dependent_actions(field: str, value: object, option: str) -> None:
+    from pydantic import ValidationError
+
+    from theHarvester.lib.api.run_models import RunRequest
+
+    with pytest.raises(ValidationError, match=rf'--no-hosts cannot be combined with: {option}'):
+        RunRequest(target='example.test', sources=['bufferoverun'], no_hosts=True, **{field: value})
+
+
+def test_no_hosts_allows_target_only_api_scan() -> None:
+    from theHarvester.lib.api.run_models import RunRequest
+
+    request = RunRequest(target='example.test', sources=[], no_hosts=True, api_scan=True)
+
+    assert request.no_hosts is True
+    assert request.api_scan is True
+
+
+def test_no_hosts_conflict_precedes_virtual_host_input_validation() -> None:
+    from pydantic import ValidationError
+
+    from theHarvester.lib.api.run_models import RunRequest
+
+    with pytest.raises(ValidationError, match=r'--no-hosts cannot be combined with: --vhost'):
+        RunRequest(target='example.test', sources=[], no_hosts=True, vhost=True)
+
+
+def test_no_hosts_child_preserves_the_run_request(tmp_path, monkeypatch) -> None:
+    from theHarvester import __main__ as main_module
+    from theHarvester.lib.api import run_worker
+    from theHarvester.lib.api.run_models import RunRequest
+    from theHarvester.lib.api.run_store import RunStore
+    from theHarvester.lib.completed_result import CompletedResult
+
+    received_options = []
+
+    async def fake_start(options, **_kwargs):
+        received_options.append(options)
+        now = datetime.now(UTC)
+        return (CompletedResult.finish(target=options.domain, started_at=now, completed_at=now, groups={}),)
+
+    monkeypatch.setattr(main_module, 'start', fake_start)
+
+    async def scenario() -> None:
+        store = RunStore(tmp_path / 'runs.sqlite')
+        created = await store.create(RunRequest(target='example.test', sources=['bufferoverun'], no_hosts=True))
+        assert await store.claim_next() is not None
+        await run_worker._child_execute(created['run_id'], store.database)
+
+    asyncio.run(scenario())
+
+    assert received_options[0].source == 'bufferoverun'
+    assert received_options[0].no_hosts is True
+
+
 def test_virtual_host_request_normalizes_a_self_contained_target_action() -> None:
     from pydantic import ValidationError
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -42,6 +42,7 @@ async def test_cli_help_explains_proxy_and_direct_action_scope(
         'Enrich discovered IPs with sourced ASN attribution, or an explicitly targeted ASN, IP, or prefix, through '
         'RouteViews.' in help_text
     )
+    assert 'Exclude hostname results while retaining other result types returned by selected sources.' in help_text
     assert 'Accepted for compatibility but currently unused; use --dns-resolvers to select resolvers.' in help_text
     assert 'Select resolver IPs for DNS actions without enabling hostname resolution.' in help_text
     assert 'text file with one IP per line' in help_text
@@ -2654,7 +2655,7 @@ async def test_routeviews_pivots_from_attributed_ips_without_expanding_discovere
             return None
 
         async def get_hostnames(self) -> set[str]:
-            return {'example.com'}
+            raise AssertionError('hostname results must not be retrieved')
 
         async def get_ips(self) -> set[str]:
             return {'192.0.2.10'}
@@ -2698,7 +2699,14 @@ async def test_routeviews_pivots_from_attributed_ips_without_expanding_discovere
     monkeypatch.setattr(theharvester_main.Core, 'routeviews_key', staticmethod(lambda: None))
 
     result = await theharvester_main.start(
-        EnumerationOptions(domain='example.com', quiet=True, routeviews=True, source='urlscan', proxies=True),
+        EnumerationOptions(
+            domain='example.com',
+            quiet=True,
+            routeviews=True,
+            source='urlscan',
+            proxies=True,
+            no_hosts=True,
+        ),
         return_completed_result=True,
     )
 
@@ -2706,6 +2714,7 @@ async def test_routeviews_pivots_from_attributed_ips_without_expanding_discovere
     completed = result[-1]
     assert ('asn', 'AS64500') in completed.results
     assert ('ip', '192.0.2.10') in completed.results
+    assert not any(kind == 'hostname' for kind, _value in completed.results)
     assert len(completed.asn_attributions) == 1
     assert completed.asn_attributions[0].subject_value == '192.0.2.10'
     execution = next(item for item in result[-1].active_evidence.executions if item.action == 'routeviews')

--- a/tests/test_no_hosts.py
+++ b/tests/test_no_hosts.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+import sys
+import xml.etree.ElementTree as ElementTree
+from typing import TYPE_CHECKING
+
+import pytest
+
+from theHarvester import __main__ as theharvester_main
+from theHarvester.lib.completed_result import CompletedResult
+from theHarvester.lib.enumeration import EnumerationOptions
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class NoopResultStore:
+    async def initialize(self) -> None:
+        return None
+
+    async def save_run(self, _result: CompletedResult) -> None:
+        return None
+
+
+class MixedResultSource:
+    async def process(self, _proxy: bool) -> None:
+        return None
+
+    async def get_hostnames(self) -> list[str]:
+        raise AssertionError('hostname results must not be retrieved')
+
+    async def get_ips(self) -> list[str]:
+        return ['192.0.2.10']
+
+
+@pytest.mark.parametrize(
+    ('overrides', 'option'),
+    [
+        ({'shodan': True}, '--shodan'),
+        ({'dns_resolve': None}, '--dns-resolve'),
+        ({'dns_lookup': True}, '--dns-lookup'),
+        ({'dns_brute': True}, '--dns-brute'),
+        ({'dns_recursive_depth': 1}, '--dns-recursive-depth'),
+        ({'take_over': True}, '--take-over'),
+        ({'screenshot': 'screenshots'}, '--screenshot'),
+        ({'vhost': True}, '--vhost'),
+    ],
+)
+@pytest.mark.asyncio
+async def test_no_hosts_rejects_hostname_dependent_cli_actions(
+    overrides: dict[str, object],
+    option: str,
+) -> None:
+    with pytest.raises(ValueError, match=rf'--no-hosts cannot be combined with: {option}'):
+        await theharvester_main.start(
+            EnumerationOptions(
+                domain='example.com',
+                source='bufferoverun',
+                no_hosts=True,
+                quiet=True,
+                **overrides,
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_hosts_keeps_mixed_source_ip_without_retrieving_hostnames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(theharvester_main, 'ResultStore', NoopResultStore)
+    monkeypatch.setattr(theharvester_main.bufferoverun, 'SearchBufferover', lambda _word: MixedResultSource())
+
+    response = await theharvester_main.start(
+        EnumerationOptions(domain='example.com', source='bufferoverun', no_hosts=True, quiet=True),
+        return_completed_result=True,
+    )
+
+    completed = response[-1]
+    assert isinstance(completed, CompletedResult)
+    assert completed.results == (('ip', '192.0.2.10'),)
+    assert completed.observations[0].source == 'bufferoverun'
+    assert completed.source_executions[0].status == 'completed'
+    assert completed.source_executions[0].result_count == 1
+    assert response[-2] == []
+
+
+@pytest.mark.asyncio
+async def test_no_hosts_skips_host_only_source_before_construction(monkeypatch: pytest.MonkeyPatch) -> None:
+    class HostOnlySource:
+        def __init__(self, _word: str) -> None:
+            raise AssertionError('host-only source must not be constructed')
+
+    monkeypatch.setattr(theharvester_main, 'ResultStore', NoopResultStore)
+    monkeypatch.setattr(theharvester_main.crtsh, 'SearchCrtsh', HostOnlySource)
+
+    response = await theharvester_main.start(
+        EnumerationOptions(domain='example.com', source='crtsh', no_hosts=True, quiet=True),
+        return_completed_result=True,
+    )
+
+    completed = response[-1]
+    assert isinstance(completed, CompletedResult)
+    assert completed.results == ()
+    assert completed.source_executions[0].source == 'crtsh'
+    assert completed.source_executions[0].status == 'skipped'
+    assert completed.source_executions[0].stop_reason == 'hostname-collection-disabled'
+
+
+@pytest.mark.asyncio
+async def test_no_hosts_omits_hostname_records_from_every_file_report(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / 'non-host-results'
+    monkeypatch.setattr(theharvester_main, 'ResultStore', NoopResultStore)
+    monkeypatch.setattr(theharvester_main.bufferoverun, 'SearchBufferover', lambda _word: MixedResultSource())
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['theHarvester', '-d', 'example.com', '-b', 'bufferoverun', '--no-hosts', '-f', str(output)],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        await theharvester_main.start()
+
+    assert exit_info.value.code == 0
+    legacy_json = json.loads(output.with_suffix('.json').read_text(encoding='utf-8'))
+    assert legacy_json['ips'] == ['192.0.2.10']
+    assert 'hosts' not in legacy_json
+    assert 'vhosts' not in legacy_json
+    xml_root = ElementTree.parse(output.with_suffix('.xml')).getroot()
+    assert xml_root.findall('host') == []
+    assert xml_root.findall('vhost') == []
+    jsonl = [json.loads(line) for line in output.with_suffix('.jsonl').read_text(encoding='utf-8').splitlines()]
+    assert [item['type'] for item in jsonl[1:]] == ['ip']

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -124,6 +124,7 @@ from theHarvester.lib.source_catalog import (
     ResultRoute,
     SourceSpec,
     get_source_spec,
+    hostname_collection_conflicts,
 )
 from theHarvester.lib.virtual_host import (
     DEFAULT_VHOST_CONCURRENCY,
@@ -230,6 +231,12 @@ async def start(
         '-p',
         '--proxies',
         help='Use proxies.yaml for supported discovery-source and takeover requests.',
+        default=False,
+        action='store_true',
+    )
+    parser.add_argument(
+        '--no-hosts',
+        help='Exclude hostname results while retaining other result types returned by selected sources.',
         default=False,
         action='store_true',
     )
@@ -439,6 +446,22 @@ async def start(
         configure_logging(verbose=args.verbose)
         if args.verbose:
             logger.info('Verbose logging enabled')
+    collect_hosts = not args.no_hosts
+    action_request = {
+        'no_hosts': args.no_hosts,
+        'shodan': args.shodan,
+        'dns_resolve': args.dns_resolve != '',
+        'dns_lookup': args.dns_lookup,
+        'dns_brute': args.dns_brute,
+        'dns_recursive_depth': args.dns_recursive_depth,
+        'takeover': args.take_over,
+        'screenshot': args.screenshot,
+        'vhost': args.vhost,
+        'vhost_endpoint': args.vhost_endpoint,
+        'vhost_candidates': args.vhost_candidates,
+    }
+    if conflicts := hostname_collection_conflicts(action_request):
+        raise ValueError(f'--no-hosts cannot be combined with: {", ".join(conflicts)}')
     vhost_enabled = args.vhost or bool(args.vhost_endpoint) or bool(args.vhost_candidates)
     vhost_scope = ''
     vhost_endpoint = ''
@@ -610,7 +633,9 @@ async def start(
             'framework': map(str, all_frameworks),
             'hostname': (
                 _normalize_hosts_for_storage(all_hosts, word) | screenshot_hostnames | set(confirmed_virtual_hostnames())
-            ),
+            )
+            if collect_hosts
+            else (),
             'infostealer': (
                 json.dumps(stealer, ensure_ascii=False, separators=(',', ':'), sort_keys=True) for stealer in all_infostealers
             ),
@@ -628,7 +653,7 @@ async def start(
             for observation in observations:
                 committed_groups.setdefault(observation.kind, []).append(observation.value)
             groups = {kind: iter(values) for kind, values in committed_groups.items()}
-        elif extra_hostnames:
+        elif collect_hosts and extra_hostnames:
             groups['hostname'] = (
                 _normalize_hosts_for_storage((*all_hosts, *extra_hostnames), word)
                 | screenshot_hostnames
@@ -646,7 +671,7 @@ async def start(
                 active_evidence=ActiveEvidence(tuple(action_executions)),
                 network_observations=network_observations,
                 asn_attributions=asn_attributions,
-                virtual_hosts=vhost_observations,
+                virtual_hosts=vhost_observations if collect_hosts else (),
             )
         except (ValueError, TypeError) as error:
             output_logger.info(f'[!] An error occurred while completing the result: {error}')
@@ -767,7 +792,7 @@ async def start(
                 ResultObservation(source_name, kind, value) for item in values if (value := str(item).strip())
             )
 
-        if ResultRoute.SUBDOMAINS in routes:
+        if collect_hosts and ResultRoute.SUBDOMAINS in routes:
             discovered_hosts = await search_engine.get_hostnames()
             host_names = list(_normalize_hosts_for_storage(discovered_hosts, word))
             paired_hosts: set[str] = set()
@@ -947,6 +972,17 @@ async def start(
     stor_lst = []
     if args.source is not None:
         engines = Core.expand_source_selection(args.source)
+        if not collect_hosts:
+            hostname_only_engines = [
+                engine
+                for engine in engines
+                if engine in SOURCE_SPECS and get_source_spec(engine).routes == frozenset({ResultRoute.SUBDOMAINS})
+            ]
+            source_executions.extend(
+                SourceExecution(engine, 'skipped', 0, 0, stop_reason='hostname-collection-disabled')
+                for engine in hostname_only_engines
+            )
+            engines = [engine for engine in engines if engine not in hostname_only_engines]
     if explicit_asn_target is not None and (
         not routeviews_enabled
         or engines
@@ -2149,7 +2185,9 @@ async def start(
         for person in all_people:
             output_logger.info(person)
 
-    if len(all_hosts) == 0:
+    if not collect_hosts:
+        all_hosts = []
+    elif len(all_hosts) == 0:
         output_logger.info('\n[*] No hosts found.\n\n')
     else:
         if dnsresolve != '':
@@ -2869,21 +2907,24 @@ async def start(
                 await file.write('<cmd>' + ' '.join(sanitized_args) + '</cmd>')
                 for email in all_emails:
                     await file.write('<email>' + sanitize_for_xml(email) + '</email>')
-                paired_hosts = {host for host, _ip in reported_host_ip_pairs}
-                for host, ip in sorted(reported_host_ip_pairs):
-                    await file.write(f'<host><ip>{sanitize_for_xml(ip)}</ip><hostname>{sanitize_for_xml(host)}</hostname></host>')
-                for x in full:
-                    host, ip = x.split(':', 1) if ':' in x else (x, '')
-                    if ip and len(ip) > 3:
-                        if (host, ip) in reported_host_ip_pairs:
-                            continue
+                if collect_hosts:
+                    paired_hosts = {host for host, _ip in reported_host_ip_pairs}
+                    for host, ip in sorted(reported_host_ip_pairs):
                         await file.write(
                             f'<host><ip>{sanitize_for_xml(ip)}</ip><hostname>{sanitize_for_xml(host)}</hostname></host>'
                         )
-                    elif host not in paired_hosts:
-                        await file.write(f'<host>{sanitize_for_xml(host)}</host>')
-                for host in confirmed_virtual_hostnames():
-                    await file.write(f'<vhost>{sanitize_for_xml(host)}</vhost>')
+                    for x in full:
+                        host, ip = x.split(':', 1) if ':' in x else (x, '')
+                        if ip and len(ip) > 3:
+                            if (host, ip) in reported_host_ip_pairs:
+                                continue
+                            await file.write(
+                                f'<host><ip>{sanitize_for_xml(ip)}</ip><hostname>{sanitize_for_xml(host)}</hostname></host>'
+                            )
+                        elif host not in paired_hosts:
+                            await file.write(f'<host>{sanitize_for_xml(host)}</host>')
+                    for host in confirmed_virtual_hostnames():
+                        await file.write(f'<vhost>{sanitize_for_xml(host)}</vhost>')
                 # TODO add Shodan output into XML report
                 await file.write('</theHarvester>')
                 output_logger.info('[*] XML File saved.')
@@ -3085,15 +3126,16 @@ async def start(
             if len(all_emails) > 0:
                 json_dict['emails'] = all_emails
 
-            if dnsresolve != '' and len(full) > 0:
-                json_dict['hosts'] = full
-            elif len(all_hosts) > 0:
-                json_dict['hosts'] = all_hosts
-            else:
-                json_dict['hosts'] = []
+            if collect_hosts:
+                if dnsresolve != '' and len(full) > 0:
+                    json_dict['hosts'] = full
+                elif len(all_hosts) > 0:
+                    json_dict['hosts'] = all_hosts
+                else:
+                    json_dict['hosts'] = []
 
-            if virtual_hostnames := confirmed_virtual_hostnames():
-                json_dict['vhosts'] = virtual_hostnames
+                if virtual_hostnames := confirmed_virtual_hostnames():
+                    json_dict['vhosts'] = virtual_hostnames
 
             if len(all_urls) > 0:
                 json_dict['urls'] = all_urls

--- a/theHarvester/lib/api/run_models.py
+++ b/theHarvester/lib/api/run_models.py
@@ -15,7 +15,12 @@ from theHarvester.lib.enumeration import (
 from theHarvester.lib.evidence_types import EvidenceStatus  # noqa: TC001 - Pydantic resolves this annotation at runtime
 from theHarvester.lib.resolver_selection import DEFAULT_DNS_RESOLVERS, normalize_resolver_addresses
 from theHarvester.lib.result_values import normalize_asn
-from theHarvester.lib.source_catalog import SOURCE_SPECS, ActivityClass, selected_action_names
+from theHarvester.lib.source_catalog import (
+    SOURCE_SPECS,
+    ActivityClass,
+    hostname_collection_conflicts,
+    selected_action_names,
+)
 from theHarvester.lib.virtual_host import (
     DEFAULT_VHOST_CONCURRENCY,
     DEFAULT_VHOST_REQUEST_LIMIT,
@@ -92,6 +97,10 @@ class RunRequest(BaseModel):
     proxies: bool = Field(
         default=False,
         description='Use configured proxies for supported discovery sources and takeover requests.',
+    )
+    no_hosts: bool = Field(
+        default=False,
+        description='Exclude hostname results while retaining other result types returned by selected sources.',
     )
     dns_brute: bool = Field(default=False, description='Try wordlist candidates below the authorized target through DNS.')
     dns_lookup: bool = Field(
@@ -225,6 +234,12 @@ class RunRequest(BaseModel):
         if len(paths) != len(set(paths)):
             raise ValueError('API scan paths must not contain duplicates')
         return paths
+
+    @model_validator(mode='after')
+    def validate_hostname_collection(self) -> Self:
+        if conflicts := hostname_collection_conflicts(self.model_dump()):
+            raise ValueError(f'--no-hosts cannot be combined with: {", ".join(conflicts)}')
+        return self
 
     @model_validator(mode='after')
     def validate_virtual_host_request(self) -> Self:

--- a/theHarvester/lib/api/run_worker.py
+++ b/theHarvester/lib/api/run_worker.py
@@ -314,6 +314,7 @@ async def _child_execute(run_id: str, database: Path) -> None:
         domain=run['target'],
         filename='',
         limit=request['limit'],
+        no_hosts=request.get('no_hosts', False),
         proxies=request.get('proxies', False),
         quiet=True,
         routeviews=request.get('routeviews', False),

--- a/theHarvester/lib/api/static/harvestview/app.js
+++ b/theHarvester/lib/api/static/harvestview/app.js
@@ -292,6 +292,7 @@
       ['Result start offset', request.start ?? 'Not recorded'],
       ['Whole-run deadline', request.deadline_seconds ? `${request.deadline_seconds} seconds` : 'Not applicable'],
       ['Proxy transport', request.proxies ? 'Selected' : 'Off'],
+      ['Hostname results', request.no_hosts ? 'Excluded' : 'Included'],
       ['DNS lookup (/24 reverse expansion)', request.dns_lookup ? 'Selected' : 'Off'],
       ['DNS resolution', request.dns_resolve ? 'Selected' : 'Off'], ['DNS brute force', request.dns_brute ? 'Selected' : 'Off'],
       ['DNS resolver vantages', request.dns_resolvers?.join(', ') || 'Not recorded'],
@@ -876,7 +877,8 @@
     const payload = {
       target: form.get('target'), sources: [...state.selectedSources], limit: Number(form.get('limit')),
       start: Number(form.get('start')), deadline_seconds: Number(form.get('deadline_seconds')),
-      proxies: form.has('proxies'), dns_lookup: form.has('dns_lookup'), dns_resolve: form.has('dns_resolve'),
+      proxies: form.has('proxies'), no_hosts: form.has('no_hosts'),
+      dns_lookup: form.has('dns_lookup'), dns_resolve: form.has('dns_resolve'),
       dns_resolvers: String(form.get('dns_resolvers')).split(',').map(value => value.trim()),
       dns_recursive_depth: Number(form.get('dns_recursive_depth')),
       dns_recursive_query_limit: Number(form.get('dns_recursive_query_limit')),

--- a/theHarvester/lib/api/static/harvestview/index.html
+++ b/theHarvester/lib/api/static/harvestview/index.html
@@ -234,6 +234,7 @@
               <small>Optional list for API endpoint interaction, one URL path per line. Leave empty to use the bundled list.</small>
             </label>
             <label class="inline-choice"><input type="checkbox" name="proxies"><span>Use configured proxies for discovery and takeover checks</span></label>
+            <label class="inline-choice"><input type="checkbox" name="no_hosts"><span>Exclude hostname results and host-dependent processing</span></label>
           </div>
         </details>
 

--- a/theHarvester/lib/enumeration.py
+++ b/theHarvester/lib/enumeration.py
@@ -27,6 +27,7 @@ class EnumerationOptions:
     start: int = DEFAULT_RESULT_START
     proxies: bool = False
     routeviews: bool = False
+    no_hosts: bool = False
     shodan: bool = False
     screenshot: str = ''
     dns_server: str | None = None
@@ -62,6 +63,7 @@ class EnumerationOptions:
             start=getattr(value, 'start', DEFAULT_RESULT_START),
             proxies=getattr(value, 'proxies', False),
             routeviews=getattr(value, 'routeviews', False),
+            no_hosts=getattr(value, 'no_hosts', False),
             shodan=getattr(value, 'shodan', False),
             screenshot=getattr(value, 'screenshot', ''),
             dns_server=getattr(value, 'dns_server', None),

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -26,6 +26,16 @@ ACTION_REQUEST_FIELDS: Final = {
     **{name: name.replace('-', '_') for name in ACTION_ACTIVITIES},
     'dns-recursive': 'dns_recursive_depth',
 }
+HOSTNAME_DEPENDENT_ACTION_OPTIONS: Final = {
+    'shodan': '--shodan',
+    'dns-resolve': '--dns-resolve',
+    'dns-lookup': '--dns-lookup',
+    'dns-brute': '--dns-brute',
+    'dns-recursive': '--dns-recursive-depth',
+    'takeover': '--take-over',
+    'screenshot': '--screenshot',
+    'vhost': '--vhost',
+}
 
 
 def selected_action_names(request: Mapping[str, object]) -> tuple[str, ...]:
@@ -36,6 +46,14 @@ def selected_action_names(request: Mapping[str, object]) -> tuple[str, ...]:
         return isinstance(value, (int, float)) and value > 0 if name == 'dns-recursive' else bool(value)
 
     return tuple(name for name in ACTION_ACTIVITIES if selected(name))
+
+
+def hostname_collection_conflicts(request: Mapping[str, object]) -> tuple[str, ...]:
+    """Return selected actions that require hostname collection."""
+    if not request.get('no_hosts'):
+        return ()
+    selected = set(selected_action_names(request))
+    return tuple(option for action, option in HOSTNAME_DEPENDENT_ACTION_OPTIONS.items() if action in selected)
 
 
 class ResultRoute(Enum):


### PR DESCRIPTION
## Summary

- add route-aware `--no-hosts` filtering to the CLI
- expose the same `no_hosts` option through the REST API and HarvestView
- skip hostname-only sources before construction while retaining non-host findings from mixed sources
- omit hostname and virtual-host results from terminal, JSON, XML, JSONL, SQLite, and API output
- reject host-dependent enrichment and active actions with a clear incompatibility error
- preserve exact sourced IP-to-ASN pivots for `--no-hosts --routeviews` runs without retrieving or persisting hostname results

## Why

This supersedes #2401, which targets the pre-refactor `master` execution path. The current implementation uses the `dev` source catalog and declared `ResultRoute` values instead of adding a parallel host-collection architecture. It also covers the normalized result store, JSONL evidence, current REST run model, and HarvestView.

Host-only sources are recorded as skipped with `hostname-collection-disabled`. Mixed sources still run, but their hostname getter is not called, so emails, IPs, URLs, ASNs, people, and breach names remain available. Target-only API endpoint interaction remains allowed because it does not depend on harvested hostnames.

After rebasing onto RouteViews, `--no-hosts` still retains sourced IP-to-ASN attribution. Those exact IPs can become RouteViews pivots, while hostname-subject attribution and hostname results remain excluded.

Closes #2400.

## Validation

- `uv run pytest -q`: 1,203 passed, 6 skipped, 26 deselected
- `uv run pytest -q -m harvestview_e2e tests/e2e/test_harvestview.py`: 26 passed
- focused no-hosts, RouteViews, API, and catalog suites: 53 passed
- two-axis review: no Spec findings and no documented Standards violations
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy theHarvester`
- `node --check theHarvester/lib/api/static/harvestview/app.js`
- `git diff --check upstream/dev...HEAD`

All provider behavior remained mocked or skipped during routine verification. No live target or provider requests were made.
