### PR TITLE
Prepare 5.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0] - 2026-08-24
+
 ### Added
 - Added authenticated REST and HarvestView export of every completed run as a portable SQLite database without queue, cancellation, worker-lease, or legacy-observation state.
 - Added a catalog-derived offline provider-contract gate that fails on missing, unknown, or duplicate source coverage while keeping live checks outside routine CI.
@@ -197,7 +199,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - Improve input sanitization and add security-focused tests ([3d7489c9](https://github.com/laramies/theHarvester/commit/3d7489c9)).
 
-[Unreleased]: https://github.com/laramies/theHarvester/compare/4.11.1...master
+[Unreleased]: https://github.com/laramies/theHarvester/compare/5.0.0...master
+[5.0.0]: https://github.com/laramies/theHarvester/compare/4.11.1...5.0.0
 [4.11.1]: https://github.com/laramies/theHarvester/compare/4.11.0...4.11.1
 [4.11.0]: https://github.com/laramies/theHarvester/compare/4.10.1...4.11.0
 [4.10.1]: https://github.com/laramies/theHarvester/compare/4.10.0...06520b40


### PR DESCRIPTION
## Summary
- move the accumulated changelog entries from Unreleased to 5.0.0 dated 2026-08-24
- advance the changelog comparison links for post-5.0 development

## Verification
- `git diff --check`
- `UV_CACHE_DIR=/private/tmp/theharvester-release-prep-uv-cache uv build --out-dir /private/tmp/theharvester-release-prep-dist`
  - built `theharvester-5.0.0.tar.gz`
  - built `theharvester-5.0.0-py3-none-any.whl`
- base release tree passed Release validation: https://github.com/laramies/theHarvester/actions/runs/32782103696 (`run_live=false`)

This is release metadata only; it changes no product behavior or dependencies.