### PR TITLE
fix: polish HarvestView evidence review

### DIFF
--- a/tests/e2e/test_harvestview.py
+++ b/tests/e2e/test_harvestview.py
@@ -777,11 +777,19 @@ def test_harvestview_summarizes_routeviews_prefix_evidence(
     expect(result_row).to_contain_text('path 64496 64500 · communities 64500:1')
 
 
+@pytest.mark.parametrize(
+    ('viewport_width', 'viewport_height'),
+    [(1440, 900), (1024, 768), (820, 1180), (390, 844)],
+    ids=['desktop', 'desktop-compact', 'tablet', 'mobile'],
+)
 def test_hostname_actions_queue_isolated_runs(
     harvestview_server_url: str,
     page: Page,
     browser_failures,
+    viewport_width: int,
+    viewport_height: int,
 ) -> None:
+    page.set_viewport_size({'width': viewport_width, 'height': viewport_height})
     browser_failures.allow_response('POST', 503, '/api/v1/runs')
     browser_failures.allow_response('POST', 503, '/api/v1/runs')
     browser_failures.allow_console_error(
@@ -847,6 +855,7 @@ def test_hostname_actions_queue_isolated_runs(
     page.goto(f'{harvestview_server_url}/')
 
     expect(page.get_by_role('button', name='Hostnames 1')).to_be_enabled()
+    assert page.evaluate('document.documentElement.scrollWidth <= document.documentElement.clientWidth')
 
     page.locator('#provider-details summary').click()
     expect(page.locator('#provider-title')).to_have_text('Execution outcomes')
@@ -863,6 +872,7 @@ def test_hostname_actions_queue_isolated_runs(
     expect(review).to_contain_text('api.example.com')
     expect(review).to_contain_text('P2 · Direct interaction')
     expect(review).to_contain_text('Creates a separate finite run')
+    assert page.evaluate('document.documentElement.scrollWidth <= document.documentElement.clientWidth')
     assert submissions == []
     review.get_by_role('button', name='Start screenshot run').click()
     expect(page.locator('#toast')).to_contain_text('Screenshot captured')
@@ -882,6 +892,7 @@ def test_hostname_actions_queue_isolated_runs(
             'dns_resolvers': ['192.0.2.53'],
         },
     ]
+    assert page.evaluate('document.documentElement.scrollWidth <= document.documentElement.clientWidth')
 
 
 def test_accepted_result_action_is_not_reported_as_failed_when_refresh_fails(
@@ -1279,6 +1290,51 @@ def test_empty_terminal_run_explains_its_lifecycle(
     expect(page.locator('#results-empty-copy')).to_contain_text('The retained evidence record is partial.')
 
 
+def test_failed_run_with_retained_evidence_puts_assessment_before_results(
+    harvestview_server_url: str,
+    page: Page,
+) -> None:
+    run = {
+        'run_id': 'failed-evidence-run',
+        'target': 'example.com',
+        'status': 'failed',
+        'origin': 'local',
+        'created_at': '2026-08-05T12:00:00+00:00',
+        'started_at': '2026-08-05T12:00:01+00:00',
+        'completed_at': '2026-08-05T12:00:02+00:00',
+        'cancellation_requested_at': None,
+        'evidence_status': 'partial',
+        'result_count': 1,
+        'activities': ['P0'],
+        'sources': ['crtsh'],
+        'request': {'sources': ['crtsh'], 'limit': 25, 'deadline_seconds': 300},
+        'source_executions': [
+            {
+                'source': 'crtsh',
+                'status': 'partial',
+                'result_count': 1,
+                'duration_ms': 1000,
+                'error_type': 'TimeoutError',
+                'stop_reason': 'timeout',
+            }
+        ],
+        'results': [{'type': 'hostname', 'value': 'api.example.com', 'sources': ['crtsh']}],
+        'screenshots': [],
+        'log': '',
+        'error': 'Provider process exited.',
+    }
+    page.route(f'{harvestview_server_url}/api/v1/runs', lambda route: route.fulfill(json=[run]))
+    page.route(f'{harvestview_server_url}/api/v1/runs/{run["run_id"]}', lambda route: route.fulfill(json=run))
+
+    page.goto(f'{harvestview_server_url}/')
+
+    expect(page.locator('#assessment-evidence')).to_contain_text('Partial')
+    expect(page.get_by_role('button', name='Hostnames 1')).to_be_enabled()
+    assert page.locator('.run-assessment').evaluate(
+        "node => Boolean(node.compareDocumentPosition(document.querySelector('#results-section')) & Node.DOCUMENT_POSITION_FOLLOWING)"
+    )
+
+
 def test_completed_empty_import_explains_terminal_outcome(
     harvestview_server_url: str,
     page: Page,
@@ -1436,7 +1492,7 @@ def test_harvestview_can_import_and_analyze_fixture_evidence_through_the_real_ui
     assert page.locator('#results-title').evaluate(
         "node => Boolean(node.compareDocumentPosition(document.querySelector('#lifecycle-title')) & Node.DOCUMENT_POSITION_FOLLOWING)"
     )
-    assert page.locator('#run-facts').evaluate(
+    assert page.locator('.run-assessment').evaluate(
         "node => Boolean(node.compareDocumentPosition(document.querySelector('#results-title')) & Node.DOCUMENT_POSITION_FOLLOWING)"
     )
 
@@ -1460,7 +1516,17 @@ def test_harvestview_can_import_and_analyze_fixture_evidence_through_the_real_ui
     expect(asn_route).to_have_attribute('aria-pressed', 'true')
     expect(asn_route).to_be_focused()
     asn_route.press('ArrowLeft')
-    expect(page.get_by_role('button', name='IP addresses 2')).to_be_focused()
+    expect(ip_route).to_be_focused()
+    route_buttons = page.locator('#route-tabs [data-route]')
+    assert page.locator('#route-tabs [data-route][tabindex="-1"]').count() == route_buttons.count() - 1
+    ip_route.press('End')
+    expect(route_buttons.last).to_be_focused()
+    expect(route_buttons.last).to_have_attribute('aria-pressed', 'true')
+    route_buttons.last.press('Home')
+    expect(route_buttons.first).to_be_focused()
+    expect(route_buttons.first).to_have_attribute('aria-pressed', 'true')
+    ip_route.click()
+    expect(ip_route).to_have_attribute('tabindex', '0')
     expect(page.locator('#route-count')).to_have_text('2')
     value_column = page.locator('.tabulator-col[tabulator-field="value"]')
     value_filter = value_column.locator('.tabulator-header-filter input')
@@ -1535,7 +1601,15 @@ def test_harvestview_can_import_and_analyze_fixture_evidence_through_the_real_ui
     page.set_viewport_size({'width': 390, 'height': 844})
     assert page.locator('.version-badge').evaluate('node => parseFloat(getComputedStyle(node).fontSize)') >= 11
     assert page.locator('.run-meta').first.evaluate('node => parseFloat(getComputedStyle(node).fontSize)') >= 12
-    assert page.get_by_role('checkbox', name='Select hostname.example.com').bounding_box()['width'] >= 24
+    assert page.locator('.source-choice small').first.evaluate('node => parseFloat(getComputedStyle(node).fontSize)') >= 16
+    assert page.locator('.action-choice small').first.evaluate('node => parseFloat(getComputedStyle(node).fontSize)') >= 16
+    assert page.locator('#final-authorization-summary').evaluate('node => parseFloat(getComputedStyle(node).fontSize)') >= 16
+    row_checkbox = page.get_by_role('checkbox', name='Select hostname.example.com').bounding_box()
+    header_checkbox = page.get_by_role('checkbox', name='Select all rows on this route').bounding_box()
+    assert row_checkbox['width'] >= 44
+    assert row_checkbox['height'] >= 44
+    assert header_checkbox['width'] >= 44
+    assert header_checkbox['height'] >= 44
     expect(page.locator('#provider-outcome-summary')).to_be_visible()
     expect(page.get_by_role('columnheader', name='Outcome')).to_be_visible()
     expect(page.get_by_role('columnheader', name='Results')).to_be_hidden()

--- a/tests/e2e/test_harvestview.py
+++ b/tests/e2e/test_harvestview.py
@@ -820,7 +820,13 @@ def test_hostname_actions_queue_isolated_runs(
                 'stop_reason': 'query-errors',
             }
         ],
-        'results': [{'type': 'hostname', 'value': 'api.example.com'}],
+        'results': [
+            {
+                'type': 'hostname',
+                'value': 'api.example.com',
+                'observations': [{'endpoint': 'https://192.0.2.10', 'status': 200}],
+            }
+        ],
         'screenshots': [],
         'log': '',
         'error': None,
@@ -849,6 +855,8 @@ def test_hostname_actions_queue_isolated_runs(
     expect(action_row).to_contain_text('failed')
     expect(action_row).to_contain_text('TimeoutError')
 
+    collapsed_actions = page.locator('.tabulator-responsive-collapse').get_by_text('Actions', exact=True)
+    expect(collapsed_actions).to_be_visible()
     page.get_by_role('button', name='Take screenshot of api.example.com (P2)').click()
     review = page.locator('#result-action-dialog')
     expect(review.get_by_role('heading')).to_have_text('Review screenshot interaction')
@@ -1305,9 +1313,9 @@ def test_completed_empty_import_explains_terminal_outcome(
         'crtsh returned no normalized evidence. The retained evidence record is complete.'
     )
     expect(page.locator('#lifecycle-track strong')).to_have_text(['Original started', 'Original completed', 'Imported'])
-    expect(page.get_by_role('button', name='All JSONL')).to_be_enabled()
+    expect(page.get_by_role('button', name='Export all JSONL')).to_be_enabled()
     with page.expect_download() as jsonl_download:
-        page.get_by_role('button', name='All JSONL').click()
+        page.get_by_role('button', name='Export all JSONL').click()
     exported_records = [json.loads(line) for line in Path(jsonl_download.value.path()).read_text(encoding='utf-8').splitlines()]
     assert len(exported_records) == 1
     assert exported_records[0]['evidence_status'] == 'complete'
@@ -1428,8 +1436,8 @@ def test_harvestview_can_import_and_analyze_fixture_evidence_through_the_real_ui
     assert page.locator('#results-title').evaluate(
         "node => Boolean(node.compareDocumentPosition(document.querySelector('#lifecycle-title')) & Node.DOCUMENT_POSITION_FOLLOWING)"
     )
-    assert page.locator('#results-title').evaluate(
-        "node => Boolean(node.compareDocumentPosition(document.querySelector('#run-facts')) & Node.DOCUMENT_POSITION_FOLLOWING)"
+    assert page.locator('#run-facts').evaluate(
+        "node => Boolean(node.compareDocumentPosition(document.querySelector('#results-title')) & Node.DOCUMENT_POSITION_FOLLOWING)"
     )
 
     missing_credentials_row = page.locator('#provider-body tr').filter(has_text=ordered_sources[23]['name'])
@@ -1443,7 +1451,16 @@ def test_harvestview_can_import_and_analyze_fixture_evidence_through_the_real_ui
     page.locator('#history-search').fill('not-present')
     expect(page.locator('#history-empty')).to_be_visible()
     page.locator('#history-search').fill('')
-    page.get_by_role('button', name='IP addresses 2').click()
+    ip_route = page.get_by_role('button', name='IP addresses 2')
+    ip_route.click()
+    expect(ip_route).to_have_attribute('tabindex', '0')
+    ip_route.focus()
+    ip_route.press('ArrowRight')
+    asn_route = page.get_by_role('button', name='ASNs 1')
+    expect(asn_route).to_have_attribute('aria-pressed', 'true')
+    expect(asn_route).to_be_focused()
+    asn_route.press('ArrowLeft')
+    expect(page.get_by_role('button', name='IP addresses 2')).to_be_focused()
     expect(page.locator('#route-count')).to_have_text('2')
     value_column = page.locator('.tabulator-col[tabulator-field="value"]')
     value_filter = value_column.locator('.tabulator-header-filter input')
@@ -1469,6 +1486,7 @@ def test_harvestview_can_import_and_analyze_fixture_evidence_through_the_real_ui
 
     resize_handles = page.locator('.tabulator-header .tabulator-col-resize-handle')
     expect(resize_handles).to_have_count(2)
+    page.locator('#result-workbench').scroll_into_view_if_needed()
     selection_column_width = page.locator('.tabulator-header .tabulator-row-header').bounding_box()['width']
     assert 40 <= selection_column_width <= 56
     resize_handle = resize_handles.first
@@ -1487,7 +1505,7 @@ def test_harvestview_can_import_and_analyze_fixture_evidence_through_the_real_ui
     assert page.evaluate('navigator.clipboard.readText()') == '192.0.2.10'
 
     with page.expect_download() as jsonl_download:
-        page.get_by_role('button', name='All JSONL').click()
+        page.get_by_role('button', name='Export all JSONL').click()
     exported_records = [json.loads(line) for line in Path(jsonl_download.value.path()).read_text(encoding='utf-8').splitlines()]
     assert exported_records[0]['type'] == 'summary'
     assert exported_records[0]['evidence_status'] == 'partial'
@@ -1495,6 +1513,9 @@ def test_harvestview_can_import_and_analyze_fixture_evidence_through_the_real_ui
 
     page.get_by_role('button', name='Start enumeration').first.click()
     expect(page.locator('#new-run-dialog').get_by_text('Credentials required:', exact=False).first).to_be_visible()
+    assert page.locator('.source-choice small').first.evaluate('node => parseFloat(getComputedStyle(node).fontSize)') >= 12
+    assert page.locator('.action-choice small').first.evaluate('node => parseFloat(getComputedStyle(node).fontSize)') >= 12
+    assert page.locator('#final-authorization-summary').evaluate('node => parseFloat(getComputedStyle(node).fontSize)') >= 12
     page.get_by_role('button', name='Select all P0').click()
     assert page.locator('[data-activity="P0"] input:checked').count() == len(
         [source for source in passive_sources if source['ready']]
@@ -1512,6 +1533,9 @@ def test_harvestview_can_import_and_analyze_fixture_evidence_through_the_real_ui
     assert page.locator('.app-shell').evaluate("node => getComputedStyle(node).display === 'block'")
     assert page.evaluate('document.documentElement.scrollWidth <= document.documentElement.clientWidth')
     page.set_viewport_size({'width': 390, 'height': 844})
+    assert page.locator('.version-badge').evaluate('node => parseFloat(getComputedStyle(node).fontSize)') >= 11
+    assert page.locator('.run-meta').first.evaluate('node => parseFloat(getComputedStyle(node).fontSize)') >= 12
+    assert page.get_by_role('checkbox', name='Select hostname.example.com').bounding_box()['width'] >= 24
     expect(page.locator('#provider-outcome-summary')).to_be_visible()
     expect(page.get_by_role('columnheader', name='Outcome')).to_be_visible()
     expect(page.get_by_role('columnheader', name='Results')).to_be_hidden()

--- a/theHarvester/lib/api/static/harvestview/app.css
+++ b/theHarvester/lib/api/static/harvestview/app.css
@@ -776,6 +776,12 @@ dialog[open] { animation: dialog-in 180ms cubic-bezier(0.22, 1, 0.36, 1); }
   .request-options { grid-template-columns: 1fr; }
   .source-groups { max-height: none; grid-template-columns: 1fr; overflow: visible; }
   .source-selection-summary { position: static; }
+  .source-choice small,
+  .action-choice small,
+  .source-selection-summary,
+  .activity-summary,
+  .final-authorization-review strong,
+  .final-authorization-review span { font-size: 16px; }
   .source-tools { align-items: stretch; flex-direction: column; }
   .source-actions .button { flex: 1; }
   .action-grid { grid-template-columns: 1fr 1fr; }
@@ -787,7 +793,49 @@ dialog[open] { animation: dialog-in 180ms cubic-bezier(0.22, 1, 0.36, 1); }
   .table-toolbar input { width: 100%; }
   .table-guidance { max-width: none; }
   .tabulator .tabulator-header .tabulator-col .tabulator-header-filter input { min-height: 44px; }
-  .tabulator input[type="checkbox"] { width: 24px; height: 24px; }
+  .tabulator input[type="checkbox"] {
+    position: relative;
+    display: inline-grid;
+    width: 44px;
+    height: 44px;
+    margin: 0;
+    padding: 0;
+    appearance: none;
+    place-items: center;
+    background: transparent;
+    border: 0;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .tabulator input[type="checkbox"]::before {
+    width: 24px;
+    height: 24px;
+    content: "";
+    background: var(--surface-raised);
+    border: 1px solid var(--line-strong);
+    border-radius: 4px;
+  }
+  .tabulator input[type="checkbox"]::after {
+    position: absolute;
+    width: 7px;
+    height: 12px;
+    content: "";
+    border-inline-end: 2px solid var(--nav);
+    border-block-end: 2px solid var(--nav);
+    opacity: 0;
+    transform: translateY(-2px) rotate(45deg);
+  }
+  .tabulator input[type="checkbox"]:checked::before,
+  .tabulator input[type="checkbox"]:indeterminate::before { background: var(--accent-strong); border-color: var(--accent-strong); }
+  .tabulator input[type="checkbox"]:checked::after { opacity: 1; }
+  .tabulator input[type="checkbox"]:indeterminate::after {
+    width: 10px;
+    height: 2px;
+    background: var(--nav);
+    border: 0;
+    opacity: 1;
+    transform: none;
+  }
   .tabulator .tabulator-footer .tabulator-footer-contents { justify-content: flex-start; white-space: normal; }
   .tabulator .tabulator-footer .tabulator-paginator { width: 100%; justify-content: flex-start; }
   .provider-table th:nth-child(5), .provider-table td:nth-child(5) { display: none; }

--- a/theHarvester/lib/api/static/harvestview/app.css
+++ b/theHarvester/lib/api/static/harvestview/app.css
@@ -219,7 +219,7 @@ a:focus-visible {
   color: var(--nav-muted);
   border: 1px solid var(--nav-line);
   border-radius: 999px;
-  font: 700 10px/1 var(--font-mono);
+  font: 700 11px/1 var(--font-mono);
   white-space: nowrap;
 }
 
@@ -366,8 +366,8 @@ a:focus-visible {
 .run-item.selected { background: var(--nav-raised); border-color: var(--accent); }
 .run-item.selected::before { background: var(--accent); }
 .run-target { min-width: 0; overflow: hidden; font-weight: 760; text-overflow: ellipsis; white-space: nowrap; }
-.run-meta { min-width: 0; overflow: hidden; color: var(--nav-muted); font: 11px/1.4 var(--font-mono); text-overflow: ellipsis; white-space: nowrap; }
-.run-results { align-self: end; color: var(--nav-muted); font: 11px/1 var(--font-mono); }
+.run-meta { min-width: 0; overflow: hidden; color: var(--nav-muted); font: 12px/1.4 var(--font-mono); text-overflow: ellipsis; white-space: nowrap; }
+.run-results { align-self: end; color: var(--nav-muted); font: 12px/1 var(--font-mono); }
 
 .history-empty { padding: 42px 10px; color: var(--nav-muted); text-align: center; }
 .history-empty span { display: block; font-size: 26px; }
@@ -401,10 +401,10 @@ a:focus-visible {
 .detail-header { display: flex; align-items: start; justify-content: space-between; gap: 24px; padding-block-end: 25px; border-block-end: 1px solid var(--line-strong); }
 .detail-identity { min-width: 0; }
 .detail-identity h2 { margin: 2px 0 5px; overflow-wrap: anywhere; font-size: clamp(31px, 4vw, 58px); line-height: 1; letter-spacing: -0.038em; text-wrap: balance; }
-.detail-run-id { margin: 0; overflow-wrap: anywhere; color: var(--muted); font-size: 11px; }
+.detail-run-id { margin: 0; overflow-wrap: anywhere; color: var(--muted); font-size: 12px; }
 .detail-status { display: flex; flex: 0 0 auto; flex-direction: column; align-items: end; gap: 12px; }
 .status-chips { display: flex; flex-wrap: wrap; justify-content: end; gap: 6px; }
-.provider-outcome-summary { margin: 5px 0 0; color: var(--muted); font-size: 11px; line-height: 1.4; }
+.provider-outcome-summary { margin: 5px 0 0; color: var(--muted); font-size: 12px; line-height: 1.4; }
 
 .status-chip {
   display: inline-flex;
@@ -430,7 +430,7 @@ a:focus-visible {
 .run-facts div { min-width: 0; padding: 17px 15px; border-inline-end: 1px solid var(--line); }
 .run-facts div:first-child { padding-inline-start: 0; }
 .run-facts div:last-child { border: 0; }
-.run-facts dt { color: var(--muted); font: 700 10px/1.2 var(--font-mono); letter-spacing: 0.08em; text-transform: uppercase; }
+.run-facts dt { color: var(--muted); font: 700 11px/1.2 var(--font-mono); letter-spacing: 0.08em; text-transform: uppercase; }
 .run-facts dd { margin: 6px 0 0; overflow-wrap: anywhere; font-weight: 720; }
 
 .run-assessment { margin-block: 24px 30px; border-block: 1px solid var(--line-strong); }
@@ -440,9 +440,9 @@ a:focus-visible {
 .assessment-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); margin: 0; border-block-start: 1px solid var(--line); }
 .assessment-grid > div { min-width: 0; padding: 15px 16px 17px 0; }
 .assessment-grid > div + div { padding-inline-start: 16px; border-inline-start: 1px solid var(--line); }
-.assessment-grid dt { color: var(--muted); font: 700 10px/1.2 var(--font-mono); letter-spacing: 0.08em; text-transform: uppercase; }
+.assessment-grid dt { color: var(--muted); font: 700 11px/1.2 var(--font-mono); letter-spacing: 0.08em; text-transform: uppercase; }
 .assessment-grid dd { margin: 6px 0 0; overflow-wrap: anywhere; font-size: 17px; font-weight: 760; }
-.assessment-grid dd small { display: block; margin-block-start: 4px; color: var(--muted); font-size: 11px; font-weight: 500; line-height: 1.4; }
+.assessment-grid dd small { display: block; margin-block-start: 4px; color: var(--muted); font-size: 12px; font-weight: 500; line-height: 1.4; }
 .assessment-review .button { margin-block-start: 10px; }
 
 .section-heading { display: flex; align-items: end; justify-content: space-between; gap: 18px; margin-block-end: 16px; }
@@ -494,8 +494,8 @@ a:focus-visible {
 .lifecycle-step::before { content: ""; position: absolute; inset: -6px auto auto 0; width: 10px; height: 10px; background: var(--surface-raised); border: 2px solid var(--line-strong); border-radius: 50%; }
 .lifecycle-step.reached { border-color: var(--accent); }
 .lifecycle-step.reached::before { background: var(--accent); border-color: var(--accent); }
-.lifecycle-step strong { display: block; overflow: hidden; font: 750 11px/1.3 var(--font-mono); text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
-.lifecycle-step span { display: block; margin-block-start: 5px; color: var(--muted); font-size: 11px; }
+.lifecycle-step strong { display: block; overflow: hidden; font: 750 12px/1.3 var(--font-mono); text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
+.lifecycle-step span { display: block; margin-block-start: 5px; color: var(--muted); font-size: 12px; }
 
 .overview-grid { display: grid; grid-template-columns: 1fr; border: 1px solid var(--line-strong); }
 .overview-panel { min-width: 0; padding: 20px; background: var(--surface); }
@@ -505,12 +505,12 @@ a:focus-visible {
 .activity-band.active.p0 { color: var(--accent-text); border-color: var(--accent); background: var(--accent-soft); }
 .activity-band.active.p1 { color: var(--warning); border-color: var(--warning); background: var(--warning-soft); }
 .activity-band.active.p2 { color: var(--danger); border-color: var(--danger); background: var(--danger-soft); }
-.activity-band strong { display: block; font: 800 11px/1 var(--font-mono); }
-.activity-band span { display: block; margin-block-start: 5px; font-size: 11px; }
+.activity-band strong { display: block; font: 800 12px/1 var(--font-mono); }
+.activity-band span { display: block; margin-block-start: 5px; font-size: 12px; }
 
 .request-options { display: grid; grid-template-columns: 1fr 1fr; margin: 0; }
 .request-options div { min-width: 0; padding: 8px 10px 8px 0; border-block-start: 1px solid var(--line); }
-.request-options dt { color: var(--muted); font-size: 11px; }
+.request-options dt { color: var(--muted); font-size: 12px; }
 .request-options dd { margin: 2px 0 0; overflow-wrap: anywhere; font: 12px/1.4 var(--font-mono); }
 
 .provider-table-wrap { max-height: 264px; overflow: auto; }
@@ -521,7 +521,7 @@ a:focus-visible {
 .provider-details summary #provider-title { margin-inline-end: auto; }
 .provider-table { width: 100%; border-collapse: collapse; }
 .provider-table th, .provider-table td { padding: 9px 8px; text-align: start; border-block-end: 1px solid var(--line); }
-.provider-table th { position: sticky; inset-block-start: 0; z-index: 1; color: var(--muted); background: var(--surface); font: 700 10px/1.2 var(--font-mono); letter-spacing: 0.06em; text-transform: uppercase; }
+.provider-table th { position: sticky; inset-block-start: 0; z-index: 1; color: var(--muted); background: var(--surface); font: 700 11px/1.2 var(--font-mono); letter-spacing: 0.06em; text-transform: uppercase; }
 .provider-table td:first-child { font-weight: 720; }
 .provider-table td:nth-child(4), .provider-table th:nth-child(4), .provider-table td:nth-child(5), .provider-table th:nth-child(5) { text-align: end; }
 .panel-empty { margin: 25px 0; color: var(--muted); text-align: center; }
@@ -529,7 +529,7 @@ a:focus-visible {
 .results-section { margin-block-start: 36px; }
 .results-heading { align-items: start; }
 .route-tabs { display: flex; overflow-x: auto; border-block-end: 1px solid var(--line-strong); scrollbar-width: thin; }
-.route-overflow-cue { display: none; margin: 7px 0 0; color: var(--muted); font-size: 12px; }
+.route-overflow-cue { margin: 7px 0 0; color: var(--muted); font-size: 12px; }
 .route-tab { display: inline-flex; min-height: 46px; flex: 0 0 auto; align-items: center; gap: 8px; padding: 8px 13px; color: var(--muted); background: transparent; border: 0; border-block-end: 3px solid transparent; font-weight: 720; }
 .route-tab:hover { color: var(--ink); background: var(--surface-muted); }
 .route-tab.active { color: var(--accent-text); border-color: var(--accent); }
@@ -539,7 +539,7 @@ a:focus-visible {
 .table-toolbar { display: flex; min-height: 60px; align-items: center; justify-content: space-between; gap: 16px; padding: 9px 12px; border-block-end: 1px solid var(--line); }
 .table-toolbar label { display: flex; align-items: center; gap: 9px; color: var(--muted); font-size: 12px; }
 .table-toolbar input { width: min(340px, 42vw); min-height: 44px; padding: 7px 10px; color: var(--ink); background: var(--surface-raised); border: 1px solid var(--line); border-radius: 6px; }
-.table-guidance { max-width: 34ch; margin: 0; color: var(--muted); font-size: 11px; line-height: 1.4; }
+.table-guidance { max-width: 34ch; margin: 0; color: var(--muted); font-size: 12px; line-height: 1.4; }
 .results-empty { padding: 54px 20px; color: var(--muted); text-align: center; border-block-end: 1px solid var(--line); }
 .results-empty span { font: 34px/1 var(--font-mono); }
 .results-empty h4 { margin: 11px 0 4px; color: var(--ink); }
@@ -594,10 +594,10 @@ a:focus-visible {
 .tabulator .tabulator-footer .tabulator-page.active { color: var(--nav); background: var(--accent); }
 .value-cell { overflow-wrap: anywhere; font-family: var(--font-mono); font-size: 12px; }
 .vhost-observations { display: grid; gap: 6px; overflow-wrap: anywhere; }
-.vhost-observations span { display: block; font: 11px/1.45 var(--font-mono); }
+.vhost-observations span { display: block; font: 12px/1.45 var(--font-mono); }
 .result-actions { display: flex; flex-wrap: wrap; gap: 6px; }
 .result-actions .button { flex: 1 1 118px; white-space: nowrap; }
-.dns-label { display: inline-flex; min-width: 82px; align-items: center; gap: 6px; font-size: 11px; font-weight: 750; }
+.dns-label { display: inline-flex; min-width: 82px; align-items: center; gap: 6px; font-size: 12px; font-weight: 750; }
 .dns-label::before { content: ""; width: 7px; height: 7px; background: currentColor; border-radius: 50%; }
 .dns-label.resolved { color: var(--success); }
 .dns-label.disputed, .dns-label.uncertain { color: var(--warning); }
@@ -615,7 +615,7 @@ a:focus-visible {
 
 .run-log { margin-block-start: 28px; color: var(--ink-soft); border-block: 1px solid var(--line); }
 .run-log summary { padding: 14px 4px; cursor: pointer; font-weight: 730; }
-.run-log pre { max-height: 360px; margin: 0 0 15px; padding: 15px; overflow: auto; color: var(--ink-soft); background: var(--surface-muted); font: 11px/1.5 var(--font-mono); white-space: pre-wrap; }
+.run-log pre { max-height: 360px; margin: 0 0 15px; padding: 15px; overflow: auto; color: var(--ink-soft); background: var(--surface-muted); font: 12px/1.5 var(--font-mono); white-space: pre-wrap; }
 
 dialog {
   max-width: calc(100vw - 28px);
@@ -666,21 +666,21 @@ dialog[open] { animation: dialog-in 180ms cubic-bezier(0.22, 1, 0.36, 1); }
 .source-group[data-activity="P0"] { border-color: var(--accent); }
 .source-group[data-activity="P1"] { border-color: var(--warning); }
 .source-group[data-activity="P2"] { border-color: var(--danger); }
-.source-group > summary { display: grid; min-height: 44px; grid-template-columns: 8px 1fr auto; align-items: center; gap: 9px; cursor: pointer; font: 800 11px/1 var(--font-mono); }
+.source-group > summary { display: grid; min-height: 44px; grid-template-columns: 8px 1fr auto; align-items: center; gap: 9px; cursor: pointer; font: 800 12px/1 var(--font-mono); }
 .source-group > summary::before { width: 6px; height: 6px; content: ''; border-inline-end: 2px solid currentcolor; border-block-end: 2px solid currentcolor; transform: rotate(45deg); transition: transform 120ms ease-out; }
 .source-group:not([open]) > summary::before { transform: rotate(-45deg); }
 .source-group > summary span { color: var(--muted); font-weight: 600; }
 .source-choice { display: flex; min-height: 44px; align-items: start; gap: 8px; padding: 9px 5px; border-block-start: 1px solid var(--line); font-weight: 650; }
 .source-choice input, .action-choice input { flex: 0 0 auto; width: 17px; height: 17px; margin-block-start: 2px; accent-color: var(--accent-strong); }
 .source-choice span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.source-choice small { display: block; overflow: hidden; font: 10px/1.35 var(--font-mono); text-overflow: ellipsis; white-space: nowrap; }
+.source-choice small { display: block; overflow: hidden; font: 12px/1.4 var(--font-mono); text-overflow: ellipsis; white-space: nowrap; }
 .source-choice .credential-note { color: var(--warning); }
 .source-choice.needs-configuration { color: var(--ink-soft); }
 .source-choice.needs-configuration input { cursor: not-allowed; }
 .source-choice .source-readiness { font-weight: 750; }
 .source-choice .source-readiness.ready { color: var(--accent-text); }
 .source-choice .source-readiness.blocked { color: var(--warning); }
-.source-selection-summary { margin: 10px 0 0; padding: 9px 11px; color: var(--ink-soft); background: var(--surface-raised); border: 1px solid var(--line); border-radius: 6px; font: 700 11px/1.4 var(--font-mono); }
+.source-selection-summary { margin: 10px 0 0; padding: 9px 11px; color: var(--ink-soft); background: var(--surface-raised); border: 1px solid var(--line); border-radius: 6px; font: 700 12px/1.4 var(--font-mono); }
 .source-group-empty { color: var(--muted); font-size: 12px; }
 
 .action-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 7px; }
@@ -690,7 +690,7 @@ dialog[open] { animation: dialog-in 180ms cubic-bezier(0.22, 1, 0.36, 1); }
 .action-choice.p2 { border-block-start-color: var(--danger); }
 .action-choice strong, .action-choice small { display: block; }
 .action-choice strong { line-height: 1.3; }
-.action-choice small { margin-block-start: 3px; font-size: 10px; line-height: 1.35; }
+.action-choice small { margin-block-start: 3px; font-size: 12px; line-height: 1.4; }
 .activity-summary { padding: 11px 13px; color: var(--ink) !important; background: var(--accent-soft); border: 1px solid var(--accent); font: 700 12px/1.4 var(--font-mono); }
 .form-error { margin: 12px 0 0; padding: 10px 12px; color: var(--danger) !important; background: var(--danger-soft); border: 1px solid var(--danger); font-weight: 650; }
 .dialog-actions { display: flex; justify-content: end; gap: 8px; margin-block-start: 24px; }
@@ -703,7 +703,7 @@ dialog[open] { animation: dialog-in 180ms cubic-bezier(0.22, 1, 0.36, 1); }
   color: var(--ink-soft);
 }
 .final-authorization-review strong { color: var(--ink); font-size: 12px; }
-.final-authorization-review span { font: 700 11px/1.45 var(--font-mono); overflow-wrap: anywhere; }
+.final-authorization-review span { font: 700 12px/1.45 var(--font-mono); overflow-wrap: anywhere; }
 #new-run-dialog .dialog-actions {
   position: sticky;
   z-index: var(--z-sticky);
@@ -717,7 +717,7 @@ dialog[open] { animation: dialog-in 180ms cubic-bezier(0.22, 1, 0.36, 1); }
 .action-review-grid div { min-width: 0; padding: 13px 14px; border-block-end: 1px solid var(--line); }
 .action-review-grid div:nth-child(odd) { border-inline-end: 1px solid var(--line); }
 .action-review-grid div:last-child { grid-column: 1 / -1; border-block-end: 0; border-inline-end: 0; }
-.action-review-grid dt { color: var(--muted); font: 700 10px/1.2 var(--font-mono); letter-spacing: 0.06em; text-transform: uppercase; }
+.action-review-grid dt { color: var(--muted); font: 700 11px/1.2 var(--font-mono); letter-spacing: 0.06em; text-transform: uppercase; }
 .action-review-grid dd { margin: 5px 0 0; overflow-wrap: anywhere; font-weight: 680; }
 
 .file-drop { position: relative; display: grid; min-height: 210px; margin-block-start: 22px; padding: 28px; place-items: center; align-content: center; text-align: center; background: var(--surface); border: 2px dashed var(--line-strong); border-radius: 9px; cursor: pointer; }
@@ -762,7 +762,6 @@ dialog[open] { animation: dialog-in 180ms cubic-bezier(0.22, 1, 0.36, 1); }
   .detail-header, .section-heading, .results-heading { align-items: start; flex-direction: column; }
   .detail-status { width: 100%; align-items: start; }
   .status-chips { justify-content: start; }
-  .route-overflow-cue { display: block; }
   .run-facts { grid-template-columns: 1fr 1fr; }
   .run-facts div, .run-facts div:nth-child(3), .run-facts div:nth-child(n+4) { padding: 12px 10px; border: 0; border-block-end: 1px solid var(--line); }
   .run-facts div:nth-child(odd) { padding-inline-start: 0; border-inline-end: 1px solid var(--line); }
@@ -788,6 +787,7 @@ dialog[open] { animation: dialog-in 180ms cubic-bezier(0.22, 1, 0.36, 1); }
   .table-toolbar input { width: 100%; }
   .table-guidance { max-width: none; }
   .tabulator .tabulator-header .tabulator-col .tabulator-header-filter input { min-height: 44px; }
+  .tabulator input[type="checkbox"] { width: 24px; height: 24px; }
   .tabulator .tabulator-footer .tabulator-footer-contents { justify-content: flex-start; white-space: normal; }
   .tabulator .tabulator-footer .tabulator-paginator { width: 100%; justify-content: flex-start; }
   .provider-table th:nth-child(5), .provider-table td:nth-child(5) { display: none; }
@@ -800,7 +800,7 @@ dialog[open] { animation: dialog-in 180ms cubic-bezier(0.22, 1, 0.36, 1); }
 @media (max-width: 500px) {
   .brand img { width: 38px; height: 38px; }
   .brand strong { font-size: 15px; }
-  .version-badge { padding: 3px 6px; font-size: 9px; }
+  .version-badge { padding: 3px 6px; font-size: 11px; }
   .header-button { font-size: 12px; }
   #theme-button { white-space: nowrap; }
   .detail-identity h2 { font-size: 34px; }

--- a/theHarvester/lib/api/static/harvestview/app.js
+++ b/theHarvester/lib/api/static/harvestview/app.js
@@ -37,7 +37,8 @@
     retryWorkspace: $('#retry-workspace-button'),
     runCount: $('#run-count'), historySearch: $('#history-search'), runList: $('#run-list'), historyEmpty: $('#history-empty'),
     detailTarget: $('#detail-target'), detailRunId: $('#detail-run-id'), statusChips: $('#status-chips'), cancel: $('#cancel-run-button'),
-    runFacts: $('#run-facts'), lifecycleTrack: $('#lifecycle-track'), lifecycleNote: $('#lifecycle-note'),
+    runFacts: $('#run-facts'), runAssessment: $('.run-assessment'),
+    lifecycleTrack: $('#lifecycle-track'), lifecycleNote: $('#lifecycle-note'),
     assessmentEvidence: $('#assessment-evidence'), assessmentProducers: $('#assessment-producers'),
     assessmentReview: $('#assessment-review'), reviewOutcomes: $('#review-outcomes-button'),
     resultsSection: $('#results-section'),
@@ -458,8 +459,8 @@
   function resultActionFormatter(cell) {
     const target = escapeHtml(cell.getRow().getData().value);
     return `<div class="result-actions">
-      <button class="button small" type="button" data-run-action="screenshot" aria-label="Take screenshot of ${target} (P2)">Screenshot (P2)</button>
-      <button class="button small" type="button" data-run-action="dns_brute" aria-label="DNS brute force ${target} (P1)">DNS brute (P1)</button>
+      <button class="button small" type="button" data-run-action="screenshot" data-run-target="${target}" aria-label="Take screenshot of ${target} (P2)">Screenshot (P2)</button>
+      <button class="button small" type="button" data-run-action="dns_brute" data-run-target="${target}" aria-label="DNS brute force ${target} (P1)">DNS brute (P1)</button>
     </div>`;
   }
 
@@ -701,12 +702,6 @@
       columns.push({
         title: 'Actions', field: 'actions', formatter: resultActionFormatter, headerSort: false,
         minWidth: 265, width: 265, responsive: 3, resizable: false,
-        cellClick: (event, cell) => {
-          const button = event.target.closest('[data-run-action]');
-          if (!button) return;
-          event.stopPropagation();
-          reviewResultAction(button.dataset.runAction, cell.getRow().getData().value, button);
-        },
       });
     }
     state.resultTable = new Tabulator(nodes.resultWorkbench.querySelector('#result-grid'), {
@@ -781,9 +776,10 @@
     }
     if (!groups.some(([type]) => type === state.route)) state.route = groups[0][0];
     nodes.routeTabs.innerHTML = groups.map(([type, results]) => `
-      <button class="route-tab ${type === state.route ? 'active' : ''}" type="button" data-route="${escapeHtml(type)}" aria-pressed="${type === state.route}">
+      <button class="route-tab ${type === state.route ? 'active' : ''}" type="button" data-route="${escapeHtml(type)}" aria-pressed="${type === state.route}" tabindex="${type === state.route ? '0' : '-1'}">
         ${escapeHtml(ROUTE_LABELS[type] || type)} <span class="count-badge">${results.length}</span>
       </button>`).join('');
+    requestAnimationFrame(updateRouteOverflowCue);
     const rows = groups.find(([type]) => type === state.route)?.[1] || [];
     nodes.routeCount.textContent = rows.length;
     nodes.resultSearch.value = '';
@@ -833,8 +829,10 @@
     nodes.cancel.hidden = !['queued', 'running', 'cancelling'].includes(run.status);
     nodes.cancel.disabled = run.status === 'cancelling';
     nodes.cancel.textContent = run.status === 'cancelling' ? 'Cancellation in progress' : 'Request cancellation';
-    if (isTerminalStatus(run.status)) {
+    if (isTerminalStatus(run.status) && run.status === 'completed' && run.evidence_status === 'complete') {
       nodes.detail.insertBefore(nodes.resultsSection, nodes.runFacts);
+    } else if (isTerminalStatus(run.status)) {
+      nodes.runAssessment.after(nodes.resultsSection);
     } else {
       nodes.detail.insertBefore(nodes.resultsSection, nodes.providerDetails);
     }
@@ -1284,6 +1282,10 @@
     }
   }
 
+  function updateRouteOverflowCue() {
+    nodes.routeOverflowCue.hidden = nodes.routeTabs.hidden || nodes.routeTabs.scrollWidth <= nodes.routeTabs.clientWidth + 1;
+  }
+
   function openScreenshot(index) {
     const screenshot = state.detail?.screenshots?.[index];
     const objectUrl = state.screenshotUrls.get(screenshot?.url);
@@ -1314,6 +1316,27 @@
   });
   nodes.exportJsonl.addEventListener('click', downloadServerExport);
   nodes.copySelected.addEventListener('click', copySelected);
+  nodes.resultWorkbench.addEventListener('click', event => {
+    const button = event.target.closest('[data-run-action]');
+    if (!button) return;
+    event.preventDefault();
+    event.stopPropagation();
+    reviewResultAction(button.dataset.runAction, button.dataset.runTarget, button);
+  }, true);
+  nodes.routeTabs.addEventListener('keydown', event => {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+    const buttons = [...nodes.routeTabs.querySelectorAll('[data-route]')];
+    if (!buttons.length) return;
+    event.preventDefault();
+    const current = Math.max(0, buttons.indexOf(event.target.closest('[data-route]')));
+    const next = event.key === 'Home'
+      ? 0
+      : event.key === 'End'
+        ? buttons.length - 1
+        : (current + (event.key === 'ArrowRight' ? 1 : -1) + buttons.length) % buttons.length;
+    buttons[next].click();
+    requestAnimationFrame(() => nodes.routeTabs.querySelector(`[data-route="${CSS.escape(state.route)}"]`)?.focus({preventScroll: true}));
+  });
   nodes.resultSearch.addEventListener('input', event => {
     const query = event.target.value.trim().toLowerCase();
     state.resultTable?.setFilter(row => !query || row.value.toLowerCase().includes(query));
@@ -1375,6 +1398,7 @@
     stopPolling();
     revokeScreenshots();
   });
+  window.addEventListener('resize', updateRouteOverflowCue);
 
   async function start() {
     applyTheme();

--- a/theHarvester/lib/api/static/harvestview/index.html
+++ b/theHarvester/lib/api/static/harvestview/index.html
@@ -152,7 +152,7 @@
               </div>
               <div class="section-actions">
                 <button id="copy-route-button" class="button small" type="button" title="Copy only the selected rows from the open result route." disabled>Copy selected</button>
-                <button id="export-jsonl-button" class="button small" type="button" title="Download the complete normalized result stream as JSONL.">All JSONL</button>
+                <button id="export-jsonl-button" class="button small" type="button" title="Download the complete normalized result stream as JSONL.">Export all JSONL</button>
               </div>
             </div>
             <nav id="route-tabs" class="route-tabs" aria-label="Result routes"></nav>


### PR DESCRIPTION
## Summary

- make responsive-collapsed hostname P1/P2 actions open the existing review dialog without submitting immediately
- put partial and failed run assessment ahead of result routes while preserving the complete-run layout
- add measured route-overflow guidance plus roving Arrow/Home/End keyboard navigation
- raise operational text sizes and provide 44px mobile row/header selection targets with compact checkbox visuals
- clarify the full-run JSONL export label

## Regression coverage

- exercise isolated P1/P2 action review at 1440x900, 1024x768, 820x1180, and 390x844
- assert no document overflow through those interaction flows
- cover partial and failed runs with retained evidence ordering
- cover ArrowLeft/ArrowRight/Home/End focus and inactive `tabindex=-1` state
- verify mobile 16px authorization prose and 44x44 row/header checkbox hit areas

## Verification

- HarvestView real-browser suite: 33 passed
- full non-browser suite: 1729 passed, 6 skipped, 33 deselected
- `pytest tests/lib/test_harvestview_ui.py -q`: 6 passed
- `ruff check .`
- `ruff format --check .`
- `mypy theHarvester`
- `node --check theHarvester/lib/api/static/harvestview/app.js`
- four-viewport browser acceptance found no document overflow, console errors, page errors, or request failures

Testing used isolated local fixtures and reserved example data. No enumeration was submitted and no target reconnaissance was performed. The longer multi-step enumeration-dialog redesign remains a separate follow-up.