### PR TITLE
Fix Baidu browser user agent

### DIFF
--- a/tests/discovery/test_baidusearch.py
+++ b/tests/discovery/test_baidusearch.py
@@ -206,6 +206,7 @@ class TestBaiduSearch:
                 PageResponse('Visit sub.a.example.com. baz@example.com'),
             ],
         )
+        monkeypatch.setattr(baidusearch.Core, 'get_browser_user_agent', staticmethod(lambda: 'UA'))
         search = baidusearch.SearchBaidu(word='example.com', limit=21)
         report = await search.process(proxy=True)
 
@@ -218,7 +219,7 @@ class TestBaiduSearch:
         assert all(call['wait_until'] == 'domcontentloaded' for call in state.calls)
         assert all(call['timeout'] == 60_000 for call in state.calls)
         assert state.launch_kwargs == {'headless': True, 'proxy': {'server': 'http://proxy.example:8080'}}
-        assert state.context_kwargs == {}
+        assert state.context_kwargs == {'user_agent': 'UA'}
         assert state.delays == [1.0, 1.0]
         assert state.page_closed
         assert state.context_closed

--- a/theHarvester/discovery/baidusearch.py
+++ b/theHarvester/discovery/baidusearch.py
@@ -114,7 +114,7 @@ class SearchBaidu:
                 headless=True,
                 proxy={'server': proxy_url} if proxy_url else None,
             )
-            context = await browser.new_context()
+            context = await browser.new_context(user_agent=Core.get_browser_user_agent())
             page = await context.new_page()
             for page_number, url in enumerate(urls):
                 if page_number:


### PR DESCRIPTION
## Summary

- configure the Baidu Playwright context with the existing ordinary browser user agent
- prevent Playwright default HeadlessChrome identity from triggering immediate security verification
- add regression coverage for the browser context option

## Verification

- 1842 passed, 6 skipped, 36 deselected
- 69 focused search-source tests passed
- ruff check and format checks passed
- mypy passed for 115 source files

## Live observation

A controlled A/B test returned Baidu results when only the HeadlessChrome identity was replaced with the ordinary browser identity. After repeated probes, the current egress was challenged for all tested identities, so the final live rerun remained blocked by Baidu security verification.