### PR TITLE
Link discovery sources to provider documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,68 +162,68 @@ The `shodan` source contributes subdomains. Shodan host enrichment through `-s` 
 
 | Source | Result routes | Activity | Credentials |
 | --- | --- | :---: | :---: |
-| `apis-guru` | subdomains, emails, urls | P0 | No |
-| `arquivo` | subdomains | P0 | No |
-| `baidu` | subdomains, emails | P0 | No |
-| `bevigil` | subdomains, urls | P0 | Required |
-| `bufferoverun` | subdomains, ips | P0 | Required |
-| `builtwith` | subdomains, urls | P0 | Required |
-| `brave` | subdomains, emails | P0 | Required |
-| `censys` | subdomains, emails | P0 | Required |
-| `certspotter` | subdomains | P0 | No |
-| `commoncrawl` | subdomains | P0 | No |
-| `criminalip` | subdomains, ips, asns | P2 | Required |
-| `crt-name` | subdomains | P0 | No |
-| `crtsh` | subdomains | P0 | No |
-| `dehashed` | emails, ips | P0 | Required |
-| `dnsdb` | subdomains | P0 | Required |
-| `dnsdumpster` | subdomains, ips | P0 | Required |
-| `duckduckgo` | subdomains, emails | P0 | No |
-| `dymo` | subdomains | P0 | Required |
-| `fofa` | subdomains, ips | P0 | Required |
-| `fullhunt` | subdomains | P0 | Required |
-| `github-code` | subdomains, emails | P0 | Required |
-| `gitlab` | subdomains, emails, urls | P0 | No |
-| `hackertarget` | subdomains, ips | P0 | Optional |
-| `haveibeenpwned` | breaches | P0 | No |
-| `hibpverified` | emails, breaches | P0 | Required |
-| `hudsonrock` | subdomains, emails, ips | P0 | No |
-| `hunter` | subdomains, emails | P0 | Required |
-| `hunterhow` | subdomains | P0 | Required |
-| `intelx` | subdomains, emails, urls | P0 | Required |
-| `leakix` | subdomains | P0 | Required |
-| `leaklookup` | emails, breaches | P0 | Required |
-| `mojeek` | subdomains, emails | P0 | Optional |
-| `netlas` | subdomains | P0 | Required |
-| `onyphe` | subdomains, ips, asns | P0 | Required |
-| `otx` | subdomains, ips | P0 | No |
-| `pentesttools` | subdomains, ips | P1 | Required |
-| `projectdiscovery` | subdomains | P0 | Required |
-| `rapiddns` | subdomains, ips | P0 | No |
-| `robtex` | ips | P0 | No |
-| `rocketreach` | emails, urls | P0 | Required |
-| `securityscorecard` | subdomains, ips | P0 | Required |
-| `securityTrails` | subdomains, ips | P0 | Required |
-| `sherlockeye` | subdomains, emails, ips | P0 | Required |
-| `shodan` | subdomains | P1 | Required |
-| `shodanInternetDB` | subdomains, ips | P1 | No |
-| `shodanct` | subdomains | P0 | No |
-| `sourcegraph` | subdomains | P0 | No |
-| `subdomaincenter` | subdomains | P0 | No |
-| `subdomainfinderc99` | subdomains | P1 | No |
-| `thc` | subdomains | P0 | No |
-| `tomba` | subdomains, emails | P0 | Required |
-| `urlscan` | subdomains, ips, asns, urls | P0 | No |
-| `virustotal` | subdomains | P0 | Required |
-| `waybackarchive` | subdomains | P0 | No |
-| `whoisxml` | subdomains | P0 | Required |
-| `windvane` | subdomains, emails, ips | P0 | Optional |
-| `yahoo` | subdomains, emails | P0 | No |
-| `zoomeye` | subdomains, emails, ips, asns, urls | P0 | Required |
+| [`apis-guru`](https://apis.guru/) | subdomains, emails, urls | P0 | No |
+| [`arquivo`](https://arquivo.pt/) | subdomains | P0 | No |
+| [`baidu`](https://www.baidu.com/) | subdomains, emails | P0 | No |
+| [`bevigil`](https://bevigil.com/osint-api) | subdomains, urls | P0 | Required |
+| [`bufferoverun`](https://tls.bufferover.run/) | subdomains, ips | P0 | Required |
+| [`builtwith`](https://builtwith.com/) | subdomains, urls | P0 | Required |
+| [`brave`](https://brave.com/search/api/) | subdomains, emails | P0 | Required |
+| [`censys`](https://search.censys.io/) | subdomains, emails | P0 | Required |
+| [`certspotter`](https://sslmate.com/certspotter/) | subdomains | P0 | No |
+| [`commoncrawl`](https://commoncrawl.org/) | subdomains | P0 | No |
+| [`criminalip`](https://www.criminalip.io/) | subdomains, ips, asns | P2 | Required |
+| [`crt-name`](https://crt.name/) | subdomains | P0 | No |
+| [`crtsh`](https://crt.sh/) | subdomains | P0 | No |
+| [`dehashed`](https://dehashed.com/) | emails, ips | P0 | Required |
+| [`dnsdb`](https://docs.domaintools.com/api/dnsdb/) | subdomains | P0 | Required |
+| [`dnsdumpster`](https://dnsdumpster.com/) | subdomains, ips | P0 | Required |
+| [`duckduckgo`](https://duckduckgo.com/) | subdomains, emails | P0 | No |
+| [`dymo`](https://docs.tpeoficial.com/docs/dymo-api/private/data-verifier) | subdomains | P0 | Required |
+| [`fofa`](https://en.fofa.info/) | subdomains, ips | P0 | Required |
+| [`fullhunt`](https://fullhunt.io/) | subdomains | P0 | Required |
+| [`github-code`](https://github.com/) | subdomains, emails | P0 | Required |
+| [`gitlab`](https://gitlab.com/) | subdomains, emails, urls | P0 | No |
+| [`hackertarget`](https://hackertarget.com/) | subdomains, ips | P0 | Optional |
+| [`haveibeenpwned`](https://haveibeenpwned.com/) | breaches | P0 | No |
+| [`hibpverified`](https://haveibeenpwned.com/API/v3#BreachedDomain) | emails, breaches | P0 | Required |
+| [`hudsonrock`](https://www.hudsonrock.com/) | subdomains, emails, ips | P0 | No |
+| [`hunter`](https://hunter.io/) | subdomains, emails | P0 | Required |
+| [`hunterhow`](https://hunter.how/) | subdomains | P0 | Required |
+| [`intelx`](https://intelx.io/) | subdomains, emails, urls | P0 | Required |
+| [`leakix`](https://leakix.net/) | subdomains | P0 | Required |
+| [`leaklookup`](https://leak-lookup.com/) | emails, breaches | P0 | Required |
+| [`mojeek`](https://www.mojeek.com/services/search/web-search-api/) | subdomains, emails | P0 | Optional |
+| [`netlas`](https://netlas.io/) | subdomains | P0 | Required |
+| [`onyphe`](https://www.onyphe.io/) | subdomains, ips, asns | P0 | Required |
+| [`otx`](https://otx.alienvault.com/) | subdomains, ips | P0 | No |
+| [`pentesttools`](https://pentest-tools.com/) | subdomains, ips | P1 | Required |
+| [`projectdiscovery`](https://chaos.projectdiscovery.io/) | subdomains | P0 | Required |
+| [`rapiddns`](https://rapiddns.io/) | subdomains, ips | P0 | No |
+| [`robtex`](https://www.robtex.com/) | ips | P0 | No |
+| [`rocketreach`](https://rocketreach.co/) | emails, urls | P0 | Required |
+| [`securityscorecard`](https://securityscorecard.com/) | subdomains, ips | P0 | Required |
+| [`securityTrails`](https://securitytrails.com/) | subdomains, ips | P0 | Required |
+| [`sherlockeye`](https://sherlockeye.io/) | subdomains, emails, ips | P0 | Required |
+| [`shodan`](https://www.shodan.io/) | subdomains | P1 | Required |
+| [`shodanInternetDB`](https://internetdb.shodan.io/) | subdomains, ips | P1 | No |
+| [`shodanct`](https://ctl.shodan.io/) | subdomains | P0 | No |
+| [`sourcegraph`](https://sourcegraph.com/search) | subdomains | P0 | No |
+| [`subdomaincenter`](https://www.subdomain.center/) | subdomains | P0 | No |
+| [`subdomainfinderc99`](https://subdomainfinder.c99.nl/) | subdomains | P1 | No |
+| [`thc`](https://ip.thc.org/) | subdomains | P0 | No |
+| [`tomba`](https://tomba.io/) | subdomains, emails | P0 | Required |
+| [`urlscan`](https://urlscan.io/) | subdomains, ips, asns, urls | P0 | No |
+| [`virustotal`](https://www.virustotal.com/) | subdomains | P0 | Required |
+| [`waybackarchive`](https://web.archive.org/) | subdomains | P0 | No |
+| [`whoisxml`](https://subdomains.whoisxmlapi.com/) | subdomains | P0 | Required |
+| [`windvane`](https://windvane.lichoin.com/) | subdomains, emails, ips | P0 | Optional |
+| [`yahoo`](https://www.yahoo.com/) | subdomains, emails | P0 | No |
+| [`zoomeye`](https://www.zoomeye.ai/) | subdomains, emails, ips, asns, urls | P0 | Required |
 
 </details>
 
-Provider plans and quotas change often, so this README does not list prices. See [Configuration and API keys](docs/wiki/Configuration-and-API-Keys.md) for credential names and setup. Contributors can add a provider through the [module guide](docs/wiki/How-to-add-a-new-module.md); the source catalog remains the executable inventory.
+Each source name links to its provider's site or documentation, where current plans, quotas, and terms are published. See [Configuration and API keys](docs/wiki/Configuration-and-API-Keys.md) for credential names and setup. Contributors can add a provider through the [module guide](docs/wiki/How-to-add-a-new-module.md); the source catalog remains the executable inventory.
 
 ## Configuration
 

--- a/docs/wiki/Configuration-and-API-Keys.md
+++ b/docs/wiki/Configuration-and-API-Keys.md
@@ -41,9 +41,7 @@ apikeys:
 
 Do not commit populated configuration files. Prefer provider credentials scoped to the minimum access the provider supports.
 
-The [README source matrix](https://github.com/laramies/theHarvester/blob/dev/README.md#discovery-sources) lists each source's result routes, activity class, and credential requirement. The executable source catalog is the authoritative inventory.
-
-Provider pricing, quotas, and terms change frequently. Check the provider's current documentation for these details.
+The [README source matrix](https://github.com/laramies/theHarvester/blob/dev/README.md#discovery-sources) lists each source's result routes, activity class, and credential requirement. Every source name links to its provider's site or documentation for current plans, quotas, and terms. The executable source catalog is the authoritative inventory.
 
 `censys.token` is a Censys Platform Personal Access Token. Set `organization_id` when searches should use an entitled organization. This source uses the Global Search API, which is unavailable to Free accounts because they are limited to asset lookups. Search API ID and secret fields are not accepted.
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -14,6 +14,66 @@ API_KEY_SOURCE_ALIASES = {
     'pentestTools': {'pentesttools'},
     'projectDiscovery': {'projectdiscovery'},
 }
+SOURCE_PROVIDER_LINKS = {
+    'apis-guru': 'https://apis.guru/',
+    'arquivo': 'https://arquivo.pt/',
+    'baidu': 'https://www.baidu.com/',
+    'bevigil': 'https://bevigil.com/osint-api',
+    'bufferoverun': 'https://tls.bufferover.run/',
+    'builtwith': 'https://builtwith.com/',
+    'brave': 'https://brave.com/search/api/',
+    'censys': 'https://search.censys.io/',
+    'certspotter': 'https://sslmate.com/certspotter/',
+    'commoncrawl': 'https://commoncrawl.org/',
+    'criminalip': 'https://www.criminalip.io/',
+    'crt-name': 'https://crt.name/',
+    'crtsh': 'https://crt.sh/',
+    'dehashed': 'https://dehashed.com/',
+    'dnsdb': 'https://docs.domaintools.com/api/dnsdb/',
+    'dnsdumpster': 'https://dnsdumpster.com/',
+    'duckduckgo': 'https://duckduckgo.com/',
+    'dymo': 'https://docs.tpeoficial.com/docs/dymo-api/private/data-verifier',
+    'fofa': 'https://en.fofa.info/',
+    'fullhunt': 'https://fullhunt.io/',
+    'github-code': 'https://github.com/',
+    'gitlab': 'https://gitlab.com/',
+    'hackertarget': 'https://hackertarget.com/',
+    'haveibeenpwned': 'https://haveibeenpwned.com/',
+    'hibpverified': 'https://haveibeenpwned.com/API/v3#BreachedDomain',
+    'hudsonrock': 'https://www.hudsonrock.com/',
+    'hunter': 'https://hunter.io/',
+    'hunterhow': 'https://hunter.how/',
+    'intelx': 'https://intelx.io/',
+    'leakix': 'https://leakix.net/',
+    'leaklookup': 'https://leak-lookup.com/',
+    'mojeek': 'https://www.mojeek.com/services/search/web-search-api/',
+    'netlas': 'https://netlas.io/',
+    'onyphe': 'https://www.onyphe.io/',
+    'otx': 'https://otx.alienvault.com/',
+    'pentesttools': 'https://pentest-tools.com/',
+    'projectdiscovery': 'https://chaos.projectdiscovery.io/',
+    'rapiddns': 'https://rapiddns.io/',
+    'robtex': 'https://www.robtex.com/',
+    'rocketreach': 'https://rocketreach.co/',
+    'securityscorecard': 'https://securityscorecard.com/',
+    'securityTrails': 'https://securitytrails.com/',
+    'sherlockeye': 'https://sherlockeye.io/',
+    'shodan': 'https://www.shodan.io/',
+    'shodanInternetDB': 'https://internetdb.shodan.io/',
+    'shodanct': 'https://ctl.shodan.io/',
+    'sourcegraph': 'https://sourcegraph.com/search',
+    'subdomaincenter': 'https://www.subdomain.center/',
+    'subdomainfinderc99': 'https://subdomainfinder.c99.nl/',
+    'thc': 'https://ip.thc.org/',
+    'tomba': 'https://tomba.io/',
+    'urlscan': 'https://urlscan.io/',
+    'virustotal': 'https://www.virustotal.com/',
+    'waybackarchive': 'https://web.archive.org/',
+    'whoisxml': 'https://subdomains.whoisxmlapi.com/',
+    'windvane': 'https://windvane.lichoin.com/',
+    'yahoo': 'https://www.yahoo.com/',
+    'zoomeye': 'https://www.zoomeye.ai/',
+}
 WIKI_PAGES = {
     'Configuration-and-API-Keys.md',
     'Contributing-and-Security.md',
@@ -37,14 +97,27 @@ def _declared_source_contracts() -> dict[str, set[str]]:
     return {source: set(spec.capabilities) for source, spec in SOURCE_SPECS.items()}
 
 
+def _source_matrix(readme: str) -> str:
+    return readme.split('<summary><strong>View the source and result matrix</strong></summary>', 1)[1].split('</details>', 1)[0]
+
+
 def _documented_source_rows(readme: str) -> dict[str, list[str]]:
-    matrix = readme.split('<summary><strong>View the source and result matrix</strong></summary>', 1)[1].split('</details>', 1)[0]
     rows: dict[str, list[str]] = {}
-    for line in matrix.splitlines():
-        if line.startswith('| `'):
+    for line in _source_matrix(readme).splitlines():
+        if line.startswith('| [`'):
             cells = [cell.strip() for cell in line.strip('|').split('|')]
-            rows[cells[0].strip('`')] = cells[1:]
+            source = re.fullmatch(r'\[`([^`]+)`\]\((https://[^)]+)\)', cells[0])
+            assert source is not None
+            rows[source.group(1)] = cells[1:]
     return rows
+
+
+def _documented_source_links(readme: str) -> list[tuple[str, str]]:
+    return [
+        (match.group(1), match.group(2))
+        for line in _source_matrix(readme).splitlines()
+        if (match := re.match(r'^\| \[`([^`]+)`\]\((https://[^)]+)\)', line))
+    ]
 
 
 def _documented_source_contracts(readme: str) -> dict[str, set[str]]:
@@ -73,6 +146,9 @@ def test_readme_matches_declared_source_contracts() -> None:
     assert len(declared) == 58
     assert len(documented) == 58
     assert documented == declared
+    source_links = _documented_source_links(readme)
+    assert len(source_links) == len(declared)
+    assert dict(source_links) == SOURCE_PROVIDER_LINKS
     assert _documented_source_activities(readme) == {source: spec.activity.value for source, spec in SOURCE_SPECS.items()}
     assert {'securitytrails', 'shodaninternetdb'}.isdisjoint(documented)
 


### PR DESCRIPTION
## Summary
- link all 58 discovery sources in the README matrix to provider-owned sites or documentation
- point the API-key guide to those links for current plans, quotas, and terms
- enforce exact source coverage and provider URL mapping in the README contract test

Historical hard-coded prices are intentionally not restored because provider plans change and contributor guidance requires provider-owned links.

## Verification
- `uv run pytest tests/test_readme.py -q` — 9 passed
- `uv run ruff check tests/test_readme.py`
- `uv run ruff format --check tests/test_readme.py`
- `git diff --check origin/dev...HEAD`
- two-axis review at `b14e564c`: 0 Standards findings, 0 Spec findings
- live reachability pass over all 58 links: 51 returned HTTP 200; seven provider endpoints returned bot, rate-limit, or transient responses but were manually verified as provider-owned URLs