### PR TITLE
fix: update BuiltWith to current Domain API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Replaced Shodan's synchronous Python SDK with cancellable async Host API requests that honor configured proxies, query every unique resolved IPv4, paginate target-bound hostname and TLS-certificate searches without an adapter-specific result cap, retain successful partial results, and add no source-local deadline. Shodan now stores one canonical `shodan-host` result per IP with every normalized TCP or UDP service and scoped certificate CN/SAN metadata in native JSONL, SQLite, API, and HarvestView details instead of an escaped JSON value.
+- Migrated BuiltWith to the current v23 Domain API with privacy-preserving request controls, nested result parsing, and truthful partial or failed outcomes.
 - Removed the transport-wide delay before reading ready HTTP responses, bounded Wayback Archive to 30 seconds and Common Crawl to 120 seconds, kept both sources within the requested result limit, and made long-source progress visible in verbose mode. Common Crawl now requests one 50-record page at a time instead of bursting page batches.
 - Made Baidu, crt.sh, HackerTarget, Have I Been Pwned, Mojeek, OTX, and Robtex report blocked, malformed, or transport failures truthfully. Also fixed HackerTarget CSV parsing and Robtex AAAA results.
 - Hardened BufferOver, ProjectDiscovery, DNSDumpster, ONYPHE, and URLScan parsing and result attribution, including scoped typed results and bounded URLScan pagination.

--- a/tests/discovery/test_builtwith.py
+++ b/tests/discovery/test_builtwith.py
@@ -1,7 +1,9 @@
+import asyncio
 import json
 import sys
 import types
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -20,6 +22,7 @@ from theHarvester import __main__ as theharvester_main
 from theHarvester.discovery import builtwith
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib.completed_result import CompletedResult
+from theHarvester.lib.core import FetcherResponse, ResponseStreamError
 
 
 @pytest.mark.asyncio
@@ -31,103 +34,249 @@ async def test_missing_key_raises(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_process_accepts_text_json_content_type(monkeypatch) -> None:
-    """BuiltWith API returns 'text/json' content-type; response.json(content_type=None)
-    must be used so aiohttp does not raise a ContentTypeError."""
+async def test_process_uses_v23_privacy_controls_and_parses_nested_results(monkeypatch) -> None:
     monkeypatch.setattr(builtwith.Core, 'builtwith_key', lambda: 'dummy-key')
-
+    monkeypatch.setattr(builtwith.Core, 'get_user_agent', lambda: 'test-agent')
     api_payload = {
-        'domains': ['sub.example.com'],
-        'paths': ['https://example.com/login'],
-        'technologies': [
-            None,
-            {'name': 'Django', 'category': 'framework'},
-            {'name': 'Python', 'category': 'language'},
-            {'name': 'nginx', 'category': 'server'},
-            {'name': 'WordPress', 'category': 'cms'},
-            {'name': 'Google Analytics', 'category': 'analytics'},
-            {'category': 'framework'},
-            {'name': ' ', 'category': 'server'},
-            {'name': 7, 'category': 'cms'},
-        ],
+        'Results': [
+            {
+                'Lookup': 'example.com',
+                'Result': {
+                    'Paths': [
+                        {
+                            'Domain': 'example.com',
+                            'SubDomain': 'api',
+                            'Url': 'dd',
+                            'Technologies': [
+                                {'Name': 'Django', 'Tag': 'framework'},
+                                {'Name': 'Python', 'Tag': 'language'},
+                                {'Name': 'nginx', 'Categories': ['Web Server']},
+                                {'Name': 'WordPress', 'Tag': 'cms'},
+                                {'Name': 'Google Analytics', 'Categories': ['Analytics']},
+                            ],
+                        },
+                        {
+                            'Domain': 'example.com',
+                            'SubDomain': '',
+                            'Url': '/login',
+                            'Technologies': [],
+                        },
+                    ]
+                },
+            }
+        ]
     }
+    captured: dict[str, Any] = {}
 
-    class _FakeResponse:
-        status = 200
+    async def fake_fetch_json(url: str, **kwargs: Any) -> FetcherResponse:
+        captured['url'] = url
+        captured.update(kwargs)
+        return FetcherResponse(api_payload, 200, {})
 
-        async def json(self, **kwargs):
-            # Simulate aiohttp accepting content_type=None for 'text/json' responses
-            assert kwargs.get('content_type') is None, (
-                'content_type=None must be passed to accept non-standard MIME types like text/json'
-            )
-            return api_payload
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            pass
-
-    class _FakeSession:
-        def __init__(self, **_kwargs):
-            pass
-
-        def get(self, *_args, **_kwargs):
-            return _FakeResponse()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            pass
-
-    monkeypatch.setattr(builtwith.aiohttp, 'ClientSession', _FakeSession)
-
+    monkeypatch.setattr(builtwith.AsyncFetcher, 'fetch_json', fake_fetch_json)
     search = builtwith.SearchBuiltWith('example.com')
-    await search.process()
+    await search.process(proxy=True)
 
-    assert await search.get_hostnames() == {'sub.example.com'}
+    assert captured == {
+        'url': 'https://api.builtwith.com/v23/api.json',
+        'params': {
+            'HIDEDL': 'yes',
+            'LOOKUP': 'example.com',
+            'NOATTR': 'yes',
+            'NOMETA': 'yes',
+            'NOPII': 'yes',
+        },
+        'proxy': True,
+        'headers': {
+            'Accept': 'application/json',
+            'Authorization': 'API dummy-key',
+            'User-Agent': 'test-agent',
+        },
+    }
+    assert await search.get_hostnames() == {'api.example.com', 'example.com'}
     assert await search.get_urls() == {'https://example.com/login'}
     assert await search.get_frameworks() == {'Django'}
     assert await search.get_languages() == {'Python'}
     assert await search.get_servers() == {'nginx'}
     assert await search.get_cms() == {'WordPress'}
     assert await search.get_analytics() == {'Google Analytics'}
+    assert search.execution_status == 'completed'
+    assert search.stop_reason is None
 
 
 @pytest.mark.asyncio
-async def test_process_handles_non_200_status(monkeypatch) -> None:
+async def test_www_target_does_not_accept_sibling_subdomains(monkeypatch) -> None:
+    monkeypatch.setattr(builtwith.Core, 'builtwith_key', lambda: 'dummy-key')
+    captured: dict[str, Any] = {}
+    payload = {
+        'Results': [
+            {
+                'Result': {
+                    'Paths': [
+                        {'Domain': 'example.com', 'SubDomain': 'www', 'Url': 'dd', 'Technologies': []},
+                        {'Domain': 'example.com', 'SubDomain': 'api', 'Url': 'dd', 'Technologies': []},
+                    ]
+                }
+            }
+        ]
+    }
+
+    async def fake_fetch_json(*_args: Any, **kwargs: Any) -> FetcherResponse:
+        captured.update(kwargs)
+        return FetcherResponse(payload, 200, {})
+
+    monkeypatch.setattr(builtwith.AsyncFetcher, 'fetch_json', fake_fetch_json)
+    search = builtwith.SearchBuiltWith('www.example.com')
+
+    await search.process()
+
+    assert captured['params']['LOOKUP'] == 'example.com'
+    assert await search.get_hostnames() == {'www.example.com'}
+    assert await search.get_urls() == set()
+    assert search.execution_status == 'completed'
+    assert search.stop_reason is None
+
+
+@pytest.mark.asyncio
+async def test_named_technology_without_a_usable_category_is_malformed(monkeypatch) -> None:
+    monkeypatch.setattr(builtwith.Core, 'builtwith_key', lambda: 'dummy-key')
+    payload = {
+        'Results': [
+            {
+                'Result': {
+                    'Paths': [
+                        {
+                            'Domain': 'example.com',
+                            'SubDomain': 'www',
+                            'Url': 'dd',
+                            'Technologies': [{'Name': 'Unclassified Product', 'Tag': ' ', 'Categories': []}],
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    async def fake_fetch_json(*_args: Any, **_kwargs: Any) -> FetcherResponse:
+        return FetcherResponse(payload, 200, {})
+
+    monkeypatch.setattr(builtwith.AsyncFetcher, 'fetch_json', fake_fetch_json)
+    search = builtwith.SearchBuiltWith('example.com')
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'www.example.com'}
+    assert await search.get_urls() == set()
+    assert await search.get_frameworks() == set()
+    assert search.execution_status == 'partial'
+    assert search.stop_reason == 'invalid-response'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('response', 'expected_status', 'expected_reason'),
+    [
+        (None, 'failed', 'transport-error'),
+        (FetcherResponse(None, 401, {}), 'failed', 'access-denied'),
+        (FetcherResponse(None, 403, {}), 'failed', 'access-denied'),
+        (FetcherResponse(None, 429, {}), 'rate-limited', 'http-429'),
+        (FetcherResponse(None, 503, {}), 'failed', 'http-503'),
+        (FetcherResponse([], 200, {}), 'failed', 'invalid-response'),
+        (FetcherResponse({'Results': {}}, 200, {}), 'failed', 'invalid-response'),
+    ],
+)
+async def test_process_reports_failed_responses_truthfully(
+    monkeypatch,
+    response: FetcherResponse | None,
+    expected_status: str,
+    expected_reason: str,
+) -> None:
     monkeypatch.setattr(builtwith.Core, 'builtwith_key', lambda: 'dummy-key')
 
-    class _FakeResponse:
-        status = 403
+    async def fake_fetch_json(*_args: Any, **_kwargs: Any) -> FetcherResponse | None:
+        return response
 
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            pass
-
-    class _FakeSession:
-        def __init__(self, **_kwargs):
-            pass
-
-        def get(self, *_args, **_kwargs):
-            return _FakeResponse()
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_args):
-            pass
-
-    monkeypatch.setattr(builtwith.aiohttp, 'ClientSession', _FakeSession)
-
+    monkeypatch.setattr(builtwith.AsyncFetcher, 'fetch_json', fake_fetch_json)
     search = builtwith.SearchBuiltWith('example.com')
     await search.process()
 
     assert await search.get_hostnames() == set()
     assert await search.get_tech_stack() == {}
+    assert search.execution_status == expected_status
+    assert search.stop_reason == expected_reason
+
+
+@pytest.mark.asyncio
+async def test_malformed_nested_containers_retain_accepted_evidence(monkeypatch) -> None:
+    monkeypatch.setattr(builtwith.Core, 'builtwith_key', lambda: 'dummy-key')
+    payload = {
+        'Results': [
+            {
+                'Result': {
+                    'Paths': [
+                        {
+                            'Domain': 'example.com',
+                            'SubDomain': 'api',
+                            'Url': 'dd',
+                            'Technologies': [
+                                None,
+                                {'Name': 'Django', 'Tag': 'framework'},
+                                {'Name': 'nginx', 'Categories': ['Web Server', None]},
+                            ],
+                        },
+                        {'Domain': 'outside.invalid', 'SubDomain': '', 'Url': 'dd', 'Technologies': []},
+                        {'Domain': 'example.com', 'SubDomain': 7, 'Url': [], 'Technologies': {}},
+                    ]
+                }
+            },
+            None,
+        ]
+    }
+
+    async def fake_fetch_json(*_args: Any, **_kwargs: Any) -> FetcherResponse:
+        return FetcherResponse(payload, 200, {})
+
+    monkeypatch.setattr(builtwith.AsyncFetcher, 'fetch_json', fake_fetch_json)
+    search = builtwith.SearchBuiltWith('example.com')
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com'}
+    assert await search.get_urls() == set()
+    assert await search.get_frameworks() == {'Django'}
+    assert await search.get_servers() == {'nginx'}
+    assert search.execution_status == 'partial'
+    assert search.stop_reason == 'invalid-response'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('reason', ['invalid-response', 'response-limit', 'transport-error'])
+async def test_bounded_response_failures_are_attributed(monkeypatch, reason: str) -> None:
+    monkeypatch.setattr(builtwith.Core, 'builtwith_key', lambda: 'dummy-key')
+
+    async def fake_fetch_json(*_args: Any, **_kwargs: Any) -> FetcherResponse:
+        raise ResponseStreamError(reason)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(builtwith.AsyncFetcher, 'fetch_json', fake_fetch_json)
+    search = builtwith.SearchBuiltWith('example.com')
+
+    await search.process()
+
+    assert search.execution_status == 'failed'
+    assert search.stop_reason == reason
+
+
+@pytest.mark.asyncio
+async def test_cancellation_propagates(monkeypatch) -> None:
+    monkeypatch.setattr(builtwith.Core, 'builtwith_key', lambda: 'dummy-key')
+
+    async def fake_fetch_json(*_args: Any, **_kwargs: Any) -> FetcherResponse:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(builtwith.AsyncFetcher, 'fetch_json', fake_fetch_json)
+
+    with pytest.raises(asyncio.CancelledError):
+        await builtwith.SearchBuiltWith('example.com').process()
 
 
 @pytest.mark.asyncio

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -108,7 +108,7 @@ from theHarvester.lib.enumeration import (
     DEFAULT_RESULT_START,
     EnumerationOptions,
 )
-from theHarvester.lib.hostnames import normalize_scoped_hostname
+from theHarvester.lib.hostnames import normalize_hostname, normalize_scoped_hostname
 from theHarvester.lib.output import configure_logging, output_logger, print_linkedin_people, print_section, sorted_unique
 from theHarvester.lib.recursive_dns import (
     DEFAULT_RECURSIVE_DNS_QUERY_LIMIT,
@@ -138,7 +138,6 @@ from theHarvester.lib.virtual_host import (
     discover_harvested_virtual_hosts,
     normalize_virtual_host_candidates,
     normalize_virtual_host_endpoint,
-    normalize_virtual_host_hostname,
 )
 from theHarvester.screenshot.screenshot import ScreenShotter
 
@@ -469,7 +468,7 @@ async def start(
     vhost_candidates: tuple[str, ...] = ()
     vhost_limits: VirtualHostLimits | None = None
     if vhost_enabled:
-        vhost_scope = normalize_virtual_host_hostname(args.domain)
+        vhost_scope = normalize_hostname(args.domain)
         if args.proxies:
             raise ValueError('virtual-host discovery supports direct transport only; do not use --proxies')
         vhost_endpoint = normalize_virtual_host_endpoint(args.vhost_endpoint) if args.vhost_endpoint else ''

--- a/theHarvester/discovery/builtwith.py
+++ b/theHarvester/discovery/builtwith.py
@@ -1,26 +1,26 @@
-import logging
-from typing import Any
+from __future__ import annotations
 
-import aiohttp
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from theHarvester.discovery.constants import MissingKey
-from theHarvester.lib.core import AsyncFetcher, Core
-
-logger = logging.getLogger(__name__)
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse, ResponseStreamError
+from theHarvester.lib.hostnames import normalize_scoped_hostname
+from theHarvester.lib.virtual_host import normalize_virtual_host_hostname
 
 
 class SearchBuiltWith:
-    def __init__(self, word: str):
-        self.word = word
+    """Collect scoped technology evidence from the BuiltWith Domain API."""
+
+    SERVER = 'https://api.builtwith.com/v23/api.json'
+
+    def __init__(self, word: str) -> None:
+        self.word = normalize_virtual_host_hostname(word)
+        self.lookup_domain = self.word.removeprefix('www.')
         self.api_key = Core.builtwith_key()
-        if self.api_key is None:
+        if not isinstance(self.api_key, str) or not self.api_key.strip():
             raise MissingKey('BuiltWith')
-        self.base_url = 'https://api.builtwith.com/v21/api.json'
-        self.headers = {
-            'Authorization': f'Bearer {self.api_key}',
-            'Content-Type': 'application/json',
-            'User-Agent': Core.get_user_agent(),
-        }
+        self.api_key = self.api_key.strip()
         self.hosts: set[str] = set()
         self.tech_stack: dict[str, Any] = {}
         self.urls: set[str] = set()
@@ -29,59 +29,198 @@ class SearchBuiltWith:
         self.servers: set[str] = set()
         self.cms: set[str] = set()
         self.analytics: set[str] = set()
+        self.execution_status = 'completed'
+        self.stop_reason: str | None = None
+
+    def _has_results(self) -> bool:
+        return bool(self.hosts or self.urls or self.frameworks or self.languages or self.servers or self.cms or self.analytics)
+
+    def _stop(self, status: str, reason: str) -> None:
+        self.execution_status = 'partial' if self._has_results() else status
+        self.stop_reason = reason
+
+    def _path_hostname(self, path: dict[str, object]) -> tuple[str | None, bool]:
+        domain = path.get('Domain')
+        subdomain = path.get('SubDomain')
+        if not isinstance(domain, str) or not isinstance(subdomain, str):
+            return None, True
+        try:
+            domain = normalize_virtual_host_hostname(domain)
+        except ValueError:
+            return None, True
+        normalized_domain = normalize_scoped_hostname(domain, self.lookup_domain)
+        if normalized_domain is None:
+            return None, False
+        candidate = normalized_domain if not subdomain.strip() else f'{subdomain.strip()}.{normalized_domain}'
+        try:
+            candidate = normalize_virtual_host_hostname(candidate)
+        except ValueError:
+            return None, True
+        return normalize_scoped_hostname(candidate, self.word), False
+
+    def _path_url(self, value: object, hostname: str) -> tuple[str | None, bool]:
+        if not isinstance(value, str) or not (value := value.strip()):
+            return None, True
+        if value == 'dd':
+            return None, False
+        try:
+            parsed = urlsplit(value)
+            if parsed.scheme or parsed.netloc:
+                if (
+                    parsed.scheme.lower() not in {'http', 'https'}
+                    or parsed.hostname is None
+                    or parsed.username is not None
+                    or parsed.password is not None
+                ):
+                    return None, True
+                parsed_hostname = normalize_virtual_host_hostname(parsed.hostname)
+                scoped_hostname = normalize_scoped_hostname(parsed_hostname, self.word)
+                if scoped_hostname is None:
+                    return None, False
+                port = f':{parsed.port}' if parsed.port is not None else ''
+                return (
+                    urlunsplit((parsed.scheme.lower(), f'{scoped_hostname}{port}', parsed.path, parsed.query, parsed.fragment)),
+                    False,
+                )
+            if not parsed.path.startswith('/'):
+                return None, True
+            return urlunsplit(('https', hostname, parsed.path, parsed.query, parsed.fragment)), False
+        except (UnicodeError, ValueError):
+            return None, True
+
+    def _extract_technology(self, technology: object) -> bool:
+        if not isinstance(technology, dict):
+            return True
+        name = technology.get('Name')
+        if not isinstance(name, str) or not (name := name.strip()):
+            return True
+
+        malformed = False
+        categories: list[str] = []
+        tag = technology.get('Tag')
+        if tag is not None:
+            if isinstance(tag, str):
+                if tag := tag.strip():
+                    categories.append(tag)
+                else:
+                    malformed = True
+            else:
+                malformed = True
+        nested_categories = technology.get('Categories')
+        if nested_categories is not None:
+            if not isinstance(nested_categories, list):
+                malformed = True
+            else:
+                for category in nested_categories:
+                    if isinstance(category, str) and (category := category.strip()):
+                        categories.append(category)
+                    else:
+                        malformed = True
+
+        if not categories:
+            return True
+
+        category_text = ' '.join(categories).lower()
+        for category, results in (
+            ('framework', self.frameworks),
+            ('language', self.languages),
+            ('server', self.servers),
+            ('cms', self.cms),
+            ('analytics', self.analytics),
+        ):
+            if category in category_text:
+                results.add(name)
+                break
+        return malformed
+
+    def _extract_data(self) -> bool:
+        results = self.tech_stack.get('Results')
+        if not isinstance(results, list):
+            return True
+        malformed = False
+        for envelope in results:
+            if not isinstance(envelope, dict) or not isinstance(envelope.get('Result'), dict):
+                malformed = True
+                continue
+            paths = envelope['Result'].get('Paths')
+            if not isinstance(paths, list):
+                malformed = True
+                continue
+            for path in paths:
+                if not isinstance(path, dict):
+                    malformed = True
+                    continue
+                hostname, path_malformed = self._path_hostname(path)
+                malformed = path_malformed or malformed
+                if hostname is None:
+                    continue
+                self.hosts.add(hostname)
+                path_url, url_malformed = self._path_url(path.get('Url'), hostname)
+                malformed = url_malformed or malformed
+                if path_url is not None:
+                    self.urls.add(path_url)
+                technologies = path.get('Technologies')
+                if not isinstance(technologies, list):
+                    malformed = True
+                    continue
+                for technology in technologies:
+                    malformed = self._extract_technology(technology) or malformed
+        return malformed
 
     async def process(self, proxy: bool = False) -> None:
-        """Get technology stack information for a domain."""
+        headers = {
+            'Accept': 'application/json',
+            'Authorization': f'API {self.api_key}',
+            'User-Agent': Core.get_user_agent(),
+        }
+        params = {
+            'HIDEDL': 'yes',
+            'LOOKUP': self.lookup_domain,
+            'NOATTR': 'yes',
+            'NOMETA': 'yes',
+            'NOPII': 'yes',
+        }
         try:
-            if proxy:
-                response = await AsyncFetcher.fetch(
-                    session=None, url=f'{self.base_url}?KEY={self.api_key}&LOOKUP={self.word}', headers=self.headers, proxy=proxy
-                )
-                if response:
-                    self.tech_stack = response
-                    self._extract_data()
-            else:
-                async with aiohttp.ClientSession(headers=self.headers) as session:
-                    async with session.get(f'{self.base_url}?KEY={self.api_key}&LOOKUP={self.word}') as response:
-                        if response.status == 200:
-                            data = await response.json(content_type=None)
-                            self.tech_stack = data
-                            self._extract_data()
-        except Exception as e:
-            logger.info(f'Error in BuiltWith search: {e}')
+            response = await AsyncFetcher.fetch_json(
+                self.SERVER,
+                params=params,
+                proxy=proxy,
+                headers=headers,
+            )
+        except ResponseStreamError as error:
+            self._stop('failed', error.reason)
+            return
+        except Exception:
+            self._stop('failed', 'transport-error')
+            return
+        if not isinstance(response, FetcherResponse):
+            self._stop('failed', 'transport-error')
+            return
+        if response.status in {401, 403}:
+            self._stop('failed', 'access-denied')
+            return
+        if response.status == 429:
+            self._stop('rate-limited', 'http-429')
+            return
+        if not 200 <= response.status < 300 or not isinstance(response.body, dict):
+            reason = f'http-{response.status}' if not 200 <= response.status < 300 else 'invalid-response'
+            self._stop('failed', reason)
+            return
+        if not isinstance(response.body.get('Results'), list):
+            self._stop('failed', 'invalid-response')
+            return
 
-    def _extract_data(self) -> None:
-        """Extract and categorize technology information."""
-        if 'domains' in self.tech_stack:
-            self.hosts.update(self.tech_stack['domains'])
-        if 'paths' in self.tech_stack:
-            self.urls.update(self.tech_stack['paths'])
-        if 'technologies' in self.tech_stack:
-            for tech in self.tech_stack['technologies']:
-                if not isinstance(tech, dict):
-                    continue
-                category = tech.get('category')
-                name = tech.get('name')
-                if not isinstance(category, str) or not isinstance(name, str) or not name.strip():
-                    continue
-                category = category.lower()
-                name = name.strip()
-
-                if 'framework' in category:
-                    self.frameworks.add(name)
-                elif 'language' in category:
-                    self.languages.add(name)
-                elif 'server' in category:
-                    self.servers.add(name)
-                elif 'cms' in category:
-                    self.cms.add(name)
-                elif 'analytics' in category:
-                    self.analytics.add(name)
+        self.tech_stack = response.body
+        if self._extract_data():
+            self._stop('failed', 'invalid-response')
+        else:
+            self.execution_status = 'completed'
+            self.stop_reason = None if self._has_results() else 'no-results'
 
     async def get_hostnames(self) -> set[str]:
         return self.hosts
 
-    async def get_tech_stack(self) -> dict:
+    async def get_tech_stack(self) -> dict[str, Any]:
         return self.tech_stack
 
     async def get_urls(self) -> set[str]:

--- a/theHarvester/discovery/builtwith.py
+++ b/theHarvester/discovery/builtwith.py
@@ -5,8 +5,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse, ResponseStreamError
-from theHarvester.lib.hostnames import normalize_scoped_hostname
-from theHarvester.lib.virtual_host import normalize_virtual_host_hostname
+from theHarvester.lib.hostnames import normalize_hostname, normalize_scoped_hostname
 
 
 class SearchBuiltWith:
@@ -15,7 +14,7 @@ class SearchBuiltWith:
     SERVER = 'https://api.builtwith.com/v23/api.json'
 
     def __init__(self, word: str) -> None:
-        self.word = normalize_virtual_host_hostname(word)
+        self.word = normalize_hostname(word)
         self.lookup_domain = self.word.removeprefix('www.')
         self.api_key = Core.builtwith_key()
         if not isinstance(self.api_key, str) or not self.api_key.strip():
@@ -45,7 +44,7 @@ class SearchBuiltWith:
         if not isinstance(domain, str) or not isinstance(subdomain, str):
             return None, True
         try:
-            domain = normalize_virtual_host_hostname(domain)
+            domain = normalize_hostname(domain)
         except ValueError:
             return None, True
         normalized_domain = normalize_scoped_hostname(domain, self.lookup_domain)
@@ -53,7 +52,7 @@ class SearchBuiltWith:
             return None, False
         candidate = normalized_domain if not subdomain.strip() else f'{subdomain.strip()}.{normalized_domain}'
         try:
-            candidate = normalize_virtual_host_hostname(candidate)
+            candidate = normalize_hostname(candidate)
         except ValueError:
             return None, True
         return normalize_scoped_hostname(candidate, self.word), False
@@ -73,7 +72,7 @@ class SearchBuiltWith:
                     or parsed.password is not None
                 ):
                     return None, True
-                parsed_hostname = normalize_virtual_host_hostname(parsed.hostname)
+                parsed_hostname = normalize_hostname(parsed.hostname)
                 scoped_hostname = normalize_scoped_hostname(parsed_hostname, self.word)
                 if scoped_hostname is None:
                     return None, False

--- a/theHarvester/lib/asn_attribution.py
+++ b/theHarvester/lib/asn_attribution.py
@@ -7,8 +7,8 @@ from ipaddress import ip_address
 from typing import Literal, cast
 
 from theHarvester.lib.evidence_types import format_utc
+from theHarvester.lib.hostnames import normalize_hostname
 from theHarvester.lib.result_values import normalize_asn
-from theHarvester.lib.virtual_host import normalize_virtual_host_hostname
 
 ProducerKind = Literal['source', 'action']
 SubjectKind = Literal['hostname', 'ip']
@@ -29,7 +29,7 @@ def _normalize_name(value: str, label: str, *, max_length: int = 255) -> str:
 
 def _normalize_subject(kind: SubjectKind, value: str) -> str:
     if kind == 'hostname':
-        return normalize_virtual_host_hostname(value)
+        return normalize_hostname(value)
     if kind == 'ip':
         if not isinstance(value, str) or '%' in value:
             raise ValueError('ASN attribution IP subject must be a canonical IP address')

--- a/theHarvester/lib/completed_result.py
+++ b/theHarvester/lib/completed_result.py
@@ -22,6 +22,7 @@ from theHarvester.lib.evidence_types import (
     ResultKind,
     format_utc,
 )
+from theHarvester.lib.hostnames import normalize_hostname
 from theHarvester.lib.network_evidence import (
     BgpRouteObservation,
     NetworkObservation,
@@ -33,7 +34,7 @@ from theHarvester.lib.network_evidence import (
 )
 from theHarvester.lib.result_values import normalize_result_value
 from theHarvester.lib.shodan_evidence import ShodanHostObservation, canonical_shodan_hosts
-from theHarvester.lib.virtual_host import VirtualHostObservation, normalize_virtual_host_hostname
+from theHarvester.lib.virtual_host import VirtualHostObservation
 
 
 def virtual_host_details(observations: Iterable[VirtualHostObservation]) -> list[dict[str, object]]:
@@ -274,7 +275,7 @@ class CompletedResult:
             raise ValueError('virtual-host observations must be deduplicated and sorted')
         if self.virtual_hosts:
             try:
-                virtual_host_scope = normalize_virtual_host_hostname(self.target)
+                virtual_host_scope = normalize_hostname(self.target)
             except ValueError as error:
                 raise ValueError('virtual-host observations require a hostname run target scope') from error
         for observation in self.virtual_hosts:

--- a/theHarvester/lib/hostnames.py
+++ b/theHarvester/lib/hostnames.py
@@ -1,3 +1,33 @@
+import ipaddress
+
+
+def normalize_hostname(value: str) -> str:
+    hostname = value.strip().rstrip('.').lower()
+    if not hostname:
+        raise ValueError('hostname must not be empty')
+    try:
+        hostname = hostname.encode('idna').decode('ascii')
+    except UnicodeError as error:
+        raise ValueError('hostname must be valid') from error
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    else:
+        raise ValueError('hostname must not be an IP address')
+    labels = hostname.split('.')
+    if len(hostname) > 253 or any(
+        not label
+        or len(label) > 63
+        or label.startswith('-')
+        or label.endswith('-')
+        or not all(character.isalnum() or character == '-' for character in label)
+        for label in labels
+    ):
+        raise ValueError('hostname must be valid')
+    return hostname
+
+
 def normalize_scoped_hostname(value: object, target: str) -> str | None:
     """Return a canonical hostname when value is inside the target boundary."""
     if not isinstance(value, str):

--- a/theHarvester/lib/virtual_host.py
+++ b/theHarvester/lib/virtual_host.py
@@ -15,6 +15,8 @@ from urllib.parse import urlsplit
 
 import aiohttp
 
+from theHarvester.lib.hostnames import normalize_hostname
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -63,33 +65,6 @@ class VirtualHostLimits:
             raise ValueError('virtual-host concurrency must be positive')
 
 
-def normalize_virtual_host_hostname(value: str) -> str:
-    hostname = value.strip().rstrip('.').lower()
-    if not hostname:
-        raise ValueError('virtual-host candidate must not be empty')
-    try:
-        hostname = hostname.encode('idna').decode('ascii')
-    except UnicodeError as error:
-        raise ValueError('virtual-host candidate must be a valid hostname') from error
-    try:
-        ipaddress.ip_address(hostname)
-    except ValueError:
-        pass
-    else:
-        raise ValueError('virtual-host candidate must be a hostname, not an IP address')
-    labels = hostname.split('.')
-    if len(hostname) > 253 or any(
-        not label
-        or len(label) > 63
-        or label.startswith('-')
-        or label.endswith('-')
-        or not all(character.isalnum() or character == '-' for character in label)
-        for label in labels
-    ):
-        raise ValueError('virtual-host candidate must be a valid hostname')
-    return hostname
-
-
 def _candidate_shape(candidate: str, scope: str) -> tuple[int, ...]:
     if candidate == scope:
         return (1,)
@@ -120,10 +95,10 @@ def normalize_virtual_host_endpoint(endpoint: str) -> str:
 
 
 def normalize_virtual_host_candidates(scope: str, candidates: tuple[str, ...]) -> tuple[str, ...]:
-    normalized_scope = normalize_virtual_host_hostname(scope)
+    normalized_scope = normalize_hostname(scope)
     normalized_candidates: list[str] = []
     for candidate in candidates:
-        normalized = normalize_virtual_host_hostname(candidate)
+        normalized = normalize_hostname(candidate)
         if normalized != normalized_scope and not normalized.endswith(f'.{normalized_scope}'):
             raise ValueError(f'virtual-host candidate is outside authorized scope: {candidate}')
         if normalized not in normalized_candidates:
@@ -149,7 +124,7 @@ class VirtualHostRequest:
         insecure: bool = False,
     ) -> None:
         normalized_endpoint = normalize_virtual_host_endpoint(endpoint)
-        normalized_scope = normalize_virtual_host_hostname(scope)
+        normalized_scope = normalize_hostname(scope)
         normalized_candidates = normalize_virtual_host_candidates(normalized_scope, candidates)
         if not normalized_candidates:
             raise ValueError('virtual-host discovery requires at least one candidate')
@@ -248,7 +223,7 @@ class VirtualHostObservation:
         endpoint_value = record.get('endpoint')
         if not isinstance(hostname_value, str) or not isinstance(endpoint_value, str):
             raise ValueError('virtual-host record must identify an endpoint and hostname')
-        hostname = normalize_virtual_host_hostname(hostname_value)
+        hostname = normalize_hostname(hostname_value)
         endpoint = normalize_virtual_host_endpoint(endpoint_value)
         parsed = urlsplit(endpoint)
         port = parsed.port or (443 if parsed.scheme == 'https' else 80)
@@ -948,7 +923,7 @@ async def discover_harvested_virtual_hosts(
     request_error_count = 0
     request_error_types: set[str] = set()
     scan_error_type: str | None = None
-    normalized_scope = normalize_virtual_host_hostname(scope)
+    normalized_scope = normalize_hostname(scope)
     normalized_candidates = normalize_virtual_host_candidates(normalized_scope, candidates)
     endpoints = (normalize_virtual_host_endpoint(endpoint_override),) if endpoint_override else _harvested_endpoints(addresses)
     total_endpoint_count = len(endpoints)


### PR DESCRIPTION
## Summary

- migrate BuiltWith lookup to the current v23 Domain API
- send the API key via `Authorization: API ...` and request privacy-preserving response controls
- parse the documented nested result, path, technology, and category shapes, including scoped subdomains
- retain target scope, normalized evidence, truthful partial/failure status, and native cancellation
- move generic hostname normalization to `lib/hostnames.py` so BuiltWith does not depend on the active virtual-host probing module

## Verification

- focused BuiltWith, virtual-host, completed-result, persistence, API, and CLI tests: 303 passed
- full offline pytest: 1,216 passed, 6 skipped, 26 deselected
- Ruff check and format check passed
- mypy passed for 104 source files
- `git diff --check` passed

Provider behavior is covered with offline fixtures; no live BuiltWith or target traffic was used.

Tracks fork issue: https://github.com/NotoriousRebel/theHarvester/issues/281
