### PR TITLE
feat: export completed runs as SQLite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ theHarvester is a Python OSINT reconnaissance tool for collecting public informa
 
 ## Domain language
 
-Read [CONTEXT.md](CONTEXT.md) when changing discovery terminology, evidence classification, scope handling, DNS validation, or P0/P1/P2 activity boundaries.
+Read [CONTEXT.md](CONTEXT.md) before changing discovery semantics, result or evidence models, run lifecycle, interchange or persistence, target scope, DNS validation, or P0/P1/P2 activity boundaries.
 
 ## Code review rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added authenticated REST and HarvestView export of every completed run as a portable SQLite database without queue, cancellation, worker-lease, or legacy-observation state.
 - Added a catalog-derived offline provider-contract gate that fails on missing, unknown, or duplicate source coverage while keeping live checks outside routine CI.
 - Added sourced ASN organization attribution from URLScan, ONYPHE, and Shodan, linked to the exact hostname or IP evidence and retained in SQLite, JSONL, the API, CLI output, and HarvestView without claiming ownership or scope.
 - Added bounded RouteViews routing enrichment for exact discovered IPs with sourced ASN attribution, or explicit ASN, IP, and CIDR targets, retaining typed origin, BGP-route, and RPKI evidence as external relationships without expanding active scope.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,13 +2,13 @@
 
 Status: accepted release baseline
 
-Release: Unreleased changes after 4.11.1 on `dev`
+Release: 5.0.0 development line on `dev`
 
 Reconciled: 2026-08-16
 
-This document is the semantic source of truth for the next release. It defines the product boundary, execution model, evidence contract, scope rules, and shared language used by code, tests, issues, pull requests, output, and operator documentation.
+This document is the semantic source of truth for the 5.0.0 release. It defines the product boundary, execution model, evidence contract, scope rules, and shared language used by code, tests, issues, pull requests, output, and operator documentation.
 
-The package version in `theHarvester/__init__.py` and the release headings in `CHANGELOG.md` remain authoritative for the eventual version number. Exact flags, source names, result kinds, schemas, and routes remain authoritative in the executable catalog, type declarations, CLI help, and OpenAPI document. This file records the meanings and boundaries those interfaces must preserve.
+Version 5.0.0 is the accepted release target. The package version in `theHarvester/__init__.py` and the release heading in `CHANGELOG.md` are updated together when the release is cut. Exact flags, source names, result kinds, schemas, and routes remain authoritative in the executable catalog, type declarations, CLI help, and OpenAPI document. This file records the meanings and boundaries those interfaces must preserve.
 
 When a change alters one of these boundaries, update this document and the nearest decision record in the same pull request. Completion means the implementation, focused regression coverage, operator documentation, and this context express the same contract.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,10 +1,61 @@
-# theHarvester discovery context
+# theHarvester release context
 
-This glossary is the source of truth for discussing subdomain discovery and HarvestView lifecycle behavior across code, issues, pull requests, output, and documentation. It separates current addressability from historical, indirect, or unresolved evidence.
+Status: accepted release baseline
 
-The definitions state intended semantics; they do not imply that every discovery adapter already produces every evidence class. Update this glossary when a change alters a term's meaning or boundary.
+Release: Unreleased changes after 4.11.1 on `dev`
 
-## Language
+Reconciled: 2026-08-16
+
+This document is the semantic source of truth for the next release. It defines the product boundary, execution model, evidence contract, scope rules, and shared language used by code, tests, issues, pull requests, output, and operator documentation.
+
+The package version in `theHarvester/__init__.py` and the release headings in `CHANGELOG.md` remain authoritative for the eventual version number. Exact flags, source names, result kinds, schemas, and routes remain authoritative in the executable catalog, type declarations, CLI help, and OpenAPI document. This file records the meanings and boundaries those interfaces must preserve.
+
+When a change alters one of these boundaries, update this document and the nearest decision record in the same pull request. Completion means the implementation, focused regression coverage, operator documentation, and this context express the same contract.
+
+## Release contract
+
+### Product boundary
+
+- theHarvester is a finite, one-shot enumerator. Each invocation or submitted run has an explicit target, selected sources or actions, limits, and a terminal outcome.
+- The CLI, authenticated REST API, and HarvestView project the same normalized terminal evidence. HarvestView is the local browser workspace for submitting and reviewing runs; it is not a separate discovery engine.
+- The local API owns durable run records and one isolated worker. Queue and process ownership remain separate from terminal evidence so a later worker or deployment design can change without rewriting completed results.
+
+### Authorization and scope
+
+- Every provider, DNS, or direct action stays within the operator's explicit target and selected activity. P0, P1, and P2 describe observable network behavior, not confidence or importance.
+- P0 sources query existing providers or datasets. P1 actions query DNS about authorized names or addresses. P2 actions contact a target endpoint or cause equivalent direct interaction.
+- Scope-extension candidates and external relationships remain review evidence. An operator decision is the only path that promotes them into a later run's authorized scope.
+- ASN labels, registry records, BGP origins, RPKI states, DNS answers, and endpoint responses remain time-bound evidence. None establishes ownership, legal control, reachability, or authorization by itself.
+
+### Execution and lifecycle
+
+- The source catalog is the authority for canonical source names, aliases, credentials, result capabilities, and activity class. Explicit source names and capability selectors form a union; `all` selects every cataloged P0 source once.
+- A source adapter returns `None` for ordinary completion or an immutable `SourceExecutionReport` when it must preserve an explicit outcome or stop reason. The central source runner owns observation collection, result counting, no-result classification, exception handling, and final source status.
+- Source execution statuses are `completed`, `partial`, `failed`, `rate-limited`, and `skipped`. Mutable adapter fields such as `execution_status` and `stop_reason` are outside this release contract and are rejected, including when an adapter raises or is cancelled.
+- Run lifecycle statuses are `queued`, `running`, `cancelling`, `cancelled`, `completed`, and `failed`. Terminal evidence status is independently `complete`, `partial`, or `failed`; retained evidence survives a later cancellation or process failure.
+- Imported runs enter as completed run records and execute no source or action. Action-only runs create independent run records instead of mutating the evidence of the run that supplied their candidate.
+
+### Evidence and portability
+
+- A merged result is canonical by result kind and value. Source and action provenance, typed observations, execution outcomes, timestamps, and artifact metadata remain attached through deduplication and persistence.
+- JSONL is the primary single-run interchange format: one summary record followed by sorted finding records. It retains terminal evidence status, producer outcomes, provenance, and supported structured observations.
+- SQLite is the canonical local multi-run store. Portable SQLite export contains every finalized evidence record, preserves original run IDs and canonical structured evidence, and excludes queue, cancellation, worker-lease, and legacy-observation state. Screenshot metadata travels with evidence; screenshot files remain separately managed artifacts.
+- Legacy JSON and XML remain supported grouped reports for existing consumers. They are presentation formats and do not replace JSONL or SQLite when lossless provenance and structured evidence are required.
+
+### Release gates
+
+- Routine tests and CI use mocked provider responses, local services, RFC-reserved domains, and TEST-NET addresses. Live provider or target checks remain explicit operator-run integration work.
+- Every executable source has offline contract coverage for its declared lifecycle, and the catalog gate rejects missing, duplicate, or unknown coverage.
+- Persistence and interchange changes prove canonical export and import round trips. HarvestView changes pass a separate real-browser gate covering the affected operator workflow.
+- Release publication requires green Python, formatting, lint, typing, container, security, documentation, and HarvestView browser checks at the publication head.
+
+### Deferred boundaries
+
+- Continuous monitoring and scheduling remain separate future product decisions; an enumeration run stays finite.
+- Distributed workers, multi-host operation, PostgreSQL, and hosted multi-user authorization require measured demand and new decisions. The release remains SQLite-first and local-operator focused.
+- Automatic scope expansion remains deferred. Evidence can suggest a later target, while the operator controls every scope change.
+
+## Domain language
 
 **Currently addressable subdomain**:
 A normalized, in-scope subdomain with current resolver consensus evidence of an A or AAAA record, or a permitted CNAME chain ending in one, that is neither wildcard-indistinguishable nor resolver-disputed.
@@ -113,6 +164,18 @@ _Avoid_: Internal workflow names, operator app, console, dashboard
 **Imported run**:
 A run record created from an existing theHarvester result file. Import records evidence but never executes discovery or contacts a target.
 _Avoid_: Uploaded scan, replayed run
+
+**Finalized evidence record**:
+A completed-result record with stable run ID, target, timestamps, normalized results, producer outcomes, provenance, typed observations, artifact metadata, and terminal evidence status. A partial or failed terminal evidence status can still be finalized and portable.
+_Avoid_: Successful run, lifecycle row, complete-only result
+
+**JSONL run interchange**:
+One finalized evidence record encoded as a summary line followed by normalized finding lines. It is the primary streamable format for one-run automation and round trips.
+_Avoid_: JSON report, event log, lifecycle export
+
+**Portable SQLite export**:
+A validated database containing finalized evidence records and their original run IDs without API lifecycle, cancellation, worker-lease, or legacy-observation state.
+_Avoid_: Database backup, worker-state export, application clone
 
 **Lifecycle status**:
 The durable state of a run record: queued, running, cancelling, cancelled, completed, or failed. It describes control flow, not evidence quality.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for helping improve theHarvester. This guide explains how to propose a
 - Search the [issues](https://github.com/laramies/theHarvester/issues) and [pull requests](https://github.com/laramies/theHarvester/pulls) for existing work.
 - Open an issue before investing in a large feature, dependency change, or user-visible behavior change.
 - Keep each pull request to one logical change. Leave unrelated cleanup and reformatting for separate work.
-- Base contribution branches on the current upstream `master` branch.
+- Base contribution branches on the current upstream `dev` branch.
 
 For a bug report, include a minimal reproduction, expected and actual behavior, operating system, Python version, and only the output needed to diagnose the problem. Remove credentials, account information, private target data, and raw API responses.
 
@@ -22,7 +22,7 @@ git clone https://github.com/YOUR-GITHUB-USERNAME/theHarvester.git
 cd theHarvester
 git remote add upstream https://github.com/laramies/theHarvester.git
 git fetch upstream
-git switch -c fix/short-description upstream/master
+git switch -c fix/short-description upstream/dev
 uv sync --all-groups
 ```
 
@@ -95,7 +95,7 @@ CI runs additional source smoke tests, CodeQL, dependency review, and container 
 
 ## Open a pull request
 
-Push the topic branch to your fork and open a pull request against `laramies/theHarvester:master`.
+Push the topic branch to your fork and open a pull request against `laramies/theHarvester:dev`.
 
 The pull request should include:
 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,13 @@ theHarvester gathers open-source intelligence about a domain or organization fro
 
 It is built for the early reconnaissance stage of authorized security assessments. Use it only on targets you own or have explicit permission to test.
 
-## Why theHarvester
+## What it does
 
-- **Broad discovery coverage:** combine many independent sources in one run instead of querying each provider manually.
-- **Useful result types:** collect hostnames, email addresses, IP addresses, URLs, ASNs, and people.
-- **Enrichment after discovery:** optionally enrich routing evidence through RouteViews, resolve DNS, query Shodan, check for subdomain takeovers, brute-force DNS names, scan common API paths, and capture screenshots.
-- **CLI and browser-accessible API:** use the command line interactively or run the FastAPI service for automation and interactive Swagger/ReDoc documentation.
-- **Repeatable output:** print results, write provenance-aware JSONL, retain run evidence in SQLite, and generate legacy JSON and XML reports when needed.
-- **Operational controls:** select individual sources, set result limits, use HTTP or SOCKS proxies, choose DNS resolvers, and suppress missing-key noise.
+theHarvester combines many public data sources in one run and normalizes their results. It can collect hostnames, email addresses, IP addresses, URLs, ASNs, people, and breach names. Optional actions cover DNS, RouteViews, Shodan, takeover checks, virtual hosts, API paths, and screenshots.
 
-Source availability, quotas, and response formats are controlled by third parties and can change independently of theHarvester.
+Use the CLI for one-off work or HarvestView for a local browser workflow. JSONL and SQLite retain structured evidence and provenance. JSON and XML remain available for existing integrations.
+
+Providers control their own availability, quotas, and response formats, so individual sources may change independently of theHarvester.
 
 ## Package versions
 
@@ -55,9 +52,7 @@ Query several passive sources:
 uv run theHarvester -d example.com -b crtsh,certspotter,commoncrawl
 ```
 
-Three discovery sources run at once by default. Use `-j` or `--source-workers` with a positive number to change that
-concurrency. The worker count never skips a selected source or limits its results, and it is automatically reduced when
-fewer sources are selected. REST `source_workers` and HarvestView use the same setting.
+Three discovery sources run at once by default. Use `-j` or `--source-workers` to change the worker count. The REST API and HarvestView expose the same setting.
 
 Run every source that can contribute subdomains:
 
@@ -79,7 +74,7 @@ Exclude hostname results while retaining other result types:
 uv run theHarvester -d example.com -b emails,ips,urls --no-hosts -f non-host-results
 ```
 
-`--no-hosts` skips sources whose only declared route is `subdomains`. Mixed sources still run, but their hostname getter is not called; emails, IPs, URLs, ASNs, people, and breach names remain available. Hostname and virtual-host records are omitted from terminal, JSON, XML, JSONL, SQLite, API, and HarvestView output. The option cannot be combined with Shodan enrichment, DNS resolution/lookup/brute force/recursion, takeover checks, screenshots, or virtual-host discovery. Target-only API endpoint interaction remains available because it does not depend on harvested hostnames. HarvestView and `POST /api/v1/runs` expose the same option as `no_hosts`.
+`--no-hosts` skips hostname-only sources and omits hostname results while keeping other result types. It cannot be combined with actions that depend on hostnames. HarvestView and the REST API expose the same option as `no_hosts`.
 
 Save a durable JSONL report:
 
@@ -102,19 +97,13 @@ List every option and its current behavior:
 uv run theHarvester -h
 ```
 
-### Active features
+## Activity and scope
 
-Options such as DNS brute force (`-c`), bounded recursive DNS (`--dns-recursive-depth`), reverse DNS lookup (`-n`), takeover checks (`-t`), API endpoint scanning (`-a`), DNS resolution (`-r`), and screenshots (`--screenshot`) generate additional network activity. Use them only within an explicitly authorized scope.
+Passive sources are P0. DNS resolution, brute force, recursive DNS, and reverse lookup are P1. HTTP, TLS, screenshot, takeover, virtual-host, port, and endpoint actions are P2. P1 and P2 activity runs only when you select it.
 
-Hostname resolution deduplicates normalized candidates from every selected source before one run-wide A, AAAA, and CNAME phase. It runs at most 20 hostname jobs concurrently with no default query-count or phase-runtime ceiling, while retaining completed evidence. Reverse DNS uses a separate run-wide job set: overlapping `/24` ranges are deduplicated and streamed lazily through at most 20 active PTR jobs, also with no default candidate, request, or phase-runtime ceiling. Explicit library limits still report budget or runtime stops as partial when completed evidence exists.
+Common active options include DNS resolution (`-r`), DNS brute force (`-c`), reverse DNS (`-n`), recursive DNS (`--dns-recursive-depth`), takeover checks (`-t`), API path scanning (`-a`), and screenshots (`--screenshot`). A takeover indicator is evidence for review, not proof that a provider resource can be claimed.
 
-Recursive DNS requires exactly three distinct resolver IPs through `--dns-resolvers` or the compatible `--dns-resolve` value. It advances only names with two-vantage address consensus that are distinguishable from closest-encloser wildcard controls. Depth is required to enable it; the existing query and runtime flags are optional finite overrides, with no default ceiling or zero-yield early stop. PTR names for current addresses are retained as secondary evidence, but they do not establish current addressability or become recursion seeds. HarvestView and `POST /api/v1/runs` expose the same controls.
-
-Takeover checks start with each canonical in-scope hostname and the configured DNS resolvers. HTTP requests run only after a CNAME matches a pinned, reviewed provider rule. Before making those requests, a random sibling control checks whether the same provider response comes from wildcard DNS; indistinguishable cases are reported as inconclusive instead of findings. Requests keep the original hostname for HTTP `Host` and TLS SNI, do not follow redirects, verify TLS, isolate cookies, and stop at a 1 MiB response safety bound. The action uses at most 20 candidate workers, with no default candidate, request, result, or phase-runtime ceiling. Proxy mode stops before active requests when no configured proxy is available.
-
-A match is a takeover indicator, not proof that an operator can claim the provider resource. Every checked hostname is retained as one `indicator`, `no-indicator`, or `inconclusive` outcome. JSONL, SQLite, the API, and HarvestView keep the canonical hostname together with its service, rule revision, resolver-specific CNAME chain and terminal RCODE, wildcard control, HTTP status, redirect location, matched predicates, and errors. The bundled rules are a reviewed translation of [can-i-take-over-xyz](https://github.com/EdOverflow/can-i-take-over-xyz) at `5bd4e128` and selected compound predicates from [Nuclei templates](https://github.com/projectdiscovery/nuclei-templates) at `9090ee10`; no rules are downloaded during a run.
-
-Screenshot capture also requires a Playwright-compatible browser; see the installation guide for setup.
+Read [Responsible use and scope](docs/wiki/Responsible-Use-and-Scope.md) before active work. [Operator workflows](docs/wiki/Operator-Workflows.md) covers limits, resolvers, proxies, and action-specific behavior. Screenshot capture requires a Playwright-compatible browser.
 
 ## HarvestView and REST API
 
@@ -125,21 +114,13 @@ export THEHARVESTER_API_KEY='replace-with-a-long-random-value'
 uv run harvestview
 ```
 
-Open [HarvestView](http://127.0.0.1:5000/) to run and inspect finite enumerations in the local web app. The server gives the local browser a derived HttpOnly session cookie, so the API key is never entered into or stored by HarvestView.
-
-HarvestView uses its own `app.css` rather than a general UI framework. Bootstrap,
-Bulma, Pico, and Tailwind would duplicate the existing design layer or require a
-markup and build-pipeline rewrite. Tabulator 6.5.2's table behavior and default
-theme load from pinned CDNjs URLs with Subresource Integrity. HarvestView
-therefore needs network access to CDNjs by default. See the
-[self-hosting instructions](docs/wiki/Installation.md) for
-an isolated deployment.
+Open [HarvestView](http://127.0.0.1:5000/) to submit and inspect finite runs. The browser receives a derived HttpOnly session cookie and never stores the API key. See the [installation guide](docs/wiki/Installation.md) for local assets, screenshots, and isolated deployments.
 
 Open [Swagger](http://127.0.0.1:5000/docs) or [ReDoc](http://127.0.0.1:5000/redoc) for the automation contract.
 
 ### Docker Compose
 
-The supplied Compose service runs as an unprivileged user, stores run records in a named volume, loads the operator key from a file secret, and publishes only to host loopback. Create the secret before the first start:
+The Compose service runs as an unprivileged user, stores runs in a named volume, reads the operator key from a file secret, and publishes only to host loopback:
 
 ```bash
 install -d -m 0700 .secrets
@@ -148,8 +129,6 @@ chmod 0444 .secrets/operator-api-key
 docker compose up --build -d
 docker compose ps
 ```
-
-The `0700` directory protects the secret on the host, while the read-only `0444` file lets the unprivileged container process read its bind-mounted copy. Open [HarvestView](http://127.0.0.1:5000/). The image includes Chromium for optional screenshots. Provider keys and proxies remain in the existing read-only YAML mounts and are excluded from the image build context.
 
 ```bash
 docker compose logs -f theharvester.svc.local
@@ -168,106 +147,83 @@ docker compose down
 | `GET /api/v1/runs/export-database` | Export all completed run evidence as a portable SQLite database. |
 | `GET /api/v1/runs/{run_id}/export` | Export normalized evidence as JSONL. |
 
-HarvestView can start a screenshot or DNS brute-force run directly from a hostname result. These actions create a separate run record for that hostname and leave the parent evidence unchanged. Resolver addresses may be entered directly or loaded from a text file with one IP address per line. Ordinary DNS actions accept one or more resolvers; recursive DNS requires exactly three.
+HarvestView can start screenshot and DNS brute-force runs from a hostname result. Each action creates its own run and leaves the original evidence unchanged.
 
-API clients send `THEHARVESTER_API_KEY` in the `X-API-Key` header; HarvestView uses its derived browser cookie. Provider credentials stay in server-side configuration and cannot be supplied in a request. Keep the service bound to localhost. If you require remote access, add network access controls and TLS.
-
-When `--proxies` and `--take-over` are combined, takeover requests use a configured proxy or stop before contacting discovered hosts. They never fall back to a direct request.
+API clients send `THEHARVESTER_API_KEY` in the `X-API-Key` header. Provider credentials stay in server-side configuration. Keep the service on localhost unless you add TLS and network access controls. The [REST API guide](docs/wiki/Rest-API.md) documents requests, imports, exports, and authentication.
 
 ## Discovery sources
 
-The table shows which result types each source can add to consolidated CLI results. XML keeps its existing schema. Legacy JSON now consolidates `interesting_urls`, `linkedin_links`, and `trello_urls` into one `urls` field. Breach names are retained in JSONL and SQLite. Some adapters parse fields that the reports do not store.
+Select sources by name or by any result route listed below. `-b all` runs the P0 sources. P1 and P2 sources require explicit selection. Credentials marked optional can provide additional access but are not required.
 
-JSON and XML group findings by result type without source attribution. JSONL and SQLite retain source attribution when the collection adapter provides it. Empty optional fields may be omitted.
-BuiltWith's normalized frameworks, languages, servers, CMS products, and analytics products are retained in JSONL and completed-result SQLite rows.
-
-Contributors add an ordinary discovery provider with one catalog entry and one factory entry; the shared runner handles CLI execution, persistence, and output. See [the contributor module guide](docs/wiki/How-to-add-a-new-module.md).
-
-A checkmark means the source can add that result type. The **Additional action output** column lists optional actions that return other data.
-
-Read the **API key** column as follows:
-
-- **✓**: credentials are required.
-- **Optional**: a key can provide additional access.
-- **No**: the source has no key setting.
+The `shodan` source contributes subdomains. Shodan host enrichment through `-s` or `--shodan` is a separate action and is not a source result route.
 
 <details>
 <summary><strong>View the source and result matrix</strong></summary>
 
-| Source | Subdomains | Emails | IPs | ASNs | URLs | People | Breaches | Additional action output (not consolidated report) | API key |
-| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | --- | :---: |
-| `apis-guru` | ✓ | ✓ | No | No | ✓ | No | No | No | No |
-| `arquivo` | ✓ | No | No | No | No | No | No | No | No |
-| `baidu` | ✓ | ✓ | No | No | No | No | No | No | No |
-| `bevigil` | ✓ | No | No | No | ✓ | No | No | No | ✓ |
-| `bufferoverun` | ✓ | No | ✓ | No | No | No | No | No | ✓ |
-| `builtwith` | ✓ | No | No | No | ✓ | No | No | No | ✓ |
-| `brave` | ✓ | ✓ | No | No | No | No | No | No | ✓ |
-| `censys` | ✓ | ✓ | No | No | No | No | No | No | ✓ |
-| `certspotter` | ✓ | No | No | No | No | No | No | No | No |
-| `commoncrawl` | ✓ | No | No | No | No | No | No | No | No |
-| `criminalip` | ✓ | No | ✓ | ✓ | No | No | No | No | ✓ |
-| `crt-name` | ✓ | No | No | No | No | No | No | No | No |
-| `crtsh` | ✓ | No | No | No | No | No | No | No | No |
-| `dehashed` | No | ✓ | ✓ | No | No | No | No | No | ✓ |
-| `dnsdb` | ✓ | No | No | No | No | No | No | No | ✓ |
-| `dnsdumpster` | ✓ | No | ✓ | No | No | No | No | No | ✓ |
-| `duckduckgo` | ✓ | ✓ | No | No | No | No | No | No | No |
-| `dymo` | ✓ | No | No | No | No | No | No | No | ✓ |
-| `fofa` | ✓ | No | ✓ | No | No | No | No | No | ✓ |
-| `fullhunt` | ✓ | No | No | No | No | No | No | No | ✓ |
-| `github-code` | ✓ | ✓ | No | No | No | No | No | No | ✓ |
-| `gitlab` | ✓ | ✓ | No | No | ✓ | No | No | No | No |
-| `hackertarget` | ✓ | No | ✓ | No | No | No | No | No | Optional |
-| `haveibeenpwned` | No | No | No | No | No | No | ✓ | No | No |
-| `hibpverified` | No | ✓ | No | No | No | No | ✓ | No | ✓ |
-| `hudsonrock` | ✓ | ✓ | ✓ | No | No | No | No | No | No |
-| `hunter` | ✓ | ✓ | No | No | No | No | No | No | ✓ |
-| `hunterhow` | ✓ | No | No | No | No | No | No | No | ✓ |
-| `intelx` | ✓ | ✓ | No | No | ✓ | No | No | No | ✓ |
-| `leakix` | ✓ | No | No | No | No | No | No | No | ✓ |
-| `leaklookup` | No | ✓ | No | No | No | No | ✓ | No | ✓ |
-| `mojeek` | ✓ | ✓ | No | No | No | No | No | No | Optional |
-| `netlas` | ✓ | No | No | No | No | No | No | No | ✓ |
-| `onyphe` | ✓ | No | ✓ | ✓ | No | No | No | No | ✓ |
-| `otx` | ✓ | No | ✓ | No | No | No | No | No | No |
-| `pentesttools` | ✓ | No | ✓ | No | No | No | No | No | ✓ |
-| `projectdiscovery` | ✓ | No | No | No | No | No | No | No | ✓ |
-| `rapiddns` | ✓ | No | ✓ | No | No | No | No | No | No |
-| `robtex` | No | No | ✓ | No | No | No | No | No | No |
-| `rocketreach` | No | ✓ | No | No | ✓ | No | No | No | ✓ |
-| `securityscorecard` | ✓ | No | ✓ | No | No | No | No | No | ✓ |
-| `securityTrails` | ✓ | No | ✓ | No | No | No | No | No | ✓ |
-| `sherlockeye` | ✓ | ✓ | ✓ | No | No | No | No | No | ✓ |
-| `shodan` | ✓ | No | No | No | No | No | No | `-s` / `--shodan` host-enrichment output | ✓ |
-| `shodanInternetDB` | ✓ | No | ✓ | No | No | No | No | No | No |
-| `shodanct` | ✓ | No | No | No | No | No | No | No | No |
-| `sourcegraph` | ✓ | No | No | No | No | No | No | No | No |
-| `subdomaincenter` | ✓ | No | No | No | No | No | No | No | No |
-| `subdomainfinderc99` | ✓ | No | No | No | No | No | No | No | No |
-| `thc` | ✓ | No | No | No | No | No | No | No | No |
-| `tomba` | ✓ | ✓ | No | No | No | No | No | No | ✓ |
-| `urlscan` | ✓ | No | ✓ | ✓ | ✓ | No | No | No | No |
-| `virustotal` | ✓ | No | No | No | No | No | No | No | ✓ |
-| `waybackarchive` | ✓ | No | No | No | No | No | No | No | No |
-| `whoisxml` | ✓ | No | No | No | No | No | No | No | ✓ |
-| `windvane` | ✓ | ✓ | ✓ | No | No | No | No | No | Optional |
-| `yahoo` | ✓ | ✓ | No | No | No | No | No | No | No |
-| `zoomeye` | ✓ | ✓ | ✓ | ✓ | ✓ | No | No | No | ✓ |
+| Source | Result routes | Activity | Credentials |
+| --- | --- | :---: | :---: |
+| `apis-guru` | subdomains, emails, urls | P0 | No |
+| `arquivo` | subdomains | P0 | No |
+| `baidu` | subdomains, emails | P0 | No |
+| `bevigil` | subdomains, urls | P0 | Required |
+| `bufferoverun` | subdomains, ips | P0 | Required |
+| `builtwith` | subdomains, urls | P0 | Required |
+| `brave` | subdomains, emails | P0 | Required |
+| `censys` | subdomains, emails | P0 | Required |
+| `certspotter` | subdomains | P0 | No |
+| `commoncrawl` | subdomains | P0 | No |
+| `criminalip` | subdomains, ips, asns | P2 | Required |
+| `crt-name` | subdomains | P0 | No |
+| `crtsh` | subdomains | P0 | No |
+| `dehashed` | emails, ips | P0 | Required |
+| `dnsdb` | subdomains | P0 | Required |
+| `dnsdumpster` | subdomains, ips | P0 | Required |
+| `duckduckgo` | subdomains, emails | P0 | No |
+| `dymo` | subdomains | P0 | Required |
+| `fofa` | subdomains, ips | P0 | Required |
+| `fullhunt` | subdomains | P0 | Required |
+| `github-code` | subdomains, emails | P0 | Required |
+| `gitlab` | subdomains, emails, urls | P0 | No |
+| `hackertarget` | subdomains, ips | P0 | Optional |
+| `haveibeenpwned` | breaches | P0 | No |
+| `hibpverified` | emails, breaches | P0 | Required |
+| `hudsonrock` | subdomains, emails, ips | P0 | No |
+| `hunter` | subdomains, emails | P0 | Required |
+| `hunterhow` | subdomains | P0 | Required |
+| `intelx` | subdomains, emails, urls | P0 | Required |
+| `leakix` | subdomains | P0 | Required |
+| `leaklookup` | emails, breaches | P0 | Required |
+| `mojeek` | subdomains, emails | P0 | Optional |
+| `netlas` | subdomains | P0 | Required |
+| `onyphe` | subdomains, ips, asns | P0 | Required |
+| `otx` | subdomains, ips | P0 | No |
+| `pentesttools` | subdomains, ips | P1 | Required |
+| `projectdiscovery` | subdomains | P0 | Required |
+| `rapiddns` | subdomains, ips | P0 | No |
+| `robtex` | ips | P0 | No |
+| `rocketreach` | emails, urls | P0 | Required |
+| `securityscorecard` | subdomains, ips | P0 | Required |
+| `securityTrails` | subdomains, ips | P0 | Required |
+| `sherlockeye` | subdomains, emails, ips | P0 | Required |
+| `shodan` | subdomains | P1 | Required |
+| `shodanInternetDB` | subdomains, ips | P1 | No |
+| `shodanct` | subdomains | P0 | No |
+| `sourcegraph` | subdomains | P0 | No |
+| `subdomaincenter` | subdomains | P0 | No |
+| `subdomainfinderc99` | subdomains | P1 | No |
+| `thc` | subdomains | P0 | No |
+| `tomba` | subdomains, emails | P0 | Required |
+| `urlscan` | subdomains, ips, asns, urls | P0 | No |
+| `virustotal` | subdomains | P0 | Required |
+| `waybackarchive` | subdomains | P0 | No |
+| `whoisxml` | subdomains | P0 | Required |
+| `windvane` | subdomains, emails, ips | P0 | Optional |
+| `yahoo` | subdomains, emails | P0 | No |
+| `zoomeye` | subdomains, emails, ips, asns, urls | P0 | Required |
 
 </details>
 
-`apis-guru` performs P0 provider-side collection through APIs.guru's public v2 API. It requests the exact target-domain directory entry and follows every matching preferred OpenAPI specification within hard 1,000-entry and 10-minute safety ceilings. `--limit` bounds retained results per output type without truncating catalog traversal. The source retains only target-scoped hostnames, contact emails, and HTTP(S) URLs; external OAuth, CDN, and third-party server references are excluded. API specifications, operations, security declarations, version provenance, and external relationships remain deferred until the normalized evidence model can represent them without flattening their meaning.
-
-`crt-name` requests the provider's single unpaginated composite response for the exact operator-requested scope and retains only names inside that scope. It does not broaden a descendant target to its registrable domain, use `-l` / `--limit`, contact the target, or replace `crtsh`. Its results combine certificate-transparency and other public datasets, so overlap with `crtsh` is expected and a returned hostname is not proof of ownership, scope, or current liveness. The response remains subject to the shared 64 MiB stream and 90-second runtime ceilings.
-
-`sourcegraph` makes one anonymous, provider-only search capped at 5,000 code matches. It does not use `-l` / `--limit`; returned names are candidates mentioned in indexed code, not proof of ownership or liveness.
-
-Provider pricing is intentionally omitted because plans and quotas change frequently. See [Configuration and API Keys](docs/wiki/Configuration-and-API-Keys.md) and each provider's current documentation.
-
-`haveibeenpwned` remains the keyless public breach catalogue. `hibpverified` is a separate authenticated source for HIBP's `breachedDomain` endpoint. It participates in `all` and matching capability selectors just like every other P0 source, and skips normally when its provider key is absent. API run requests can select it through the shared source contract and return normalized emails plus stable breach names. A live run requires a user-owned paid HIBP API key and a user-owned domain verified in that account; routine tests use offline responses.
-
-The inert legacy identifiers `linkedin`, `netcraft`, `omnisint`, `sublist3r`, and `zoomeyeapi` are no longer registered. Use the table above, `SOURCE_SPECS`, and `SOURCE_FACTORIES` as the supported provider inventory.
+Provider plans and quotas change often, so this README does not list prices. See [Configuration and API keys](docs/wiki/Configuration-and-API-Keys.md) for credential names and setup. Contributors can add a provider through the [module guide](docs/wiki/How-to-add-a-new-module.md); the source catalog remains the executable inventory.
 
 ## Configuration
 
@@ -275,37 +231,27 @@ On first use, theHarvester creates default configuration files under `~/.theHarv
 
 - `api-keys.yaml` stores provider credentials.
 - `proxies.yaml` configures HTTP and SOCKS5 proxies used with `-p`.
-- The `shodan` source and `-s` / `--shodan` enrichment call Shodan's Host REST API without the Python SDK. When `-p` is enabled, both send those requests through `proxies.yaml`.
+- The `shodan` source and `-s` / `--shodan` enrichment use Shodan's Host REST API. When `-p` is enabled, both send those requests through `proxies.yaml`.
+- `routeviews.key` is optional and enables authenticated RouteViews access for PeeringDB-verified users.
 
 Never commit populated configuration files, API keys, account details, or provider responses.
 
-## Results and local data
+## Output and local data
 
-- Terminal output shows consolidated findings. Separately selected actions, such as `-s` / `--shodan`, may print their own enrichment.
-- `-f NAME` writes `NAME.json`, `NAME.xml`, and `NAME.jsonl`.
-- Screenshots are written to the directory passed to `--screenshot`.
-- Host, email, IP, and related scan records are stored in `~/.local/share/theHarvester/stash.sqlite`.
-- Full CLI pipeline runs are also stored transactionally by run UUID with their completed, deduplicated findings.
-- API executions use the same SQLite database as CLI results. Durable lifecycle rows stay separate from terminal evidence, while typed results and source or action origins remain queryable. JSONL handles individual run interchange, and the API can import completed runs from another theHarvester SQLite database.
-- Bounded [virtual host discovery](docs/wiki/Virtual-Host-Discovery.md) enriches each confirmed `hostname` result with structured endpoint observations and `vhost` action provenance.
-- `--routeviews` enriches exact discovered IPs that carry sourced ASN attribution, or an explicitly targeted ASN, IP, or CIDR, with bounded observed-origin, BGP route, and RPKI evidence. For example, `-d example.com -b asns --routeviews` asks RouteViews for the most-specific routes covering attributed IPs; it does not dump every prefix originated by a shared cloud or CDN ASN. `-d AS16509 --routeviews` remains the intentional way to request a complete ASN prefix inventory. Returned prefixes remain external relationships rather than claimed engagement scope. RouteViews is a P0 action, is not selected by `-b all`, and does not use `-l`. A configured `routeviews.key` is used automatically for PeeringDB-verified authenticated access; otherwise the action uses the guest allowance.
+Terminal output is intended for interactive use. `-f NAME` also writes `NAME.jsonl`, `NAME.json`, and `NAME.xml`. Screenshots go to the directory passed to `--screenshot`, and completed runs are stored in `~/.local/share/theHarvester/stash.sqlite`.
 
 Treat collected OSINT as potentially sensitive. Keep report files, screenshots, and the local database out of source control and share them only within the authorized engagement.
 
-### Report formats
+### JSONL
 
-Use JSONL for automation, run interchange, and structured evidence. Legacy JSON and XML remain available for consumers that depend on their existing grouped schemas.
-
-The JSONL report is finalized after the selected one-shot actions finish. The first line identifies the run with its UUID, target, UTC timestamps, and result counts. Each later line is one sorted, deduplicated finding. When you concatenate report files, treat each summary line as the start of a new run.
+JSONL is the primary format for automation and one-run interchange. The first line describes the run. Each remaining line is one sorted, deduplicated finding with its source and action provenance.
 
 ```jsonl
 {"action_executions":[],"artifacts":[],"completed_at":"2026-08-07T12:01:00Z","counts":{"hostname":1},"evidence_status":"complete","result_count":1,"run_id":"123e4567-e89b-12d3-a456-426614174000","source_executions":[],"started_at":"2026-08-07T12:00:00Z","target":"example.com","type":"summary"}
 {"sources":[],"type":"hostname","value":"api.example.com"}
 ```
 
-JSONL is easy to stream one record at a time. The summary preserves the evidence status, source and action outcomes, and screenshot artifact metadata. Finding lines carry `sources` and, when applicable, `actions`; they inherit their run ID and target from the preceding summary. Hostnames, IP addresses, and URLs use the same `hostname`, `ip`, and `url` result kinds in JSONL, SQLite, the API, and HarvestView. Provenance identifies which source or action produced each finding. Recursive DNS records plus `person` and `infostealer` store a JSON object inside the string `value`; parse those values a second time with `fromjson`. Takeover outcomes instead keep the canonical hostname in `value` and put their typed status, DNS, wildcard, HTTP, rule, and error evidence in `details`.
-
-Extract one discovery route at a time:
+Extract common result types with `jq`:
 
 ```bash
 jq -r 'select(.type == "hostname") | .value' report.jsonl
@@ -317,65 +263,28 @@ jq -c 'select(.type == "person") | .value | fromjson' report.jsonl
 jq -r 'select(.type == "breach") | .value' report.jsonl
 ```
 
-The `subdomains` source selector produces `hostname` records because a result may be the target hostname itself rather than a subordinate name.
-
-Shodan host findings instead use the canonical IP as `value` and place normalized host and per-service evidence in a native `details` object. Shodan discovery paginates both hostname and TLS-certificate searches for the target domain without an adapter-specific result cap, merges duplicate services by IP, and rejects names outside the requested domain. Host metadata appears once, while each service retains its port, TCP or UDP transport, product, version, observation time, CPEs, and available HTTP or TLS summary, including scoped certificate CNs and SANs. Raw banners, response bodies, certificate chains, and Shodan crawler metadata are not retained.
-
-Virtual-host observations do not use that string encoding. Each confirmed name remains one `hostname` finding with `actions: ["vhost"]` and a native `observations` array. Several endpoint observations can enrich the same hostname without creating another result kind or count.
-
-RouteViews evidence also uses native observations. Each `prefix` finding has `scope: "external-relationship"`, `actions: ["routeviews"]`, and observed-origin, BGP route, or RPKI validation records. These records describe provider-observed routing, never registration, ownership, authorization, reachability, or target scope.
-
-ASN organization labels from URLScan, ONYPHE, and the Shodan host action are also native observations. Each label remains tied to its provider and the exact hostname or IP that supplied the relationship. ONYPHE's physical hosting and logical WHOIS labels remain separate observations. Conflicting labels are retained for review; organization text never becomes an ASN owner field or a pivot filter. Before RouteViews runs, the exact source-attributed IP relationship, not the organization label, selects automatic network pivots.
-
-Parse recursive DNS findings as JSON objects:
+Some result types carry structured evidence. `person`, `infostealer`, and recursive DNS values contain JSON strings and need a second `fromjson` step. Shodan hosts use `details`; virtual hosts, network prefixes, and ASN attribution use native observations. Takeover results keep the hostname in `value` and their DNS, wildcard, HTTP, rule, status, and error evidence in `details`.
 
 ```bash
 jq -c 'select(.type == "dns-recursive-finding") | .value | fromjson' report.jsonl
-```
-
-List Shodan services by host:
-
-```bash
 jq -c 'select(.type == "shodan-host") | {ip: .value, services: .details.services}' report.jsonl
-```
-
-List the endpoint observations for each confirmed virtual host:
-
-```bash
 jq -c 'select(.type == "hostname" and .observations) | {hostname: .value, observations}' report.jsonl
-```
-
-List sourced organization labels for ASNs:
-
-```bash
 jq -c 'select(.type == "asn" and .observations) | {asn: .value, observations}' report.jsonl
 ```
 
-Stable Have I Been Pwned breach names use `breach` records. Normalized BuiltWith findings use `framework`, `language`, `server`, `cms`, or `analytics` records. Recursive runs also include classifications and one summary containing query cost, reached depth, zero-yield batches, and the stop reason.
-
-List every JSONL finding as tab-separated type and value columns:
+List every finding as tab-separated type and value columns:
 
 ```bash
 jq -r 'select(.type != "summary") | [.type, .value] | @tsv' report.jsonl
 ```
 
-#### Legacy JSON and XML
+The `subdomains` capability produces `hostname` records because a result can be the target hostname itself. Read [Results and local data](docs/wiki/Results-and-Local-Data.md) for the complete JSONL and evidence contract.
 
-The legacy JSON report is one object. Host entries remain plain hostnames or use `hostname:address[,address...]` when DNS resolution is enabled. DNS resolution and brute force retain candidates only when A, AAAA, or CNAME evidence is available. CNAME-only candidates remain plain hostnames in CLI, REST, JSON, and XML output.
+### SQLite, JSON, and XML
 
-`Checker.check()` and `DnsForce.run()` retain their existing `(resolved, hosts, addresses)` return shape. Their `records` mappings contain normalized A, AAAA, and CNAME values.
+CLI and API runs use the same SQLite evidence model. JSONL moves one run at a time. The API can import or export completed runs in bulk as a portable SQLite database while leaving queue and worker state behind. Screenshot files are managed separately from their metadata.
 
-| Field | Availability | Contents |
-| --- | --- | --- |
-| `cmd` | Always | Command-line arguments used for the run. |
-| `hosts` | Always | Discovered hosts; an empty array when none are found. |
-| `shodan` | Always | Shodan host objects with canonical IP `value` and structured `details`; an empty array when Shodan is not used. |
-| `ips`, `emails`, `vhosts`, `asns`, `prefixes` | When non-empty | Network and contact findings. RouteViews prefixes are external routing relationships, not claimed target scope. |
-| `urls` | When non-empty | Discovered URLs from every URL-producing source or action. |
-| `people`, `twitter_people`, `linkedin_people` | When non-empty | People and profile findings. |
-| `takeover_results` | When non-empty | Optional takeover-check results. |
-
-The XML report contains only the command, emails, hosts, and virtual hosts. JSON and XML group findings by type without source attribution, lifecycle outcomes, or structured action evidence.
+JSON and XML are compatibility reports grouped by result type. They do not include the full provenance, lifecycle outcomes, or structured action evidence available in JSONL, SQLite, the API, and HarvestView.
 
 ## Development and contributing
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ docker compose down
 | `POST /api/v1/runs/{run_id}/cancel` | Cancel queued or running work. |
 | `POST /api/v1/runs/import` | Import JSONL evidence without executing discovery. |
 | `POST /api/v1/runs/import-database` | Import completed runs from a theHarvester SQLite database. |
+| `GET /api/v1/runs/export-database` | Export all completed run evidence as a portable SQLite database. |
 | `GET /api/v1/runs/{run_id}/export` | Export normalized evidence as JSONL. |
 
 HarvestView can start a screenshot or DNS brute-force run directly from a hostname result. These actions create a separate run record for that hostname and leave the parent evidence unchanged. Resolver addresses may be entered directly or loaded from a text file with one IP address per line. Ordinary DNS actions accept one or more resolvers; recursive DNS requires exactly three.

--- a/docs/adr/0003-run-worker-lifecycle.md
+++ b/docs/adr/0003-run-worker-lifecycle.md
@@ -1,6 +1,6 @@
 # Keep run records separate with one isolated worker
 
-Status: proposed
+Status: accepted
 
 ## Decision
 
@@ -16,4 +16,4 @@ The existing core is a finite one-shot enumerator and its result object is creat
 
 ## Consequences
 
-Run records need one small SQLite table and a lifecycle API. Child-process boundaries make deadline and forced cancellation reliable across blocking provider code. Work is serialized by design. Imported evidence enters as an already completed run record and never enters the queue.
+Run records need one small SQLite table and a lifecycle API. Child-process boundaries make deadline and forced cancellation reliable across blocking provider code. Work is serialized by design. Imported evidence enters as an already completed run record and never enters the queue. Portable database export copies finalized evidence with its original run IDs while omitting lifecycle, cancellation, and worker-lease state.

--- a/docs/images/harvestview-architecture.svg
+++ b/docs/images/harvestview-architecture.svg
@@ -96,7 +96,7 @@
     <text x="1000" y="276" class="node-title">Inspect and export</text>
     <text x="1000" y="300" class="node-copy-strong">history · assessment · route tabs</text>
     <text x="1000" y="320" class="node-copy-strong">screenshots · source outcomes · logs</text>
-    <text x="1000" y="340" class="node-copy">review child actions · export JSONL</text>
+    <text x="1000" y="340" class="node-copy">review actions · JSONL / SQLite export</text>
 
     <line x1="40" y1="636" x2="1240" y2="636" stroke="rgba(14,29,34,.14)" stroke-width=".8"/>
     <line x1="48" y1="676" x2="88" y2="676" class="connector" marker-end="url(#harvestview-architecture-arrow)"/>

--- a/docs/wiki/Configuration-and-API-Keys.md
+++ b/docs/wiki/Configuration-and-API-Keys.md
@@ -41,13 +41,13 @@ apikeys:
 
 Do not commit populated configuration files. Prefer provider credentials scoped to the minimum access the provider supports.
 
-The [README source matrix](https://github.com/laramies/theHarvester/blob/dev/README.md#discovery-sources) is the canonical source list. It shows whether each source requires a key, accepts an optional key, or has no key setting.
+The [README source matrix](https://github.com/laramies/theHarvester/blob/dev/README.md#discovery-sources) lists each source's result routes, activity class, and credential requirement. The executable source catalog is the authoritative inventory.
 
 Provider pricing, quotas, and terms change frequently. Check the provider's current documentation for these details.
 
-`censys.token` is a Censys Platform Personal Access Token. Set `organization_id` when searches should use an entitled organization. This source uses the Global Search API, which is unavailable to Free accounts because they are limited to asset lookups. The retired Search API ID and secret fields are not accepted.
+`censys.token` is a Censys Platform Personal Access Token. Set `organization_id` when searches should use an entitled organization. This source uses the Global Search API, which is unavailable to Free accounts because they are limited to asset lookups. Search API ID and secret fields are not accepted.
 
-`hibpverified` queries [HIBP's authenticated verified-domain endpoint](https://haveibeenpwned.com/API/v3#BreachedDomain). It is selected by its name, the `breaches` capability, and `all`. Without a configured HIBP API key it is skipped like other unavailable keyed sources. Live use requires a user-owned paid HIBP API key and a user-owned domain verified in that account. The keyless `haveibeenpwned` source continues to query only the public breach catalogue.
+`hibpverified` queries [HIBP's authenticated verified-domain endpoint](https://haveibeenpwned.com/API/v3#BreachedDomain). It is selected by its name, the `breaches` capability, and `all`. Without a configured HIBP API key it is skipped like other unavailable keyed sources. Live use requires a user-owned paid HIBP API key and a user-owned domain verified in that account. The keyless `haveibeenpwned` source queries only the public breach catalogue.
 
 `routeviews.key` is optional. RouteViews provides authenticated API keys to verified PeeringDB users. `--routeviews` uses the authenticated endpoint and documented 10-request-per-second allowance when the key is configured; otherwise it uses guest access at one request per second. If RouteViews rejects a configured key, the action fails without retrying as a guest; remove the key to select guest access. RouteViews does not document this as a paid subscription.
 

--- a/docs/wiki/How-to-add-a-new-module.md
+++ b/docs/wiki/How-to-add-a-new-module.md
@@ -25,7 +25,7 @@ An adapter normally provides:
 
 Do not return fields the provider did not supply. Normalize and deduplicate before returning results.
 
-Return `None` when the provider conversation completed normally, including a valid zero-result response. Return an immutable `SourceExecutionReport` with a stable provider-specific reason for another terminal condition: `completed` for a successful early stop such as reaching the requested result limit, `failed` for provider or transport failure, `rate-limited` for a terminal rate limit, or `partial` when the provider itself confirms incomplete coverage. Do not add mutable `execution_status` or `stop_reason` fields to an adapter. The source runner rejects adapters that expose either removed field before execution and rechecks before evidence collection. The source runner owns finalization: it promotes any incomplete report with retained normalized evidence to `partial`, and records a normal zero-result completion as `completed` with `no-results`.
+Return `None` when the provider conversation completed normally, including a valid zero-result response. Return an immutable `SourceExecutionReport` with a stable provider-specific reason for another terminal condition: `completed` for a successful early stop such as reaching the requested result limit, `failed` for provider or transport failure, `rate-limited` for a terminal rate limit, or `partial` when the provider confirms incomplete coverage. Adapters must not define mutable `execution_status` or `stop_reason` fields. The source runner checks for either field before execution and again before evidence collection. It owns finalization, promotes incomplete reports with retained normalized evidence to `partial`, and records a normal zero-result completion as `completed` with `no-results`.
 
 ### Own the provider conversation
 
@@ -42,7 +42,7 @@ The completion check is an offline test in which a later page depends on state e
 
 ## 3. Register the source
 
-Add one catalog entry in [`theHarvester/lib/source_catalog.py`](https://github.com/laramies/theHarvester/blob/dev/theHarvester/lib/source_catalog.py) and one factory entry in [`theHarvester/lib/source_runner.py`](https://github.com/laramies/theHarvester/blob/dev/theHarvester/lib/source_runner.py). The catalog supplies CLI help, source selection, and activity classification; the factory constructs the adapter; the runner collects declared result routes and persists them through the existing completed-result flow.
+Add one catalog entry in [`theHarvester/lib/source_catalog.py`](https://github.com/laramies/theHarvester/blob/dev/theHarvester/lib/source_catalog.py) and one factory entry in [`theHarvester/lib/source_runner.py`](https://github.com/laramies/theHarvester/blob/dev/theHarvester/lib/source_runner.py). The catalog supplies CLI help, source selection, and activity classification. The factory constructs the adapter. The runner collects declared result routes and persists them with the completed run.
 
 Keep the public source identifier stable and use the same spelling everywhere.
 
@@ -74,6 +74,6 @@ Tests must not require external network access or real provider credentials.
 
 ## 6. Update operator documentation
 
-Add the source to the README source/result matrix with its actual output columns and key requirement. The matrix contract test checks that documented result types match the catalog entry.
+Add the source to the README matrix with its result routes, activity class, and credential requirement. The matrix contract test checks those values against the catalog entry.
 
 In the pull request, link the provider API documentation and explain any intentional exception to shared transport behavior.

--- a/docs/wiki/Operator-Workflows.md
+++ b/docs/wiki/Operator-Workflows.md
@@ -16,7 +16,7 @@ Use the [README source matrix](https://github.com/laramies/theHarvester/blob/dev
 uv run theHarvester -d example.com -b crtsh,certspotter -f report
 ```
 
-Use `report.jsonl` for automation, provenance, and run interchange. The same command also writes legacy `report.json` and `report.xml` compatibility files. See [Results and Local Data](Results-and-Local-Data).
+Use `report.jsonl` for automation, provenance, and run interchange. The same command also writes `report.json` and `report.xml` compatibility files. See [Results and Local Data](Results-and-Local-Data).
 
 ## DNS resolution
 
@@ -45,7 +45,7 @@ AUTHORIZED_DOMAIN='replace-with-a-domain-you-control'
 uv run theHarvester -d "$AUTHORIZED_DOMAIN" -b crtsh -r -s
 ```
 
-Shodan output is enrichment after discovery and is separate from what most discovery sources add to the consolidated result columns.
+Shodan host enrichment runs after discovery and is separate from the `shodan` source's subdomain results.
 
 ## DNS brute force
 

--- a/docs/wiki/Quick-Start.md
+++ b/docs/wiki/Quick-Start.md
@@ -24,7 +24,7 @@ This queries two passive certificate sources and prints consolidated findings. P
 uv run theHarvester -d example.com -b crtsh,certspotter -f report
 ```
 
-This writes `report.jsonl` for automation and interchange. It also writes legacy `report.json` and `report.xml` compatibility reports. See [Results and Local Data](Results-and-Local-Data).
+This writes `report.jsonl` for automation and interchange. It also writes `report.json` and `report.xml` compatibility reports. See [Results and Local Data](Results-and-Local-Data).
 
 ## Resolve discovered hosts
 

--- a/docs/wiki/Responsible-Use-and-Scope.md
+++ b/docs/wiki/Responsible-Use-and-Scope.md
@@ -24,7 +24,7 @@ The following options require additional care:
 | `--screenshot DIR` | Opens discovered web services in a browser. |
 | `-a`, `--api-scan` | Requests common API paths from the target. |
 
-Use `--dns-resolvers IPS_OR_FILE` to select resolver addresses for DNS brute force, reverse lookup, or recursive DNS without also enabling hostname resolution. The compatible `--dns-resolve` value still selects resolvers and enables hostname resolution.
+Use `--dns-resolvers IPS_OR_FILE` to select resolver addresses for DNS brute force, reverse lookup, or recursive DNS without enabling hostname resolution. `--dns-resolve [IPS_OR_FILE]` selects resolvers and enables hostname resolution.
 
 `--routeviews` is a separately selected P0 provider action. It is never enabled by `-b all` and ignores `-l`; one run is internally bounded to 300 sequential requests and 300 seconds. With no configured key it uses the documented guest rate of one request per second. A configured `routeviews.key` selects PeeringDB-verified authenticated access and the documented 10-request-per-second allowance. When selected for a domain run, it automatically queries harvested IPs backed by sourced IP-to-ASN attribution. It also accepts an ASN, IP, or CIDR supplied as the run target. Harvested IPs without that attribution are not sent, and bare ASN findings are not expanded into complete prefix inventories. IP lookups retain only the most-specific returned prefix, including all origins for a multi-origin prefix. The action does not recursively query returned prefixes and never promotes returned CIDRs into DNS or direct-action scope. Cloud and CDN routes can be useful relationship evidence, but route origins and RPKI states do not establish ownership or authorization.
 

--- a/docs/wiki/Rest-API.md
+++ b/docs/wiki/Rest-API.md
@@ -32,6 +32,7 @@ Treat the runtime OpenAPI document as the exact request and response reference.
 | `POST /api/v1/runs/{run_id}/cancel` | Cancel queued work or request cancellation of running work. |
 | `POST /api/v1/runs/import` | Import a JSONL result file without executing discovery. |
 | `POST /api/v1/runs/import-database` | Import completed runs from a theHarvester SQLite database. |
+| `GET /api/v1/runs/export-database` | Export all completed run evidence as a portable SQLite database. |
 | `GET /api/v1/runs/{run_id}/export` | Export normalized results as JSONL. |
 | `GET /api/v1/runs/{run_id}/screenshots/{name}` | Retrieve one managed screenshot. |
 
@@ -168,6 +169,16 @@ curl -s "http://127.0.0.1:5000/api/v1/runs/import-database?filename=stash.sqlite
 ```
 
 The server checks the SQLite header, integrity, schema, and each completed run before copying it. Original run IDs are preserved. Exact duplicates are skipped, while a reused ID with different evidence is rejected. Close the source process or checkpoint its WAL before uploading the database. Screenshot metadata is imported, but screenshot files must be copied separately. The default upload ceiling is 1 GiB and can be changed with `THEHARVESTER_MAX_DATABASE_IMPORT_BYTES`.
+
+Export every completed run as a consistent database that can be imported elsewhere:
+
+```bash
+curl -s "http://127.0.0.1:5000/api/v1/runs/export-database" \
+  -H "X-API-Key: $THEHARVESTER_API_KEY" \
+  -o theharvester-completed-runs.sqlite
+```
+
+The export is rebuilt from canonical completed evidence, so it excludes queue state, cancellation state, worker leases, and legacy observations. It includes screenshot metadata but not screenshot files. The server checkpoints and closes the temporary database before download; no manual WAL handling is required.
 
 Export one normalized result set in the same streamable format:
 

--- a/docs/wiki/Rest-API.md
+++ b/docs/wiki/Rest-API.md
@@ -188,7 +188,7 @@ curl -s "http://127.0.0.1:5000/api/v1/runs/$run_id/export" \
   -o results.jsonl
 ```
 
-The first line is the `summary` record, including evidence status, source and action outcomes, and artifacts. Each remaining line is one normalized finding with `type`, `value`, `sources`, and optional `actions`. A hostname confirmed by the `vhost` action adds native endpoint observations; a RouteViews `prefix` adds native origin, route, and RPKI observations with fixed external-relationship scope. This keeps the file easy to stream with `jq -c` and makes API exports importable again without a format conversion. Lifecycle details and the submitted request remain available from `GET /api/v1/runs/{run_id}`.
+The first line is the `summary` record, including evidence status, source and action outcomes, and artifacts. Each remaining line is one normalized finding with `type`, `value`, `sources`, and optional `actions`. A hostname confirmed by the `vhost` action adds native endpoint observations; a RouteViews `prefix` adds native origin, route, and RPKI observations with fixed external-relationship scope. The file can be streamed with `jq -c` or imported through the API without conversion. Lifecycle details and the submitted request are available from `GET /api/v1/runs/{run_id}`.
 
 ## Security boundary
 

--- a/docs/wiki/Results-and-Local-Data.md
+++ b/docs/wiki/Results-and-Local-Data.md
@@ -75,7 +75,7 @@ Two operational tables support the API without changing those six evidence conce
 
 ## API results
 
-`GET /api/v1/runs/{run_id}` returns lifecycle state plus a normalized `results` array. Each result has `type`, `value`, `sources`, and `actions`. A `hostname` found through the `vhost` action has native endpoint observations; a `prefix` found through RouteViews has native origin, route, and RPKI observations with fixed external-relationship scope. Run-level source and action outcomes remain available in `source_executions` and `action_executions`, while file metadata is returned through `artifacts`. JSONL imports or exports one run, and SQLite import loads completed runs in bulk. Treat runtime `/docs`, `/redoc`, and OpenAPI as the exact request and response reference.
+`GET /api/v1/runs/{run_id}` returns lifecycle state plus a normalized `results` array. Each result has `type`, `value`, `sources`, and `actions`. A `hostname` found through the `vhost` action has native endpoint observations; a `prefix` found through RouteViews has native origin, route, and RPKI observations with fixed external-relationship scope. Run-level source and action outcomes remain available in `source_executions` and `action_executions`, while file metadata is returned through `artifacts`. JSONL imports or exports one run. SQLite import and `GET /api/v1/runs/export-database` move completed runs in bulk without queue, cancellation, or worker-lease state. Treat runtime `/docs`, `/redoc`, and OpenAPI as the exact request and response reference.
 
 ## Handling and sharing
 

--- a/docs/wiki/Results-and-Local-Data.md
+++ b/docs/wiki/Results-and-Local-Data.md
@@ -20,19 +20,19 @@ The recommended automation output is `report.jsonl`. Its first record summarizes
 jq -c 'select(.type != "summary") | {type, value, sources, actions}' report.jsonl
 ```
 
-The same `-f report` command also creates `report.json` and `report.xml` for compatibility.
+The same `-f report` command creates `report.json` and `report.xml` compatibility reports.
 
-## Legacy JSON and XML
+## JSON and XML compatibility reports
 
 - **JSON** is one object and contains the broader result set. `cmd`, `hosts`, and `shodan` are always present; other fields appear when non-empty.
 - **XML** contains the command, emails, hosts, and virtual hosts. Use JSON for other result types.
-- Current JSON and XML reports do not record which source found each item.
+- JSON and XML reports do not record which source found each item.
 
 When virtual host discovery runs, JSON's `vhosts` array and XML's `<vhost>` entries contain confirmed hostnames only. They do not include endpoint or baseline evidence; use JSONL or API run details for that structured data.
 
 Host values may be plain hostnames. When DNS resolution is enabled, they can also use the `hostname:IP` form.
 
-The repository [README output section](https://github.com/laramies/theHarvester/blob/dev/README.md#report-formats) documents the current formats and provides copyable `jq` examples for JSONL.
+The repository [README output section](https://github.com/laramies/theHarvester/blob/dev/README.md#output-and-local-data) summarizes the formats and provides copyable `jq` examples for JSONL.
 
 ## SQLite database
 
@@ -57,7 +57,7 @@ The normalized persistence model can represent active-action provenance and arti
 
 Virtual-host evidence stays inside this model. `results` holds one `hostname` row, `result_origins` links it to the `vhost` action execution, and the result's `details_json` contains the canonical endpoint observation array. If one hostname is distinct on several IP endpoints, it remains one result with several observations.
 
-Current runtime collection populates passive source executions plus DNS, takeover, Shodan, and API endpoint scan executions and origins. Screenshot actions attach file metadata to their captured hostname or URL without creating fake screenshot findings.
+Runtime collection records passive source executions plus DNS, takeover, Shodan, and API endpoint scan executions and origins. Screenshot actions attach file metadata to their captured hostname or URL without creating screenshot findings.
 
 RouteViews creates `prefix` results with `scope: external-relationship` and `routeviews` action provenance. Native observations distinguish one ASN-prefix origin claim, one collector/peer BGP route, and one RPKI validation state. They are routing evidence, not registration, ownership, authorization, reachability, or expanded target scope.
 
@@ -67,7 +67,7 @@ Every discovered URL is stored as the `url` result kind. Its source or action or
 
 Hostname and IP evidence use the `hostname` and `ip` result kinds in SQLite, JSONL, the API, and HarvestView. A hostname may be the authorized target itself or a subordinate name, so the result kind does not claim that every value is a subdomain.
 
-Two operational tables support the API without changing those six evidence concepts: `run_records` stores queue and lifecycle state, and `run_worker_leases` prevents two local workers from claiming the same queue. Older runless rows remain in `legacy_observations`. SQLite upgrades supported schemas automatically during normal initialization.
+Two operational tables support the API without changing those six evidence concepts: `run_records` stores queue and lifecycle state, and `run_worker_leases` prevents two local workers from claiming the same queue. Runless rows are stored in `legacy_observations`. SQLite upgrades supported schemas automatically during normal initialization.
 
 ## Screenshots
 

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -11,4 +11,4 @@ Released changes are recorded in:
 - [CHANGELOG.md](https://github.com/laramies/theHarvester/blob/dev/CHANGELOG.md)
 - [GitHub Releases](https://github.com/laramies/theHarvester/releases)
 
-This page keeps the historical `Roadmap` URL valid without duplicating work that belongs in issues and milestones.
+This page points to the live project artifacts so plans are not duplicated in the wiki.

--- a/docs/wiki/Virtual-Host-Discovery.md
+++ b/docs/wiki/Virtual-Host-Discovery.md
@@ -259,7 +259,7 @@ The `context_*` fields contain the literal-IP response, while `control_*` contai
 
 SQLite uses the same shape without inventing another evidence concept: `results` holds one `hostname` row, `result_origins` links it to the `vhost` execution, and that result's details hold the endpoint observation array. JSONL export and API run details expose the array as native JSON. `vhost` is an action name, not a result kind.
 
-Legacy JSON and XML keep their existing virtual host name lists. They do not carry the endpoint and response evidence. Use JSONL or `GET /api/v1/runs/{run_id}` when automation needs the structured observations.
+JSON and XML compatibility reports contain virtual host name lists but not endpoint or response evidence. Use JSONL or `GET /api/v1/runs/{run_id}` when automation needs the structured observations.
 
 ## Troubleshooting
 

--- a/tests/e2e/test_harvestview.py
+++ b/tests/e2e/test_harvestview.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import asyncio
 import json
+import sqlite3
 from collections import Counter
-from concurrent.futures import ThreadPoolExecutor
-from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -1380,40 +1378,107 @@ def test_completed_empty_import_explains_terminal_outcome(
 
 
 def test_harvestview_imports_completed_runs_from_sqlite(
-    harvestview_server_url: str,
+    harvestview_server,
     page: Page,
     tmp_path: Path,
 ) -> None:
-    from theHarvester.lib.completed_result import CompletedResult
-    from theHarvester.lib.database import ResultStore, dispose_sqlite_databases
-
-    database = tmp_path / 'completed-runs.sqlite'
-    now = datetime.now(UTC)
-    completed = CompletedResult.finish(
-        target='sqlite.example.test',
-        started_at=now,
-        completed_at=now,
-        groups={'hostname': ['api.sqlite.example.test']},
+    harvestview_server_url = harvestview_server.url
+    source_run_id = '4ef278df-ce95-4120-9241-6e71dd96ad74'
+    evidence_file = tmp_path / 'completed-run.jsonl'
+    write_jsonl_evidence(
+        evidence_file,
+        {
+            'run_id': source_run_id,
+            'target': 'sqlite.example.test',
+            'started_at': '2026-08-08T01:00:00Z',
+            'completed_at': '2026-08-08T01:01:00Z',
+            'status': 'complete',
+            'source_executions': [{'source': 'crtsh', 'status': 'completed', 'duration_ms': 2, 'result_count': 1}],
+            'action_executions': [{'action': 'vhost', 'status': 'completed', 'duration_ms': 1, 'result_count': 1}],
+            'results': [
+                {
+                    'type': 'hostname',
+                    'value': 'admin.sqlite.example.test',
+                    'sources': ['crtsh'],
+                    'actions': ['vhost'],
+                    'observations': [
+                        {
+                            'endpoint': 'https://192.0.2.8:443/',
+                            'http_host': 'admin.sqlite.example.test',
+                            'tls_server_name': 'admin.sqlite.example.test',
+                            'classification': 'distinct',
+                            'phase': 'body',
+                            'status': 401,
+                            'location': None,
+                            'body_sha256': 'a' * 64,
+                            'body_size': 12,
+                            'body_truncated': False,
+                            'context_phase': 'body',
+                            'context_status': 200,
+                            'context_location': None,
+                            'context_body_sha256': 'a' * 64,
+                            'context_body_size': 12,
+                            'context_body_truncated': False,
+                            'control_phase': 'body',
+                            'control_status': 200,
+                            'control_location': None,
+                            'control_body_sha256': 'a' * 64,
+                            'control_body_size': 12,
+                            'control_body_truncated': False,
+                            'confirmation_body_sha256': None,
+                            'tls_verified': True,
+                            'distinct_signals': ['status'],
+                            'reflection_normalized': False,
+                        }
+                    ],
+                }
+            ],
+        },
     )
-
-    async def prepare_database() -> None:
-        store = ResultStore(database)
-        await store.initialize()
-        await store.save_run(completed)
-        await dispose_sqlite_databases()
-
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        executor.submit(lambda: asyncio.run(prepare_database())).result()
 
     page.goto(f'{harvestview_server_url}/')
     page.get_by_role('button', name='Import result file').first.click()
-    page.locator('#result-file').set_input_files(database)
+    page.locator('#result-file').set_input_files(evidence_file)
     page.locator('#submit-import-button').click()
 
     expect(page.locator('#detail-target')).to_have_text('sqlite.example.test')
     expect(page.locator('#run-count')).to_have_text('1')
-    expect(page.locator('#toast')).to_have_text('Imported 1 run from completed-runs.sqlite; 0 already present.')
+    expect(page.locator('#toast')).to_have_text('Imported completed-run.jsonl without executing discovery.')
     expect(page.get_by_role('button', name='Hostnames 1')).to_be_enabled()
+    imported_run_id = page.locator('#detail-run-id').inner_text()
+    with page.expect_download() as database_download:
+        page.get_by_role('button', name='Export database').click()
+    assert database_download.value.suggested_filename == 'theharvester-completed-runs.sqlite'
+    exported_database = Path(database_download.value.path())
+    portable_database = tmp_path / database_download.value.suggested_filename
+    portable_database.write_bytes(exported_database.read_bytes())
+    assert portable_database.read_bytes().startswith(b'SQLite format 3\x00')
+    with sqlite3.connect(portable_database) as connection:
+        exported_run_ids = {row[0] for row in connection.execute('SELECT run_id FROM runs')}
+        exported_tables = {row[0] for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+    assert exported_run_ids == {imported_run_id}
+    assert {'run_records', 'run_worker_leases'}.isdisjoint(exported_tables)
+
+    harvestview_server.stop()
+    database = Path(harvestview_server.environment['THEHARVESTER_RUN_DB'])
+    for database_file in (database, Path(f'{database}-wal'), Path(f'{database}-shm')):
+        database_file.unlink(missing_ok=True)
+    harvestview_server.start()
+
+    page.goto(f'{harvestview_server_url}/')
+    expect(page.get_by_role('heading', name='No enumeration runs yet')).to_be_visible()
+    page.get_by_role('button', name='Import result file').first.click()
+    page.locator('#result-file').set_input_files(portable_database)
+    page.locator('#submit-import-button').click()
+
+    expect(page.locator('#toast')).to_have_text('Imported 1 run from theharvester-completed-runs.sqlite; 0 already present.')
+    expect(page.locator('#detail-run-id')).to_have_text(imported_run_id)
+    expect(page.locator('#detail-target')).to_have_text('sqlite.example.test')
+    result_row = page.locator('.tabulator-row').first
+    expect(result_row).to_contain_text('admin.sqlite.example.test')
+    expect(result_row).to_contain_text('https://192.0.2.8:443/ · HTTP 401 · status')
+    expect(result_row).to_contain_text('crtsh')
+    expect(result_row).to_contain_text('vhost')
 
 
 def test_harvestview_can_import_and_analyze_fixture_evidence_through_the_real_ui(

--- a/tests/e2e/test_harvestview.py
+++ b/tests/e2e/test_harvestview.py
@@ -1377,7 +1377,7 @@ def test_completed_empty_import_explains_terminal_outcome(
     assert exported_records[0]['source_executions'][0]['status'] == 'completed'
 
 
-def test_harvestview_imports_completed_runs_from_sqlite(
+def test_harvestview_exports_and_reimports_completed_runs_as_sqlite(
     harvestview_server,
     page: Page,
     tmp_path: Path,

--- a/tests/lib/test_api_v1.py
+++ b/tests/lib/test_api_v1.py
@@ -265,6 +265,7 @@ def test_api_exposes_one_fresh_run_contract(tmp_path, monkeypatch) -> None:
         '/api/v1/runs',
         '/api/v1/runs/import',
         '/api/v1/runs/import-database',
+        '/api/v1/runs/export-database',
         '/api/v1/runs/{run_id}',
         '/api/v1/runs/{run_id}/cancel',
         '/api/v1/runs/{run_id}/export',
@@ -441,6 +442,11 @@ def test_openapi_explains_scope_and_execution_controls(tmp_path, monkeypatch) ->
     assert 'endpoint paths' in properties['api_scan_paths']['description']
     import_content = schema['paths']['/api/v1/runs/import']['post']['requestBody']['content']
     assert set(import_content) == {'application/x-ndjson'}
+    database_export_content = schema['paths']['/api/v1/runs/export-database']['get']['responses']['200']['content']
+    assert set(database_export_content) == {'application/vnd.sqlite3'}
+    assert database_export_content['application/vnd.sqlite3']['schema']['description'] == (
+        'Portable SQLite database containing every completed run and no API lifecycle state.'
+    )
     export_content = schema['paths']['/api/v1/runs/{run_id}/export']['get']['responses']['200']['content']
     assert set(export_content) == {'application/x-ndjson'}
     assert set(schema['components']['schemas']['NormalizedResult']['properties']) == {
@@ -793,6 +799,117 @@ def test_api_database_import_exposes_completed_cli_runs(tmp_path, monkeypatch) -
     assert imported.json()['imported_run_ids'] == [str(completed.run_id)]
     assert detail.status_code == 200
     assert detail.json()['results'] == [{'type': 'hostname', 'value': 'api.imported.example.test', 'sources': [], 'actions': []}]
+
+
+def test_api_database_export_round_trip_contains_only_completed_evidence(tmp_path, monkeypatch) -> None:
+    from theHarvester.lib.api import api
+
+    source_database = tmp_path / 'source.sqlite'
+    destination_database = tmp_path / 'destination.sqlite'
+    exported_database = tmp_path / 'exported.sqlite'
+    headers = {'X-API-Key': 'test-key'}
+    monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
+    monkeypatch.setenv('THEHARVESTER_RUN_DB', str(source_database))
+    monkeypatch.setenv('THEHARVESTER_RUN_WORKER', 'disabled')
+    vhost_records = [json.loads(line) for line in _vhost_jsonl_result().splitlines()]
+    vhost_records[0]['source_executions'] = [
+        {
+            'source': 'crtsh',
+            'status': 'completed',
+            'duration_ms': 2,
+            'result_count': 1,
+            'error_type': None,
+            'stop_reason': None,
+        }
+    ]
+    vhost_records[0]['action_executions'].append(
+        {
+            'action': 'screenshot',
+            'status': 'completed',
+            'duration_ms': 1,
+            'result_count': 0,
+            'error_type': None,
+            'stop_reason': None,
+        }
+    )
+    vhost_records[0]['artifacts'] = [
+        {
+            'action': 'screenshot',
+            'kind': 'screenshot',
+            'subject': {'kind': 'hostname', 'value': 'admin.example.test'},
+            'file': {
+                'path': 'screenshots/admin.example.test.png',
+                'media_type': 'image/png',
+                'size_bytes': 16,
+                'sha256': '0' * 64,
+            },
+            'created_at': '2026-08-08T01:01:00Z',
+        }
+    ]
+    vhost_records[1]['sources'] = ['crtsh']
+    vhost_jsonl = ''.join(json.dumps(record) + '\n' for record in vhost_records)
+
+    with TestClient(api.app) as client:
+        first = client.post(
+            '/api/v1/runs/import',
+            params={'filename': 'vhost.jsonl'},
+            headers=headers,
+            content=vhost_jsonl,
+        )
+        second = client.post(
+            '/api/v1/runs/import',
+            params={'filename': 'network.jsonl'},
+            headers=headers,
+            content=_network_jsonl_result(),
+        )
+        source_details = {
+            run_id: client.get(f'/api/v1/runs/{run_id}', headers=headers).json()
+            for run_id in (first.json()['run_id'], second.json()['run_id'])
+        }
+        exported = client.get('/api/v1/runs/export-database', headers=headers)
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert exported.status_code == 200
+    assert exported.headers['content-type'] == 'application/vnd.sqlite3'
+    assert exported.headers['content-disposition'] == 'attachment; filename="theharvester-completed-runs.sqlite"'
+    assert exported.content.startswith(b'SQLite format 3\x00')
+    exported_database.write_bytes(exported.content)
+    with sqlite3.connect(exported_database) as connection:
+        tables = {row[0] for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+    assert {'runs', 'results'} <= tables
+    assert {'run_records', 'run_worker_leases'}.isdisjoint(tables)
+
+    monkeypatch.setenv('THEHARVESTER_RUN_DB', str(destination_database))
+    with TestClient(api.app) as client:
+        reimported = client.post(
+            '/api/v1/runs/import-database',
+            params={'filename': 'theharvester-completed-runs.sqlite'},
+            headers={**headers, 'Content-Type': 'application/vnd.sqlite3'},
+            content=exported.content,
+        )
+        imported_details = {
+            run_id: client.get(f'/api/v1/runs/{run_id}', headers=headers).json()
+            for run_id in reimported.json()['imported_run_ids']
+        }
+
+    assert reimported.status_code == 201
+    assert reimported.json()['imported_run_ids'] == sorted((first.json()['run_id'], second.json()['run_id']))
+    canonical_evidence_fields = (
+        'run_id',
+        'target',
+        'started_at',
+        'completed_at',
+        'evidence_status',
+        'result_count',
+        'source_executions',
+        'action_executions',
+        'artifacts',
+        'results',
+    )
+    assert {
+        run_id: {field: detail[field] for field in canonical_evidence_fields} for run_id, detail in imported_details.items()
+    } == {run_id: {field: detail[field] for field in canonical_evidence_fields} for run_id, detail in source_details.items()}
 
 
 def test_api_jsonl_round_trip_preserves_source_attribution(tmp_path, monkeypatch) -> None:

--- a/tests/lib/test_harvestview_ui.py
+++ b/tests/lib/test_harvestview_ui.py
@@ -83,7 +83,7 @@ def test_harvestview_has_an_operator_readable_shodan_host_route(tmp_path, monkey
     assert "title: 'Services'" in script.text
 
 
-def test_harvestview_offers_jsonl_and_sqlite_imports_with_jsonl_export(tmp_path, monkeypatch) -> None:
+def test_harvestview_offers_jsonl_and_sqlite_imports_and_exports(tmp_path, monkeypatch) -> None:
     from theHarvester.lib.api import api
 
     monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
@@ -95,11 +95,14 @@ def test_harvestview_offers_jsonl_and_sqlite_imports_with_jsonl_export(tmp_path,
         script = client.get('/static/harvestview/app.js')
 
     assert 'accept=".jsonl,.sqlite,.sqlite3,.db,application/x-ndjson,application/vnd.sqlite3"' in root.text
+    assert 'id="export-database-button"' in root.text
     assert 'id="export-jsonl-button"' in root.text
     assert 'id="route-csv-button"' not in root.text
     assert 'id="export-json-button"' not in root.text
     assert 'id="export-csv-button"' not in root.text
     assert '/export' in script.text
+    assert '/api/v1/runs/export-database' in script.text
+    assert 'theharvester-completed-runs.sqlite' in script.text
     assert "fileKind === 'jsonl' ? '/api/v1/runs/import' : '/api/v1/runs/import-database'" in script.text
     assert '/exports/' not in script.text
     assert 'text/csv' not in script.text

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -6,18 +6,8 @@ from pathlib import Path
 
 import yaml
 
-from theHarvester.lib.source_catalog import SOURCE_SPECS, ResultRoute
+from theHarvester.lib.source_catalog import SOURCE_SPECS
 
-RESULT_COLUMNS = ('Subdomains', 'Emails', 'IPs', 'ASNs', 'URLs', 'People', 'Breaches')
-ROUTE_COLUMNS = {
-    ResultRoute.SUBDOMAINS: 'Subdomains',
-    ResultRoute.EMAILS: 'Emails',
-    ResultRoute.IPS: 'IPs',
-    ResultRoute.ASNS: 'ASNs',
-    ResultRoute.URLS: 'URLs',
-    ResultRoute.PEOPLE: 'People',
-    ResultRoute.BREACHES: 'Breaches',
-}
 OPTIONAL_API_KEY_SOURCES = {'hackertarget', 'mojeek', 'windvane'}
 API_KEY_SOURCE_ALIASES = {
     'github': {'github-code'},
@@ -44,7 +34,7 @@ WIKI_PAGES = {
 
 
 def _declared_source_contracts() -> dict[str, set[str]]:
-    return {source: {ROUTE_COLUMNS[route] for route in spec.routes} for source, spec in SOURCE_SPECS.items()}
+    return {source: set(spec.capabilities) for source, spec in SOURCE_SPECS.items()}
 
 
 def _documented_source_rows(readme: str) -> dict[str, list[str]]:
@@ -58,12 +48,11 @@ def _documented_source_rows(readme: str) -> dict[str, list[str]]:
 
 
 def _documented_source_contracts(readme: str) -> dict[str, set[str]]:
-    contracts: dict[str, set[str]] = {}
-    for source, cells in _documented_source_rows(readme).items():
-        markers = cells[:7]
-        assert set(markers) <= {'✓', 'No'}
-        contracts[source] = {column for column, marker in zip(RESULT_COLUMNS, markers, strict=True) if marker == '✓'}
-    return contracts
+    return {source: {route.strip() for route in cells[0].split(',')} for source, cells in _documented_source_rows(readme).items()}
+
+
+def _documented_source_activities(readme: str) -> dict[str, str]:
+    return {source: cells[1] for source, cells in _documented_source_rows(readme).items()}
 
 
 def _documented_api_key_requirements(readme: str) -> dict[str, str]:
@@ -80,10 +69,11 @@ def test_readme_matches_declared_source_contracts() -> None:
     documented = _documented_source_contracts(readme)
     declared = _declared_source_contracts()
 
-    assert '| Source | Subdomains | Emails | IPs | ASNs | URLs | People | Breaches |' in readme
+    assert '| Source | Result routes | Activity | Credentials |' in readme
     assert len(declared) == 58
     assert len(documented) == 58
     assert documented == declared
+    assert _documented_source_activities(readme) == {source: spec.activity.value for source, spec in SOURCE_SPECS.items()}
     assert {'securitytrails', 'shodaninternetdb'}.isdisjoint(documented)
 
 
@@ -92,7 +82,7 @@ def test_readme_api_key_markers_match_configuration() -> None:
     requirements = _documented_api_key_requirements(readme)
     configured_source_keys = _configured_api_key_sources() - {'routeviews'}
 
-    assert set(requirements.values()) <= {'✓', 'Optional', 'No'}
+    assert set(requirements.values()) <= {'Required', 'Optional', 'No'}
     assert {source for source, marker in requirements.items() if marker != 'No'} == configured_source_keys
     assert '`routeviews.key`' in readme
     assert {source for source, marker in requirements.items() if marker == 'Optional'} == OPTIONAL_API_KEY_SOURCES
@@ -211,14 +201,10 @@ def test_readme_explains_jsonl_record_and_structured_evidence_parsing() -> None:
         assert f'select(.type == "{result_kind}")' in readme
     assert 'select(.type == "person") | .value | fromjson' in readme
     assert 'select(.type == "dns-recursive-finding") | .value | fromjson' in readme
-    assert 'JSONL is easy to stream one record at a time.' in readme
-    assert '`person` and `infostealer`' in readme
-    assert 'Takeover outcomes instead keep the canonical hostname in `value`' in readme
-    assert 'typed status, DNS, wildcard, HTTP, rule, and error evidence in `details`' in readme
+    assert 'JSONL is the primary format for automation and one-run interchange.' in readme
+    assert '`person`, `infostealer`' in readme
+    assert 'Takeover results keep the hostname in `value`' in readme
+    assert 'DNS, wildcard, HTTP, rule, status, and error evidence in `details`' in readme
     assert 'select(.type == "shodan-host") | {ip: .value, services: .details.services}' in readme
-    assert 'paginates both hostname and TLS-certificate searches' in readme
-    assert 'scoped certificate CNs and SANs' in readme
-    assert 'Raw banners, response bodies, certificate chains, and Shodan crawler metadata are not retained.' in readme
     assert 'select(.type == "hostname" and .observations) | {hostname: .value, observations}' in readme
-    assert 'Several endpoint observations can enrich the same hostname' in readme
-    assert 'The summary preserves the evidence status, source and action outcomes' in readme
+    assert 'select(.type == "asn" and .observations) | {asn: .value, observations}' in readme

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -129,7 +129,7 @@ def test_readme_architecture_diagrams_are_local_and_accessible() -> None:
             'HarvestView run desk architecture',
             Path('docs/images/harvestview-architecture.svg'),
             'harvestview-architecture',
-            ('Authenticated REST API', 'queued → running → terminal', 'Isolated run worker', 'export JSONL'),
+            ('Authenticated REST API', 'queued → running → terminal', 'Isolated run worker', 'JSONL / SQLite export'),
         ),
     )
 
@@ -191,6 +191,16 @@ def test_operator_docs_recommend_jsonl_and_assume_uv_is_available() -> None:
     assert 'curl -LsSf https://astral.sh/uv/install.sh' not in readme
     assert 'curl -LsSf https://astral.sh/uv/install.sh' not in installation
     assert all('`report.jsonl`' in page and 'automation' in page for page in (quick_start, workflows))
+
+
+def test_operator_docs_cover_portable_database_export() -> None:
+    readme = Path('README.md').read_text()
+    rest_api = Path('docs/wiki/Rest-API.md').read_text()
+    local_data = Path('docs/wiki/Results-and-Local-Data.md').read_text()
+
+    assert all('/api/v1/runs/export-database' in page for page in (readme, rest_api, local_data))
+    assert 'queue state, cancellation state, worker leases, and legacy observations' in rest_api
+    assert 'no manual WAL handling is required' in rest_api
 
 
 def test_readme_explains_jsonl_record_and_structured_evidence_parsing() -> None:

--- a/theHarvester/lib/api/run_models.py
+++ b/theHarvester/lib/api/run_models.py
@@ -642,6 +642,20 @@ DATABASE_IMPORT_REQUEST_OPENAPI = {
         'content': {'application/vnd.sqlite3': {'schema': {'type': 'string', 'format': 'binary'}}},
     }
 }
+DATABASE_EXPORT_RESPONSES: dict[int | str, dict[str, Any]] = {
+    200: {
+        'description': 'Portable completed-run evidence as SQLite.',
+        'content': {
+            'application/vnd.sqlite3': {
+                'schema': {
+                    'type': 'string',
+                    'format': 'binary',
+                    'description': 'Portable SQLite database containing every completed run and no API lifecycle state.',
+                }
+            },
+        },
+    }
+}
 EXPORT_RESPONSES: dict[int | str, dict[str, Any]] = {
     200: {
         'description': 'Normalized run results as JSONL.',

--- a/theHarvester/lib/api/run_store.py
+++ b/theHarvester/lib/api/run_store.py
@@ -373,6 +373,10 @@ class RunStore:
             'skipped_run_ids': sorted(skipped_run_ids),
         }
 
+    async def export_database(self, destination: Path) -> None:
+        await self.initialize()
+        await self.results.export_database(destination)
+
     async def list_runs(self, *, limit: int = 100, offset: int = 0) -> list[dict[str, Any]]:
         await self.initialize()
         return [await self._row(record) for record in await self.lifecycle.list_records(limit=limit, offset=offset)]

--- a/theHarvester/lib/api/runs.py
+++ b/theHarvester/lib/api/runs.py
@@ -9,6 +9,7 @@ import anyio
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.responses import FileResponse
 from pydantic import ValidationError
+from starlette.background import BackgroundTask
 
 from theHarvester.lib.api.auth import get_api_key
 from theHarvester.lib.source_catalog import ACTION_ACTIVITIES, SOURCE_SPECS, SourceSpec, get_source_spec, resolve_sources
@@ -16,6 +17,7 @@ from theHarvester.lib.source_catalog import ACTION_ACTIVITIES, SOURCE_SPECS, Sou
 from . import run_worker
 from .run_evidence import parse_jsonl_import
 from .run_models import (
+    DATABASE_EXPORT_RESPONSES,
     DATABASE_IMPORT_REQUEST_OPENAPI,
     EXPORT_RESPONSES,
     IMPORT_REQUEST_OPENAPI,
@@ -35,6 +37,11 @@ router = APIRouter(prefix='/api/v1', tags=['Runs'])
 MAX_IMPORT_BYTES = 10 * 1024 * 1024
 MAX_RUN_REQUEST_BYTES = 64 * 1024
 DEFAULT_MAX_DATABASE_IMPORT_BYTES = 1024 * 1024 * 1024
+
+
+def _remove_database_export(path: Path) -> None:
+    for candidate in (path, Path(f'{path}-wal'), Path(f'{path}-shm')):
+        candidate.unlink(missing_ok=True)
 
 
 async def _read_limited_body(request: Request, limit: int, detail: str) -> bytes:
@@ -223,6 +230,25 @@ async def import_database(
         return DatabaseImportResponse.model_validate(await RunStore().import_database(temporary_path, safe_filename))
     finally:
         await anyio.Path(temporary_path).unlink(missing_ok=True)
+
+
+@router.get('/runs/export-database', response_class=FileResponse, responses=DATABASE_EXPORT_RESPONSES)
+async def export_database(_api_key: Annotated[str, Depends(get_api_key)]) -> FileResponse:
+    descriptor, temporary_name = tempfile.mkstemp(prefix='theharvester-export-', suffix='.sqlite')
+    os.close(descriptor)
+    temporary_path = Path(temporary_name)
+    await anyio.Path(temporary_path).chmod(0o600)
+    try:
+        await RunStore().export_database(temporary_path)
+    except BaseException:
+        _remove_database_export(temporary_path)
+        raise
+    return FileResponse(
+        temporary_path,
+        media_type='application/vnd.sqlite3',
+        filename='theharvester-completed-runs.sqlite',
+        background=BackgroundTask(_remove_database_export, temporary_path),
+    )
 
 
 @router.get('/runs/{run_id}', response_model_exclude_unset=True)

--- a/theHarvester/lib/api/static/harvestview/app.js
+++ b/theHarvester/lib/api/static/harvestview/app.js
@@ -31,7 +31,8 @@
   };
 
   const nodes = {
-    themeButton: $('#theme-button'), importButton: $('#import-button'), newRunButton: $('#new-run-button'),
+    themeButton: $('#theme-button'), importButton: $('#import-button'), exportDatabase: $('#export-database-button'),
+    newRunButton: $('#new-run-button'),
     loading: $('#loading-state'), empty: $('#empty-state'), detail: $('#run-detail'),
     workspaceError: $('#workspace-error'), workspaceErrorMessage: $('#workspace-error-message'),
     retryWorkspace: $('#retry-workspace-button'),
@@ -1249,15 +1250,31 @@
     toast(state.detail.status === 'cancelled' ? 'Queued enumeration cancelled.' : 'Cancellation requested.');
   }
 
-  async function downloadServerExport() {
+  async function downloadServerFile(path, fallbackFilename, failureMessage) {
     try {
-      const response = await api(`/api/v1/runs/${encodeURIComponent(state.selectedId)}/export`);
+      const response = await api(path);
       const disposition = response.headers.get('Content-Disposition') || '';
       const match = disposition.match(/filename="([^"]+)"/);
-      downloadBlob(await response.blob(), match?.[1] || 'harvestview-results.jsonl');
+      downloadBlob(await response.blob(), match?.[1] || fallbackFilename);
     } catch (error) {
-      toast(`Could not export results: ${error.message}. Keep the run open and try again.`, true);
+      toast(`${failureMessage}: ${error.message}`, true);
     }
+  }
+
+  function downloadServerExport() {
+    return downloadServerFile(
+      `/api/v1/runs/${encodeURIComponent(state.selectedId)}/export`,
+      'harvestview-results.jsonl',
+      'Could not export results',
+    );
+  }
+
+  function downloadDatabase() {
+    return downloadServerFile(
+      '/api/v1/runs/export-database',
+      'theharvester-completed-runs.sqlite',
+      'Could not export the database',
+    );
   }
 
   function downloadBlob(blob, filename) {
@@ -1303,6 +1320,7 @@
   nodes.retryWorkspace.addEventListener('click', start);
   nodes.newRunButton.addEventListener('click', openNewRun);
   nodes.importButton.addEventListener('click', openImport);
+  nodes.exportDatabase.addEventListener('click', downloadDatabase);
   nodes.historySearch.addEventListener('input', renderHistory);
   nodes.newRunForm.addEventListener('submit', submitRun);
   nodes.resultActionForm.addEventListener('submit', submitResultAction);

--- a/theHarvester/lib/api/static/harvestview/index.html
+++ b/theHarvester/lib/api/static/harvestview/index.html
@@ -25,6 +25,7 @@
       <nav class="header-actions" aria-label="Run desk actions">
         <button id="theme-button" class="header-button" type="button" aria-label="Change color theme" title="Cycle between system, light, and dark themes.">Theme: system</button>
         <button id="import-button" class="header-button" type="button" title="Store existing JSONL evidence or completed runs from a theHarvester SQLite database without contacting the target.">Import result file</button>
+        <button id="export-database-button" class="header-button" type="button" title="Download a portable SQLite database containing all completed run evidence and no queue or worker state.">Export database</button>
         <button id="new-run-button" class="header-button primary" type="button" title="Review the target, sources, and authorized activity before anything is queued." disabled>Start enumeration</button>
       </nav>
     </header>

--- a/theHarvester/lib/database.py
+++ b/theHarvester/lib/database.py
@@ -76,6 +76,11 @@ logger = logging.getLogger(__name__)
 
 SCHEMA_VERSION = 8
 _DEFAULT_DATABASE = Path('~/.local/share/theHarvester/stash.sqlite').expanduser()
+_PORTABLE_DATABASE_DROP_STATEMENTS = (
+    'DROP TABLE IF EXISTS legacy_observations',
+    'DROP TABLE IF EXISTS run_records',
+    'DROP TABLE IF EXISTS run_worker_leases',
+)
 
 _LEGACY_RESULT_KIND_RENAMES = {
     'api-endpoint': 'url',
@@ -505,6 +510,16 @@ def _database_for(database: str | Path) -> _SQLiteDatabase:
 
 def _row_count(result: Any) -> int:
     return int(result.rowcount)
+
+
+def _finalize_portable_database(path: Path) -> None:
+    with sqlite3.connect(path) as connection:
+        connection.execute('PRAGMA wal_checkpoint(TRUNCATE)')
+        connection.execute('PRAGMA journal_mode = DELETE')
+        for statement in _PORTABLE_DATABASE_DROP_STATEMENTS:
+            connection.execute(statement)
+        connection.commit()
+        connection.execute('VACUUM')
 
 
 class RunLifecycleStore:
@@ -1117,6 +1132,20 @@ class ResultStore:
             }
             for run, result_count in rows
         ]
+
+    async def export_database(self, destination: Path) -> None:
+        """Write every completed run to a portable, importable SQLite database."""
+        await self.initialize()
+        exported = ResultStore(destination)
+        try:
+            await exported.initialize()
+            summaries = await self.list_runs(limit=None)
+            for summary in summaries:
+                await exported.save_run(await self.load_run(UUID(str(summary['run_id']))))
+        finally:
+            await exported.dispose()
+        await asyncio.to_thread(_finalize_portable_database, destination)
+        await exported.validate_import_database()
 
     async def validate_import_database(self) -> None:
         engine = create_async_engine(URL.create('sqlite+aiosqlite', database=self.database))


### PR DESCRIPTION
## Summary

- add an authenticated `GET /api/v1/runs/export-database` endpoint and HarvestView download action
- export completed canonical evidence as a portable SQLite database while excluding queue, cancellation, worker-lease, and legacy state
- preserve run IDs, source/action provenance, structured observations, and artifact metadata for import into another theHarvester instance
- define `CONTEXT.md` as the accepted 5.0.0 release baseline and align the lifecycle ADR and agent pointer
- refocus the README and wiki on current usage, remove release-history narration, and collapse the source matrix to routes, activity, and credentials
- document the REST/UI workflow and update the HarvestView architecture diagram
- align contributor instructions with the `dev`-first upstream workflow

## Scope

Maintainer-approved exception: this release-closing PR combines SQLite export with the specifically requested 5.0.0 release context, README, and wiki cleanup. The runtime change remains limited to SQLite export.

## Verification

- `uv run pytest -m "not harvestview_e2e" -q` - 1733 passed, 6 skipped
- `uv run pytest -m harvestview_e2e -q` - 33 passed
- `uv run pytest tests/test_readme.py -q` - 9 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy theHarvester`
- independent Standards and Spec reviews - clean

The only warning is the existing FastAPI TestClient deprecation for Starlette httpx transport.