### PR TITLE
fix(windows): make winloop opt-in so Playwright sources keep working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the nonfunctional ThreatCrowd source because its service hostnames terminate at deleted AWS load balancers and return NXDOMAIN; OTX remains available through its separate adapter.
 
 ### Fixed
+- Made winloop opt-in on Windows behind `THEHARVESTER_USE_WINLOOP`, so Playwright-backed sources and screenshots no longer fail with `ValueError: startupinfo is not supported` on the default event loop.
 - Reused one connection pool, proxy identity, and cookie jar across Censys and GitHub Code pagination while keeping provider sessions isolated and cancellation-safe.
 - Sent a stable, versioned theHarvester identity with provider and API requests while preserving explicit browser identities for sources that require them.
 - Kept API endpoint scan URLs canonical instead of prefixing targets onto already complete URLs.

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -34,11 +34,30 @@ def test_cli_uses_platform_loop_factory_when_available(monkeypatch: pytest.Monke
     optional_loop.new_event_loop = new_event_loop  # type: ignore[attr-defined]
     observed = _capture_loop_factory(monkeypatch)
     monkeypatch.setattr(sys, 'platform', platform)
+    monkeypatch.setenv(theHarvester.WINLOOP_ENV_VAR, '1')
     monkeypatch.setitem(sys.modules, module_name, optional_loop)
 
     theHarvester.main()
 
     assert observed == [new_event_loop]
+
+
+def test_cli_skips_winloop_on_windows_unless_opted_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    """winloop breaks Playwright's ``startupinfo`` subprocess launch, so it is opt-in."""
+    winloop = ModuleType('winloop')
+
+    def new_event_loop() -> asyncio.AbstractEventLoop:
+        raise AssertionError('winloop must not be used without the opt-in environment variable')
+
+    winloop.new_event_loop = new_event_loop  # type: ignore[attr-defined]
+    observed = _capture_loop_factory(monkeypatch)
+    monkeypatch.setattr(sys, 'platform', 'win32')
+    monkeypatch.delenv(theHarvester.WINLOOP_ENV_VAR, raising=False)
+    monkeypatch.setitem(sys.modules, 'winloop', winloop)
+
+    theHarvester.main()
+
+    assert observed == [None]
 
 
 @pytest.mark.parametrize(('platform', 'module_name'), [('linux', 'uvloop'), ('win32', 'winloop')])
@@ -47,6 +66,7 @@ def test_cli_uses_standard_loop_when_optional_loop_is_unavailable(
 ) -> None:
     observed = _capture_loop_factory(monkeypatch)
     monkeypatch.setattr(sys, 'platform', platform)
+    monkeypatch.setenv(theHarvester.WINLOOP_ENV_VAR, '1')
     monkeypatch.setitem(sys.modules, module_name, None)
 
     theHarvester.main()

--- a/theHarvester/theHarvester.py
+++ b/theHarvester/theHarvester.py
@@ -1,8 +1,19 @@
 import asyncio
+import os
 import sys
+from collections.abc import Callable
 
 from theHarvester import __main__
 from theHarvester.lib.database import dispose_sqlite_databases
+
+LoopFactory = Callable[[], asyncio.AbstractEventLoop]
+
+# winloop cannot spawn subprocesses created with ``startupinfo``, which is how Playwright
+# starts its driver, so sources such as Baidu and the screenshot module die with
+# ``ValueError: startupinfo is not supported``. Standard asyncio on Windows handles them,
+# so winloop stays opt-in behind this environment variable.
+WINLOOP_ENV_VAR = 'THEHARVESTER_USE_WINLOOP'
+_TRUTHY = frozenset({'1', 'true', 'yes', 'on'})
 
 
 async def _run() -> None:
@@ -12,21 +23,20 @@ async def _run() -> None:
         await dispose_sqlite_databases()
 
 
+def _optional_loop_factory(module_name: str) -> LoopFactory | None:
+    try:
+        module = __import__(module_name)
+    except ModuleNotFoundError:
+        return None
+    return module.new_event_loop
+
+
 def main() -> None:
     platform = sys.platform
-    loop_factory = None  # asyncio's standard event loop
+    loop_factory: LoopFactory | None = None  # asyncio's standard event loop
     if platform == 'win32':
-        try:
-            import winloop
-
-            loop_factory = winloop.new_event_loop
-        except ModuleNotFoundError:
-            pass
+        if os.environ.get(WINLOOP_ENV_VAR, '').strip().lower() in _TRUTHY:
+            loop_factory = _optional_loop_factory('winloop')
     else:
-        try:
-            import uvloop
-
-            loop_factory = uvloop.new_event_loop
-        except ModuleNotFoundError:
-            pass
+        loop_factory = _optional_loop_factory('uvloop')
     asyncio.run(_run(), loop_factory=loop_factory)


### PR DESCRIPTION
## Problem

On Windows, every Playwright-backed code path fails before it can start a browser:

```
[*] Searching Baidu.
ERROR asyncio: Task exception was never retrieved
future: <Task finished name='Task-8' coro=<Connection.run() ...>
    exception=ValueError('startupinfo is not supported')>
  File ".../playwright/_impl/_transport.py", line 120, in connect
    self._proc = await asyncio.create_subprocess_exec(
  File "winloop/loop.pyx", line 2784, in __subprocess_run
    raise ValueError('startupinfo is not supported')
[!] Source baidu failed: ValueError.
```

`theHarvester/theHarvester.py:main()` installs `winloop` as the event loop factory on
`win32`. Playwright starts its driver with `asyncio.create_subprocess_exec(...,
startupinfo=...)`, and winloop's `subprocess_exec` does not implement that argument, so
the driver never launches. The standard Windows `ProactorEventLoop` supports it.

Affected code paths: the Baidu discovery source (`theHarvester/discovery/baidusearch.py`)
and the screenshot module (`theHarvester/screenshot/screenshot.py`). The rest of the run
continues, so this shows up as a silently degraded scan plus an unretrieved-task traceback.

## Behavior before and after

| | Before | After |
|---|---|---|
| `theHarvester -d example.com -b baidu` on Windows | `ValueError: startupinfo is not supported`, source dropped | source runs normally |
| Event loop on Windows | winloop, always | standard asyncio; winloop via `THEHARVESTER_USE_WINLOOP` |
| Event loop on Linux/macOS | uvloop when installed | unchanged |

## Changes

- `theHarvester/theHarvester.py`: winloop is now opt-in on Windows behind the
  `THEHARVESTER_USE_WINLOOP` environment variable (`1`/`true`/`yes`/`on`); the default is
  the standard asyncio loop. uvloop selection on non-Windows platforms is unchanged.
  Extracted `_optional_loop_factory()` so both platforms share one optional-import path,
  and documented the winloop/Playwright incompatibility in a comment next to the switch.
- `tests/test_bootstrap.py`: the parametrized `win32` cases now set the opt-in variable,
  plus a new `test_cli_skips_winloop_on_windows_unless_opted_in` that fails if winloop is
  selected without it.
- `CHANGELOG.md`: entry under `[Unreleased] / Fixed`.

An alternative would be pinning a winloop version that implements `startupinfo`, but no
released version does, and the failure is silent for anyone who does not read the
traceback. Keeping the working loop as the default and the faster loop as an explicit
opt-in seemed like the safer trade for a platform where Playwright is used by default.

## Tests and checks run

```
uv run pytest tests/test_bootstrap.py    7 passed
uv run ruff check .                      All checks passed!
uv run ruff format --check .             137 files already formatted
uv run mypy theHarvester                 2 pre-existing errors in lib/api/run_worker.py
                                         (os.killpg / signal.SIGKILL, Windows-only, unrelated)
```

Manual check on Windows 11 / Python 3.14, before and after, against a domain I own:

```
uv run theHarvester -d <own-domain> -b baidu
# before: [!] Source baidu failed: ValueError.
# after:  [*] Searching Baidu.  (completes, no traceback)
```

The full `uv run pytest` suite is not clean in my Windows environment, but the failures
reproduce identically on unmodified `dev` (`tests/test_screenshot.py` and other async
tests error in setup with `AttributeError: 'ProactorEventLoop' object has no attribute
'_ssock'` from pytest-asyncio on Python 3.14). They are not related to this change.

## Risk

Low, and Windows-only. The default event loop changes on Windows, so runs there lose
winloop's throughput; anyone who wants it back and does not use Playwright-backed sources
can set `THEHARVESTER_USE_WINLOOP=1`. No behavior change on Linux or macOS, no new
dependency, and `winloop` stays in `pyproject.toml`.
