### PR TITLE
Refactor API background state into app lifespan

### DIFF
--- a/docs/adr/0010-own-api-background-state-in-the-app-lifespan.md
+++ b/docs/adr/0010-own-api-background-state-in-the-app-lifespan.md
@@ -1,0 +1,31 @@
+# Own API background state in the application lifespan
+
+Status: accepted
+
+## Decision
+
+Each FastAPI application lifespan creates one `ApiRuntime` containing a `RunWorker` and a `SchedulerService`. The runtime is stored on that application instance, started before requests are served, and stopped before shared database engines are disposed.
+
+`create_app()` accepts an optional `runtime_factory`, so tests and alternate embeddings construct an explicit service graph without monkeypatching module wiring. Run and schedule routes obtain the current services through FastAPI dependencies. The scheduler and dispatcher receive their worker explicitly through constructor injection.
+
+Loop-bound mutable values—including background tasks, stop and wake events, lease/claim owner IDs, subprocess-group mappings, stores, and injected subprocess factories—are owned by service instances and their current session objects. They are not retained in module variables. The module-level ASGI `app = create_app()` remains only as the normal Uvicorn entry point.
+
+Unexpected worker or scheduler task failures are logged immediately. Service shutdown awaits the owned task, and cancellation of child execution terminates the subprocess/process tree, consumes helper tasks, and re-propagates cancellation.
+
+The durable SQLite worker lease remains the authority for single-worker execution. Separate application runtimes may exist in one interpreter, but only one owner may execute a queue backed by the same database.
+
+## Why
+
+Module globals made the initial local single-process lifecycle concise, but their import lifetime exceeded FastAPI lifespan and event-loop lifetime. They hid route and scheduler dependencies, forced tests to monkeypatch implementation details, and allowed one app/test lifecycle to retain or mutate another lifecycle's task, events, owner, process registry, or process factory.
+
+Application-owned services align allocation and cleanup with the component that uses them. Constructor injection, one small worker protocol, an `ApiRuntime` dataclass, and FastAPI's existing dependency system expose the necessary boundaries without introducing a container framework.
+
+## Consequences
+
+Worker-before-scheduler startup, scheduler-before-worker shutdown, queue serialization, durable leases, orphan recovery, cancellation, deadlines, child-process isolation, and schedule dispatch behavior remain intact.
+
+REST schemas, database schemas, environment names, and CLI flags are unchanged.
+
+Internal callers use `ApiRuntime`, `RunWorker`, `SchedulerService`, or their FastAPI dependencies instead of the removed module lifecycle functions and variables. Tests create independent applications through `create_app(runtime_factory=...)` or instantiate independent services directly.
+
+Each service still owns one long-lived task rather than a task group. This is deliberate: the task is strongly referenced and awaited during shutdown. A task group should be reconsidered only if a service later supervises several cooperating background tasks.

--- a/tests/lib/test_run_backend.py
+++ b/tests/lib/test_run_backend.py
@@ -14,6 +14,8 @@ from uuid import UUID
 import pytest
 from fastapi.testclient import TestClient
 
+from tests.runtime_helpers import runtime_with_process_factory, static_runtime
+
 
 class _FakeScreenshotBatch:
     async def reachable_targets(self, targets: list[str]) -> list[tuple[str, str]]:
@@ -117,17 +119,12 @@ def test_api_lifespan_disposes_shared_sqlite_engines(tmp_path, monkeypatch) -> N
 
     disposed = False
 
-    async def no_op() -> None:
-        return None
-
     async def dispose() -> None:
         nonlocal disposed
         disposed = True
 
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
     monkeypatch.setenv('THEHARVESTER_RUN_WORKER', 'disabled')
-    monkeypatch.setattr(api, 'start_worker', no_op)
-    monkeypatch.setattr(api, 'stop_worker', no_op)
     monkeypatch.setattr(api, 'dispose_sqlite_databases', dispose)
 
     with TestClient(api.app):
@@ -141,17 +138,12 @@ def test_api_lifespan_disposes_schedule_sqlite_engines(tmp_path, monkeypatch) ->
 
     disposed = False
 
-    async def no_op() -> None:
-        return None
-
     async def dispose() -> None:
         nonlocal disposed
         disposed = True
 
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
     monkeypatch.setenv('THEHARVESTER_RUN_WORKER', 'disabled')
-    monkeypatch.setattr(api, 'start_worker', no_op)
-    monkeypatch.setattr(api, 'stop_worker', no_op)
     monkeypatch.setattr(api, 'dispose_schedule_databases', dispose)
 
     with TestClient(api.app):
@@ -793,19 +785,13 @@ def test_worker_lease_serializes_execution_owners(tmp_path) -> None:
 
 
 def test_submission_fails_closed_when_worker_supervisor_stops(tmp_path, monkeypatch) -> None:
-    from theHarvester.lib.api import api, run_worker
-
-    async def no_op() -> None:
-        return None
+    from theHarvester.lib.api import api
 
     monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
-    monkeypatch.setattr(api, 'start_worker', no_op)
-    monkeypatch.setattr(api, 'stop_worker', no_op)
-    monkeypatch.setattr(run_worker, 'worker_enabled', lambda: True)
-    monkeypatch.setattr(run_worker, '_worker_task', type('StoppedTask', (), {'done': lambda self: True})())
+    application = api.create_app(runtime_factory=lambda: static_runtime(enabled=True, available=False))
 
-    with TestClient(api.app) as client:
+    with TestClient(application) as client:
         response = client.post(
             '/api/v1/runs',
             headers={'X-API-Key': 'test-key'},
@@ -819,19 +805,13 @@ def test_submission_fails_closed_when_worker_supervisor_stops(tmp_path, monkeypa
 
 
 def test_authenticated_operator_can_queue_direct_activity_for_selected_target(tmp_path, monkeypatch) -> None:
-    from theHarvester.lib.api import api, run_worker
-
-    async def no_op() -> None:
-        return None
+    from theHarvester.lib.api import api
 
     monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
-    monkeypatch.setattr(api, 'start_worker', no_op)
-    monkeypatch.setattr(api, 'stop_worker', no_op)
-    monkeypatch.setattr(run_worker, 'worker_enabled', lambda: True)
-    monkeypatch.setattr(run_worker, '_worker_task', type('RunningTask', (), {'done': lambda self: False})())
+    application = api.create_app(runtime_factory=static_runtime)
 
-    with TestClient(api.app) as client:
+    with TestClient(application) as client:
         response = client.post(
             '/api/v1/runs',
             headers={'X-API-Key': 'test-key'},
@@ -844,19 +824,13 @@ def test_authenticated_operator_can_queue_direct_activity_for_selected_target(tm
 
 
 def test_authenticated_operator_can_queue_screenshot_only_run(tmp_path, monkeypatch) -> None:
-    from theHarvester.lib.api import api, run_worker
-
-    async def no_op() -> None:
-        return None
+    from theHarvester.lib.api import api
 
     monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
-    monkeypatch.setattr(api, 'start_worker', no_op)
-    monkeypatch.setattr(api, 'stop_worker', no_op)
-    monkeypatch.setattr(run_worker, 'worker_enabled', lambda: True)
-    monkeypatch.setattr(run_worker, '_worker_task', type('RunningTask', (), {'done': lambda self: False})())
+    application = api.create_app(runtime_factory=static_runtime)
 
-    with TestClient(api.app) as client:
+    with TestClient(application) as client:
         response = client.post(
             '/api/v1/runs',
             headers={'X-API-Key': 'test-key'},
@@ -870,19 +844,13 @@ def test_authenticated_operator_can_queue_screenshot_only_run(tmp_path, monkeypa
 
 
 def test_authenticated_operator_can_queue_routeviews_only_ip_run(tmp_path, monkeypatch) -> None:
-    from theHarvester.lib.api import api, run_worker
-
-    async def no_op() -> None:
-        return None
+    from theHarvester.lib.api import api
 
     monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
-    monkeypatch.setattr(api, 'start_worker', no_op)
-    monkeypatch.setattr(api, 'stop_worker', no_op)
-    monkeypatch.setattr(run_worker, 'worker_enabled', lambda: True)
-    monkeypatch.setattr(run_worker, '_worker_task', type('RunningTask', (), {'done': lambda self: False})())
+    application = api.create_app(runtime_factory=static_runtime)
 
-    with TestClient(api.app) as client:
+    with TestClient(application) as client:
         response = client.post(
             '/api/v1/runs',
             headers={'X-API-Key': 'test-key'},
@@ -895,19 +863,13 @@ def test_authenticated_operator_can_queue_routeviews_only_ip_run(tmp_path, monke
 
 
 def test_dns_brute_run_accepts_operator_resolver_list(tmp_path, monkeypatch) -> None:
-    from theHarvester.lib.api import api, run_worker
-
-    async def no_op() -> None:
-        return None
+    from theHarvester.lib.api import api
 
     monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
-    monkeypatch.setattr(api, 'start_worker', no_op)
-    monkeypatch.setattr(api, 'stop_worker', no_op)
-    monkeypatch.setattr(run_worker, 'worker_enabled', lambda: True)
-    monkeypatch.setattr(run_worker, '_worker_task', type('RunningTask', (), {'done': lambda self: False})())
+    application = api.create_app(runtime_factory=static_runtime)
 
-    with TestClient(api.app) as client:
+    with TestClient(application) as client:
         response = client.post(
             '/api/v1/runs',
             headers={'X-API-Key': 'test-key'},
@@ -1227,7 +1189,7 @@ def test_api_scan_child_uses_operator_endpoint_paths(tmp_path, monkeypatch) -> N
 
 
 def test_running_cancellation_terminates_child_and_retains_partial_evidence(tmp_path, monkeypatch) -> None:
-    from theHarvester.lib.api import api, run_worker
+    from theHarvester.lib.api import api
 
     monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
@@ -1254,9 +1216,9 @@ def test_running_cancellation_terminates_child_and_retains_partial_evidence(tmp_
             stderr=asyncio.subprocess.PIPE,
         )
 
-    monkeypatch.setattr(run_worker, '_process_factory', slow_process)
+    application = api.create_app(runtime_factory=lambda: runtime_with_process_factory(slow_process))
     headers = {'X-API-Key': 'test-key'}
-    with TestClient(api.app) as client:
+    with TestClient(application) as client:
         submitted = client.post(
             '/api/v1/runs',
             headers=headers,
@@ -1289,7 +1251,6 @@ def test_whole_run_deadline_terminates_child_and_retains_partial_evidence(tmp_pa
 
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
     monkeypatch.setenv('THEHARVESTER_RUN_ARTIFACTS', str(tmp_path / 'artifacts'))
-    monkeypatch.setattr(run_worker, '_worker_stop', None)
 
     async def slow_process(_run_id, _database, artifact_dir):
         artifact_dir.mkdir(parents=True, exist_ok=True)
@@ -1311,7 +1272,7 @@ def test_whole_run_deadline_terminates_child_and_retains_partial_evidence(tmp_pa
             stderr=asyncio.subprocess.PIPE,
         )
 
-    monkeypatch.setattr(run_worker, '_process_factory', slow_process)
+    worker = run_worker.RunWorker(process_factory=slow_process)
 
     async def scenario():
         store = RunStore()
@@ -1319,7 +1280,7 @@ def test_whole_run_deadline_terminates_child_and_retains_partial_evidence(tmp_pa
         run = await store.claim_next()
         assert run is not None
         run['request']['deadline_seconds'] = 0
-        await run_worker._execute_claimed(store, run)
+        await worker.execute_claimed(store, run)
         return await store.get(run['run_id'])
 
     detail = asyncio.run(scenario())
@@ -1331,13 +1292,57 @@ def test_whole_run_deadline_terminates_child_and_retains_partial_evidence(tmp_pa
     assert detail['results'] == [{'type': 'email', 'value': 'saved@example.test', 'sources': [], 'actions': []}]
 
 
+def test_cancelling_execute_claimed_terminates_the_child_process(tmp_path, monkeypatch) -> None:
+    from theHarvester.lib.api import run_worker
+    from theHarvester.lib.api.run_models import RunRequest
+    from theHarvester.lib.api.run_store import RunStore
+
+    monkeypatch.setenv('THEHARVESTER_RUN_ARTIFACTS', str(tmp_path / 'artifacts'))
+
+    async def scenario() -> None:
+        processes: list[asyncio.subprocess.Process] = []
+        process_started = asyncio.Event()
+
+        async def slow_process(_run_id, _database, _artifact_dir):
+            process = await asyncio.create_subprocess_exec(
+                sys.executable,
+                '-c',
+                'import time; time.sleep(60)',
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            processes.append(process)
+            process_started.set()
+            return process
+
+        worker = run_worker.RunWorker(process_factory=slow_process)
+        store = RunStore(tmp_path / 'runs.sqlite')
+        await store.create(RunRequest(target='example.test', sources=['crtsh']))
+        run = await store.claim_next()
+        assert run is not None
+
+        execution = asyncio.create_task(worker.execute_claimed(store, run))
+        await asyncio.wait_for(process_started.wait(), timeout=2)
+        try:
+            execution.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await execution
+            assert processes[0].returncode is not None
+        finally:
+            for process in processes:
+                if process.returncode is None:
+                    process.kill()
+                    await process.wait()
+
+    asyncio.run(scenario())
+
+
 def test_worker_fails_run_without_attaching_child_evidence_for_another_target(tmp_path, monkeypatch) -> None:
     from theHarvester.lib.api import run_worker
     from theHarvester.lib.api.run_models import RunRequest
     from theHarvester.lib.api.run_store import RunStore
 
     monkeypatch.setenv('THEHARVESTER_RUN_ARTIFACTS', str(tmp_path / 'artifacts'))
-    monkeypatch.setattr(run_worker, '_worker_stop', None)
 
     async def mismatched_process(_run_id, _database, artifact_dir):
         artifact_dir.mkdir(parents=True, exist_ok=True)
@@ -1359,7 +1364,7 @@ def test_worker_fails_run_without_attaching_child_evidence_for_another_target(tm
             stderr=asyncio.subprocess.PIPE,
         )
 
-    monkeypatch.setattr(run_worker, '_process_factory', mismatched_process)
+    worker = run_worker.RunWorker(process_factory=mismatched_process)
 
     async def scenario():
         store = RunStore(tmp_path / 'runs.sqlite')
@@ -1367,7 +1372,7 @@ def test_worker_fails_run_without_attaching_child_evidence_for_another_target(tm
         run = await store.claim_next()
         assert run is not None
         assert run['request']['deadline_seconds'] is None
-        await run_worker._execute_claimed(store, run)
+        await worker.execute_claimed(store, run)
         return await store.get(run['run_id'])
 
     detail = asyncio.run(scenario())

--- a/tests/lib/test_runtime_services.py
+++ b/tests/lib/test_runtime_services.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.runtime_helpers import StaticRunWorker, static_runtime
+from theHarvester.lib.api.api import create_app
+from theHarvester.lib.api.run_worker import RunWorker
+from theHarvester.lib.api.runtime import create_runtime
+from theHarvester.lib.api.schedule_service import SchedulerService
+
+
+class _IdleRunStore:
+    def __init__(self, name: str) -> None:
+        self.database = Path(f'{name}.sqlite')
+        self.acquired_owner_ids: list[str] = []
+        self.released_owner_ids: list[str] = []
+        self.waiting = asyncio.Event()
+
+    async def acquire_worker_lease(self, owner_id: str) -> bool:
+        self.acquired_owner_ids.append(owner_id)
+        self.waiting.set()
+        return False
+
+    async def release_worker_lease(self, owner_id: str) -> None:
+        self.released_owner_ids.append(owner_id)
+
+
+class _IdleScheduleStore:
+    def __init__(self) -> None:
+        self.claimed_owner_ids: list[str] = []
+        self.released_owner_ids: list[str] = []
+        self.waiting = asyncio.Event()
+
+    async def initialize(self) -> None:
+        return None
+
+    async def claim_due(self, owner_id: str, *, limit: int) -> list[Any]:
+        assert limit == 1
+        self.claimed_owner_ids.append(owner_id)
+        return []
+
+    async def next_due_at(self) -> None:
+        self.waiting.set()
+        return None
+
+    async def release_claims(self, owner_id: str) -> None:
+        self.released_owner_ids.append(owner_id)
+
+
+class _FailingRunStore:
+    def __init__(self) -> None:
+        self.database = Path('failing-worker.sqlite')
+        self.failed = asyncio.Event()
+        self.released_owner_ids: list[str] = []
+
+    async def acquire_worker_lease(self, _owner_id: str) -> bool:
+        self.failed.set()
+        raise RuntimeError('worker supervisor failed')
+
+    async def release_worker_lease(self, owner_id: str) -> None:
+        self.released_owner_ids.append(owner_id)
+
+
+class _FailingScheduleStore:
+    def __init__(self) -> None:
+        self.failed = asyncio.Event()
+        self.released_owner_ids: list[str] = []
+
+    async def initialize(self) -> None:
+        self.failed.set()
+        raise RuntimeError('scheduler supervisor failed')
+
+    async def release_claims(self, owner_id: str) -> None:
+        self.released_owner_ids.append(owner_id)
+
+
+def test_worker_instances_do_not_share_lifecycle_state() -> None:
+    async def scenario() -> None:
+        first_store = _IdleRunStore('first')
+        second_store = _IdleRunStore('second')
+        first = RunWorker(store_factory=lambda: first_store)
+        second = RunWorker(store_factory=lambda: second_store)
+
+        await first.start()
+        await second.start()
+        await asyncio.gather(first_store.waiting.wait(), second_store.waiting.wait())
+
+        assert first.available is True
+        assert second.available is True
+        assert first_store.acquired_owner_ids[0] != second_store.acquired_owner_ids[0]
+
+        await first.stop()
+        assert first.available is False
+        assert second.available is True
+        assert first_store.released_owner_ids == first_store.acquired_owner_ids[:1]
+        assert second_store.released_owner_ids == []
+
+        await second.stop()
+        assert second.available is False
+        assert second_store.released_owner_ids == second_store.acquired_owner_ids[:1]
+
+    asyncio.run(scenario())
+
+
+def test_scheduler_instances_do_not_share_lifecycle_state() -> None:
+    async def scenario() -> None:
+        first_store = _IdleScheduleStore()
+        second_store = _IdleScheduleStore()
+        first = SchedulerService(
+            StaticRunWorker(),
+            schedule_store_factory=lambda: first_store,
+            run_store_factory=object,
+        )
+        second = SchedulerService(
+            StaticRunWorker(),
+            schedule_store_factory=lambda: second_store,
+            run_store_factory=object,
+        )
+
+        await first.start()
+        await second.start()
+        await asyncio.gather(first_store.waiting.wait(), second_store.waiting.wait())
+
+        assert first.available is True
+        assert second.available is True
+        assert first_store.claimed_owner_ids[0] != second_store.claimed_owner_ids[0]
+
+        await first.stop()
+        assert first.available is False
+        assert second.available is True
+        assert first_store.released_owner_ids == first_store.claimed_owner_ids[:1]
+        assert second_store.released_owner_ids == []
+
+        await second.stop()
+        assert second.available is False
+        assert second_store.released_owner_ids == second_store.claimed_owner_ids[:1]
+
+    asyncio.run(scenario())
+
+
+def test_runtime_factory_builds_a_fresh_owned_service_graph() -> None:
+    first = create_runtime()
+    second = create_runtime()
+
+    assert first is not second
+    assert first.worker is not second.worker
+    assert first.scheduler is not second.scheduler
+    assert first.scheduler.worker is first.worker
+    assert second.scheduler.worker is second.worker
+
+
+def test_app_factory_uses_the_injected_runtime_lifecycle() -> None:
+    runtime = static_runtime(enabled=True, available=True)
+    application = create_app(runtime_factory=lambda: runtime)
+
+    with TestClient(application):
+        assert application.state.runtime is runtime
+        assert runtime.worker.start_count == 1
+        assert runtime.worker.stop_count == 0
+
+    assert application.state.runtime is None
+    assert runtime.worker.stop_count == 1
+
+
+def test_app_factory_lifespans_receive_distinct_runtimes(monkeypatch) -> None:
+    monkeypatch.setenv('THEHARVESTER_RUN_WORKER', 'disabled')
+    monkeypatch.setenv('THEHARVESTER_SCHEDULER', 'disabled')
+    first_app = create_app()
+    second_app = create_app()
+
+    with TestClient(first_app):
+        first_runtime = first_app.state.runtime
+        assert first_runtime is not None
+    assert first_app.state.runtime is None
+
+    with TestClient(second_app):
+        second_runtime = second_app.state.runtime
+        assert second_runtime is not None
+    assert second_app.state.runtime is None
+
+    assert first_runtime is not second_runtime
+    assert first_runtime.worker is not second_runtime.worker
+    assert first_runtime.scheduler is not second_runtime.scheduler
+
+
+def test_worker_logs_an_unexpected_supervisor_failure(caplog) -> None:
+    async def scenario() -> None:
+        store = _FailingRunStore()
+        worker = RunWorker(store_factory=lambda: store)
+
+        await worker.start()
+        await store.failed.wait()
+        while worker.available:
+            await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        with pytest.raises(RuntimeError, match='worker supervisor failed'):
+            await worker.stop()
+        assert len(store.released_owner_ids) == 1
+
+    with caplog.at_level(logging.ERROR, logger='theHarvester.lib.api.run_worker'):
+        asyncio.run(scenario())
+
+    assert 'theharvester-run-worker-' in caplog.text
+    assert 'worker supervisor failed' in caplog.text
+
+
+def test_scheduler_logs_an_unexpected_supervisor_failure(caplog) -> None:
+    async def scenario() -> None:
+        store = _FailingScheduleStore()
+        scheduler = SchedulerService(
+            StaticRunWorker(),
+            schedule_store_factory=lambda: store,
+            run_store_factory=object,
+        )
+
+        await scheduler.start()
+        await store.failed.wait()
+        while scheduler.available:
+            await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        with pytest.raises(RuntimeError, match='scheduler supervisor failed'):
+            await scheduler.stop()
+        assert len(store.released_owner_ids) == 1
+
+    with caplog.at_level(logging.ERROR, logger='theHarvester.lib.api.schedule_service'):
+        asyncio.run(scenario())
+
+    assert 'theharvester-scheduler-' in caplog.text
+    assert 'scheduler supervisor failed' in caplog.text

--- a/tests/lib/test_schedules.py
+++ b/tests/lib/test_schedules.py
@@ -9,6 +9,8 @@ import pytest
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
+from tests.runtime_helpers import ready_worker
+
 
 def _payload(*, start_at: str = '2026-08-20T09:00:00-04:00', targets: list[str] | None = None) -> dict[str, object]:
     selected_targets = targets or ['example.test', 'example.org']
@@ -157,7 +159,6 @@ def test_schedule_api_requires_authentication(tmp_path, monkeypatch) -> None:
 
 
 def test_run_now_queues_one_normal_run_per_target(tmp_path, monkeypatch) -> None:
-    from theHarvester.lib.api import run_worker
     from theHarvester.lib.api.run_store import RunStore
     from theHarvester.lib.api.schedule_models import ScheduleCreate
     from theHarvester.lib.api.schedule_service import ScheduleDispatcher
@@ -165,16 +166,14 @@ def test_run_now_queues_one_normal_run_per_target(tmp_path, monkeypatch) -> None
 
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
     monkeypatch.setenv('THEHARVESTER_SCHEDULE_DB', str(tmp_path / 'schedules.sqlite'))
-    monkeypatch.setattr(run_worker, 'worker_enabled', lambda: True)
-    monkeypatch.setattr(run_worker, 'worker_available', lambda: True)
-    monkeypatch.setattr(run_worker, 'wake_worker', lambda: None)
 
     async def scenario() -> None:
         schedule_store = ScheduleStore()
         schedule = await schedule_store.create(
             ScheduleCreate.model_validate(_payload(targets=['example.test', 'example.org', 'example.net']))
         )
-        dispatched = await ScheduleDispatcher(schedule_store, RunStore()).dispatch_now(schedule.schedule_id)
+        dispatcher = ScheduleDispatcher(schedule_store, RunStore(), worker=ready_worker())
+        dispatched = await dispatcher.dispatch_now(schedule.schedule_id)
         assert dispatched is not None
         assert len(dispatched.run_ids) == 3
         runs = await RunStore().list_runs(limit=10)
@@ -509,7 +508,7 @@ def test_schedule_store_reserves_the_maximum_target_batch(tmp_path) -> None:
 
 
 def test_dispatch_recovery_reuses_reservations_and_run_ids(tmp_path, monkeypatch) -> None:
-    from theHarvester.lib.api import run_worker, schedule_service
+    from theHarvester.lib.api import schedule_service
     from theHarvester.lib.api.run_models import RunRequest
     from theHarvester.lib.api.run_store import RunStore
     from theHarvester.lib.api.schedule_models import ScheduleCreate
@@ -518,9 +517,6 @@ def test_dispatch_recovery_reuses_reservations_and_run_ids(tmp_path, monkeypatch
 
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
     monkeypatch.setenv('THEHARVESTER_SCHEDULE_DB', str(tmp_path / 'schedules.sqlite'))
-    monkeypatch.setattr(run_worker, 'worker_enabled', lambda: True)
-    monkeypatch.setattr(run_worker, 'worker_available', lambda: True)
-    monkeypatch.setattr(run_worker, 'wake_worker', lambda: None)
 
     async def scenario() -> None:
         schedule_store = ScheduleStore()
@@ -534,7 +530,7 @@ def test_dispatch_recovery_reuses_reservations_and_run_ids(tmp_path, monkeypatch
         await schedule_store.reserve_dispatch(schedule.schedule_id, scheduled_for, 'example.org', second_run_id)
         await run_store.create(RunRequest(target='example.org', sources=['crtsh']), run_id=second_run_id)
 
-        dispatcher = ScheduleDispatcher(schedule_store, run_store)
+        dispatcher = ScheduleDispatcher(schedule_store, run_store, worker=ready_worker())
         recovered = await dispatcher.dispatch_now(schedule.schedule_id)
         duplicate = await dispatcher.dispatch_now(schedule.schedule_id)
 
@@ -550,7 +546,6 @@ def test_dispatch_recovery_reuses_reservations_and_run_ids(tmp_path, monkeypatch
 
 @pytest.mark.parametrize('overlap_policy', ['skip', 'queue'])
 def test_overlap_policy_recovers_current_occurrence_reservations(tmp_path, monkeypatch, overlap_policy: str) -> None:
-    from theHarvester.lib.api import run_worker
     from theHarvester.lib.api.run_models import RunRequest
     from theHarvester.lib.api.run_store import RunStore
     from theHarvester.lib.api.schedule_models import ScheduleCreate
@@ -559,9 +554,6 @@ def test_overlap_policy_recovers_current_occurrence_reservations(tmp_path, monke
 
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
     monkeypatch.setenv('THEHARVESTER_SCHEDULE_DB', str(tmp_path / 'schedules.sqlite'))
-    monkeypatch.setattr(run_worker, 'worker_enabled', lambda: True)
-    monkeypatch.setattr(run_worker, 'worker_available', lambda: True)
-    monkeypatch.setattr(run_worker, 'wake_worker', lambda: None)
 
     async def scenario() -> None:
         store = ScheduleStore()
@@ -577,7 +569,7 @@ def test_overlap_policy_recovers_current_occurrence_reservations(tmp_path, monke
         await run_store.create(RunRequest(target='example.org', sources=['crtsh']), run_id=second_run_id)
 
         claimed = await store.claim_due('recovery-owner', now=scheduled_for, limit=1)
-        await ScheduleDispatcher(store, run_store).dispatch_claimed(claimed[0], 'recovery-owner')
+        await ScheduleDispatcher(store, run_store, worker=ready_worker()).dispatch_claimed(claimed[0], 'recovery-owner')
 
         dispatches = await store.list_dispatches(schedule.schedule_id)
         updated = await store.get(schedule.schedule_id)
@@ -592,7 +584,6 @@ def test_overlap_policy_recovers_current_occurrence_reservations(tmp_path, monke
 
 
 def test_recovered_queued_occurrence_completes_without_a_false_error(tmp_path, monkeypatch) -> None:
-    from theHarvester.lib.api import run_worker
     from theHarvester.lib.api.run_models import RunRequest
     from theHarvester.lib.api.run_store import RunStore
     from theHarvester.lib.api.schedule_models import ScheduleCreate
@@ -601,9 +592,6 @@ def test_recovered_queued_occurrence_completes_without_a_false_error(tmp_path, m
 
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
     monkeypatch.setenv('THEHARVESTER_SCHEDULE_DB', str(tmp_path / 'schedules.sqlite'))
-    monkeypatch.setattr(run_worker, 'worker_enabled', lambda: True)
-    monkeypatch.setattr(run_worker, 'worker_available', lambda: True)
-    monkeypatch.setattr(run_worker, 'wake_worker', lambda: None)
 
     async def scenario() -> None:
         store = ScheduleStore()
@@ -618,7 +606,7 @@ def test_recovered_queued_occurrence_completes_without_a_false_error(tmp_path, m
         await store.set_dispatch_state(run_id, 'queued')
 
         claimed = await store.claim_due('recovery-owner', now=scheduled_for, limit=1)
-        await ScheduleDispatcher(store, run_store).dispatch_claimed(claimed[0], 'recovery-owner')
+        await ScheduleDispatcher(store, run_store, worker=ready_worker()).dispatch_claimed(claimed[0], 'recovery-owner')
 
         updated = await store.get(schedule.schedule_id)
         assert updated is not None
@@ -637,7 +625,6 @@ def test_newer_occurrence_terminalizes_a_stale_runless_reservation(
     transition: str,
     overlap_policy: str,
 ) -> None:
-    from theHarvester.lib.api import run_worker
     from theHarvester.lib.api.run_store import RunStore
     from theHarvester.lib.api.schedule_models import ScheduleCreate, parse_utc
     from theHarvester.lib.api.schedule_service import ScheduleDispatcher
@@ -645,9 +632,6 @@ def test_newer_occurrence_terminalizes_a_stale_runless_reservation(
 
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
     monkeypatch.setenv('THEHARVESTER_SCHEDULE_DB', str(tmp_path / 'schedules.sqlite'))
-    monkeypatch.setattr(run_worker, 'worker_enabled', lambda: True)
-    monkeypatch.setattr(run_worker, 'worker_available', lambda: True)
-    monkeypatch.setattr(run_worker, 'wake_worker', lambda: None)
 
     async def scenario() -> None:
         store = ScheduleStore()
@@ -679,7 +663,7 @@ def test_newer_occurrence_terminalizes_a_stale_runless_reservation(
         assert changed.next_run_at is not None
         current = parse_utc(changed.next_run_at)
         claimed = await store.claim_due('current-owner', now=current)
-        await ScheduleDispatcher(store, RunStore()).dispatch_claimed(claimed[0], 'current-owner')
+        await ScheduleDispatcher(store, RunStore(), worker=ready_worker()).dispatch_claimed(claimed[0], 'current-owner')
 
         dispatches = await store.list_dispatches(schedule.schedule_id)
         stale_dispatch = next(dispatch for dispatch in dispatches if dispatch.run_id == stale_run_id)
@@ -694,7 +678,6 @@ def test_newer_occurrence_terminalizes_a_stale_runless_reservation(
 
 
 def test_large_reservation_reconciliation_renews_the_schedule_claim(tmp_path, monkeypatch) -> None:
-    from theHarvester.lib.api import run_worker
     from theHarvester.lib.api.run_store import RunStore
     from theHarvester.lib.api.schedule_models import ScheduleCreate, parse_utc
     from theHarvester.lib.api.schedule_service import ScheduleDispatcher
@@ -702,9 +685,6 @@ def test_large_reservation_reconciliation_renews_the_schedule_claim(tmp_path, mo
 
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
     monkeypatch.setenv('THEHARVESTER_SCHEDULE_DB', str(tmp_path / 'schedules.sqlite'))
-    monkeypatch.setattr(run_worker, 'worker_enabled', lambda: True)
-    monkeypatch.setattr(run_worker, 'worker_available', lambda: True)
-    monkeypatch.setattr(run_worker, 'wake_worker', lambda: None)
     renewals = 0
     renew_claim = ScheduleStore.renew_claim
 
@@ -744,7 +724,7 @@ def test_large_reservation_reconciliation_renews_the_schedule_claim(tmp_path, mo
         assert changed.next_run_at is not None
         current = parse_utc(changed.next_run_at)
         claimed = await store.claim_due('current-owner', now=current)
-        await ScheduleDispatcher(store, RunStore()).dispatch_claimed(claimed[0], 'current-owner')
+        await ScheduleDispatcher(store, RunStore(), worker=ready_worker()).dispatch_claimed(claimed[0], 'current-owner')
 
         dispatches = await store.list_dispatches(schedule.schedule_id)
         assert renewals == 2
@@ -806,7 +786,7 @@ def test_dispatch_mirrors_cancelling_run_state(tmp_path, monkeypatch) -> None:
         assert cancelled is not None
         assert cancelled['status'] == 'cancelling'
 
-        await ScheduleDispatcher(schedule_store, run_store).refresh(schedule.schedule_id)
+        await ScheduleDispatcher(schedule_store, run_store, worker=ready_worker()).refresh(schedule.schedule_id)
 
         dispatch = (await schedule_store.list_dispatches(schedule.schedule_id))[0]
         assert dispatch.state == 'cancelling'
@@ -833,7 +813,6 @@ def test_two_scheduler_instances_cannot_claim_the_same_occurrence(tmp_path, monk
 
 
 def test_claimed_occurrence_fails_closed_after_claim_loss(tmp_path, monkeypatch) -> None:
-    from theHarvester.lib.api import run_worker
     from theHarvester.lib.api.run_store import RunStore
     from theHarvester.lib.api.schedule_models import ScheduleCreate
     from theHarvester.lib.api.schedule_service import ScheduleDispatcher
@@ -841,8 +820,6 @@ def test_claimed_occurrence_fails_closed_after_claim_loss(tmp_path, monkeypatch)
 
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
     monkeypatch.setenv('THEHARVESTER_SCHEDULE_DB', str(tmp_path / 'schedules.sqlite'))
-    monkeypatch.setattr(run_worker, 'worker_enabled', lambda: True)
-    monkeypatch.setattr(run_worker, 'worker_available', lambda: True)
 
     async def scenario() -> None:
         store = ScheduleStore()
@@ -852,7 +829,7 @@ def test_claimed_occurrence_fails_closed_after_claim_loss(tmp_path, monkeypatch)
         await store.release_claims('first-owner')
 
         with pytest.raises(RuntimeError, match='lost its occurrence claim'):
-            await ScheduleDispatcher(store, RunStore()).dispatch_claimed(claimed, 'first-owner')
+            await ScheduleDispatcher(store, RunStore(), worker=ready_worker()).dispatch_claimed(claimed, 'first-owner')
 
         assert await store.list_dispatches(schedule.schedule_id) == []
         assert await RunStore().list_runs(limit=10) == []
@@ -861,7 +838,6 @@ def test_claimed_occurrence_fails_closed_after_claim_loss(tmp_path, monkeypatch)
 
 
 def test_claim_loss_during_enqueue_leaves_every_target_auditable(tmp_path, monkeypatch) -> None:
-    from theHarvester.lib.api import run_worker
     from theHarvester.lib.api.run_store import RunStore
     from theHarvester.lib.api.schedule_models import ScheduleCreate
     from theHarvester.lib.api.schedule_service import ScheduleDispatcher
@@ -869,9 +845,6 @@ def test_claim_loss_during_enqueue_leaves_every_target_auditable(tmp_path, monke
 
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
     monkeypatch.setenv('THEHARVESTER_SCHEDULE_DB', str(tmp_path / 'schedules.sqlite'))
-    monkeypatch.setattr(run_worker, 'worker_enabled', lambda: True)
-    monkeypatch.setattr(run_worker, 'worker_available', lambda: True)
-    monkeypatch.setattr(run_worker, 'wake_worker', lambda: None)
     renew_claim = ScheduleStore.renew_claim
     renewals = 0
 
@@ -893,7 +866,7 @@ def test_claim_loss_during_enqueue_leaves_every_target_auditable(tmp_path, monke
         claimed = (await store.claim_due('first-owner', now=due, limit=1))[0]
 
         with pytest.raises(RuntimeError, match='lost its occurrence claim'):
-            await ScheduleDispatcher(store, RunStore()).dispatch_claimed(claimed, 'first-owner')
+            await ScheduleDispatcher(store, RunStore(), worker=ready_worker()).dispatch_claimed(claimed, 'first-owner')
 
         dispatches = await store.list_dispatches(schedule.schedule_id)
         assert len(dispatches) == len(targets)
@@ -904,7 +877,6 @@ def test_claim_loss_during_enqueue_leaves_every_target_auditable(tmp_path, monke
 
 
 def test_due_schedules_skip_or_queue_while_a_prior_batch_is_active(tmp_path, monkeypatch) -> None:
-    from theHarvester.lib.api import run_worker
     from theHarvester.lib.api.run_models import RunRequest
     from theHarvester.lib.api.run_store import RunStore
     from theHarvester.lib.api.schedule_models import ScheduleCreate
@@ -913,9 +885,6 @@ def test_due_schedules_skip_or_queue_while_a_prior_batch_is_active(tmp_path, mon
 
     monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
     monkeypatch.setenv('THEHARVESTER_SCHEDULE_DB', str(tmp_path / 'schedules.sqlite'))
-    monkeypatch.setattr(run_worker, 'worker_enabled', lambda: True)
-    monkeypatch.setattr(run_worker, 'worker_available', lambda: True)
-    monkeypatch.setattr(run_worker, 'wake_worker', lambda: None)
 
     async def run_policy(policy: str, owner: str, prior_run_id: str) -> tuple[int, str | None]:
         store = ScheduleStore()
@@ -927,7 +896,7 @@ def test_due_schedules_skip_or_queue_while_a_prior_batch_is_active(tmp_path, mon
         await store.set_dispatch_state(prior_run_id, 'queued')
         claimed = await store.claim_due(owner, now=datetime(2026, 8, 20, 10, tzinfo=UTC), limit=1)
         assert len(claimed) == 1
-        await ScheduleDispatcher(store, RunStore()).dispatch_claimed(claimed[0], owner)
+        await ScheduleDispatcher(store, RunStore(), worker=ready_worker()).dispatch_claimed(claimed[0], owner)
         updated = await store.get(schedule.schedule_id)
         assert updated is not None
         return len(await store.list_dispatches(schedule.schedule_id)), updated.last_error
@@ -952,15 +921,16 @@ def test_due_schedules_skip_or_queue_while_a_prior_batch_is_active(tmp_path, mon
 
 
 def test_disabled_scheduler_does_not_start(tmp_path, monkeypatch) -> None:
-    from theHarvester.lib.api.schedule_service import scheduler_available, start_scheduler, stop_scheduler
+    from theHarvester.lib.api.schedule_service import SchedulerService
 
     monkeypatch.setenv('THEHARVESTER_SCHEDULE_DB', str(tmp_path / 'schedules.sqlite'))
     monkeypatch.setenv('THEHARVESTER_SCHEDULER', 'disabled')
+    scheduler = SchedulerService(ready_worker())
 
     async def scenario() -> None:
-        await start_scheduler()
-        assert scheduler_available() is False
-        await stop_scheduler()
+        await scheduler.start()
+        assert scheduler.available is False
+        await scheduler.stop()
 
     asyncio.run(scenario())
 

--- a/tests/runtime_helpers.py
+++ b/tests/runtime_helpers.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from theHarvester.lib.api.run_worker import RunWorker, RunWorkerService
+from theHarvester.lib.api.runtime import ApiRuntime
+from theHarvester.lib.api.schedule_service import SchedulerService
+
+if TYPE_CHECKING:
+    from theHarvester.lib.api.run_worker import ProcessFactory
+
+
+@dataclass
+class StaticRunWorker:
+    """Small explicit worker test double; no module state or monkeypatching required."""
+
+    enabled: bool = True
+    available: bool = True
+    wake_count: int = 0
+    start_count: int = 0
+    stop_count: int = 0
+
+    async def start(self) -> None:
+        self.start_count += 1
+
+    async def stop(self) -> None:
+        self.stop_count += 1
+
+    def wake(self) -> None:
+        self.wake_count += 1
+
+
+def static_runtime(*, enabled: bool = True, available: bool = True) -> ApiRuntime:
+    worker = StaticRunWorker(enabled=enabled, available=available)
+    scheduler = SchedulerService(worker, enabled_check=lambda: False)
+    return ApiRuntime(worker=worker, scheduler=scheduler)
+
+
+def runtime_with_process_factory(process_factory: ProcessFactory) -> ApiRuntime:
+    worker = RunWorker(process_factory=process_factory)
+    return ApiRuntime(worker=worker, scheduler=SchedulerService(worker, enabled_check=lambda: False))
+
+
+def ready_worker() -> RunWorkerService:
+    return StaticRunWorker()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -326,18 +326,22 @@ class TestSecurityBestPractices:
                     ]
                     assert not real_matches, f'Potential hardcoded secret in {file_path}: {real_matches}'
 
-    def test_sensitive_endpoints_require_validation(self, monkeypatch):
+    def test_sensitive_endpoints_require_validation(self, monkeypatch, tmp_path):
         """Reject invalid requests to authenticated endpoints."""
         from fastapi.testclient import TestClient
 
         from theHarvester.lib.api.api import app
 
         monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-secret')
-        client = TestClient(app)
+        monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
+        monkeypatch.setenv('THEHARVESTER_SCHEDULE_DB', str(tmp_path / 'schedules.sqlite'))
+        monkeypatch.setenv('THEHARVESTER_RUN_WORKER', 'disabled')
+        monkeypatch.setenv('THEHARVESTER_SCHEDULER', 'disabled')
         headers = {'X-API-Key': 'test-secret'}
 
-        missing_target = client.post('/api/v1/runs', headers=headers, json={'sources': ['crtsh']})
-        empty_sources = client.post('/api/v1/runs', headers=headers, json={'target': 'example.test', 'sources': []})
+        with TestClient(app) as client:
+            missing_target = client.post('/api/v1/runs', headers=headers, json={'sources': ['crtsh']})
+            empty_sources = client.post('/api/v1/runs', headers=headers, json={'target': 'example.test', 'sources': []})
 
         assert missing_target.status_code == 422
         assert empty_sources.status_code == 422

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -9,9 +10,8 @@ from starlette.staticfiles import StaticFiles
 
 from theHarvester import __version__
 from theHarvester.lib.api.harvestview import router as harvestview_router
-from theHarvester.lib.api.run_worker import start_worker, stop_worker
 from theHarvester.lib.api.runs import router as api_router
-from theHarvester.lib.api.schedule_service import start_scheduler, stop_scheduler
+from theHarvester.lib.api.runtime import ApiRuntime, create_runtime
 from theHarvester.lib.api.schedule_store import dispose_schedule_databases
 from theHarvester.lib.api.schedules import router as schedule_router
 from theHarvester.lib.database import dispose_sqlite_databases
@@ -19,36 +19,47 @@ from theHarvester.lib.database import dispose_sqlite_databases
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
+type RuntimeFactory = Callable[[], ApiRuntime]
 
-@asynccontextmanager
-async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
-    await start_worker()
-    try:
-        await start_scheduler()
+
+STATIC_DIRECTORY = Path(__file__).resolve().parent / 'static'
+
+
+def create_app(*, runtime_factory: RuntimeFactory = create_runtime) -> FastAPI:
+    """Build an API application with an explicitly injectable runtime graph."""
+
+    @asynccontextmanager
+    async def lifespan(application: FastAPI) -> AsyncIterator[None]:
+        runtime = runtime_factory()
+        application.state.runtime = runtime
         try:
+            await runtime.start()
             yield
         finally:
-            await stop_scheduler()
-    finally:
-        try:
-            await stop_worker()
-        finally:
             try:
-                await dispose_schedule_databases()
+                await runtime.stop()
             finally:
-                await dispose_sqlite_databases()
+                try:
+                    await dispose_schedule_databases()
+                finally:
+                    try:
+                        await dispose_sqlite_databases()
+                    finally:
+                        application.state.runtime = None
+
+    application = FastAPI(
+        title='theHarvester API',
+        description='Local API for finite theHarvester enumeration runs and run schedules',
+        version=__version__,
+        docs_url='/docs',
+        redoc_url='/redoc',
+        lifespan=lifespan,
+    )
+    application.include_router(harvestview_router)
+    application.include_router(api_router)
+    application.include_router(schedule_router)
+    application.mount('/static', StaticFiles(directory=STATIC_DIRECTORY), name='static')
+    return application
 
 
-app = FastAPI(
-    title='theHarvester API',
-    description='Local API for finite theHarvester enumeration runs and run schedules',
-    version=__version__,
-    docs_url='/docs',
-    redoc_url='/redoc',
-    lifespan=lifespan,
-)
-app.include_router(harvestview_router)
-app.include_router(api_router)
-app.include_router(schedule_router)
-STATIC_DIRECTORY = Path(__file__).resolve().parent / 'static'
-app.mount('/static', StaticFiles(directory=STATIC_DIRECTORY), name='static')
+app = create_app()

--- a/theHarvester/lib/api/run_worker.py
+++ b/theHarvester/lib/api/run_worker.py
@@ -1,82 +1,70 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import signal
 import subprocess
 import sys
 from argparse import ArgumentParser
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any, Protocol
 from uuid import UUID, uuid4
 from weakref import WeakKeyDictionary
-
-import anyio
-
-from theHarvester.lib.enumeration import (
-    DEFAULT_RESULT_START,
-    DEFAULT_SOURCE_WORKERS,
-    EnumerationOptions,
-)
-from theHarvester.lib.resolver_selection import DEFAULT_DNS_RESOLVERS
-from theHarvester.lib.virtual_host import (
-    DEFAULT_VHOST_CONCURRENCY,
-    DEFAULT_VHOST_REQUEST_LIMIT,
-    DEFAULT_VHOST_RUNTIME_SECONDS,
-    DEFAULT_VHOST_TIMEOUT_SECONDS,
-)
 
 from .run_artifacts import ensure_private_directory, read_child_evidence, write_child_evidence
 from .run_store import RunStore
 
-if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-
-_worker_task: asyncio.Task[None] | None = None
-_worker_stop: asyncio.Event | None = None
-_worker_wakeup: asyncio.Event | None = None
-_worker_owner: str | None = None
-_process_groups: WeakKeyDictionary[asyncio.subprocess.Process, int] = WeakKeyDictionary()
+ProcessFactory = Callable[[str, Path, Path], Awaitable[asyncio.subprocess.Process]]
+RunStoreFactory = Callable[[], RunStore]
+EnabledCheck = Callable[[], bool]
+_LOGGER = logging.getLogger(__name__)
 
 
-def worker_enabled() -> bool:
+def _log_task_failure(task: asyncio.Task[None]) -> None:
+    """Report a crashed supervisor as soon as the task finishes."""
+    if task.cancelled():
+        return
+    error = task.exception()
+    if error is not None:
+        _LOGGER.error(
+            '%s exited unexpectedly',
+            task.get_name(),
+            exc_info=(type(error), error, error.__traceback__),
+        )
+
+
+class RunWorkerService(Protocol):
+    """Worker capabilities used by the runtime, routes, and scheduler."""
+
+    @property
+    def enabled(self) -> bool: ...
+
+    @property
+    def available(self) -> bool: ...
+
+    def wake(self) -> None: ...
+
+    async def start(self) -> None: ...
+
+    async def stop(self) -> None: ...
+
+
+@dataclass(slots=True)
+class _WorkerSession:
+    """Loop-bound state for one started worker instance."""
+
+    store: RunStore
+    owner_id: str
+    stop_event: asyncio.Event
+    wakeup_event: asyncio.Event
+    task: asyncio.Task[None] | None = None
+
+
+def _enabled_from_environment() -> bool:
     return os.getenv('THEHARVESTER_RUN_WORKER', 'enabled').casefold() != 'disabled'
-
-
-def worker_available() -> bool:
-    return _worker_task is not None and not _worker_task.done()
-
-
-async def _default_process_factory(run_id: str, database: Path, _artifact_dir_path: Path) -> asyncio.subprocess.Process:
-    command = (
-        sys.executable,
-        '-m',
-        'theHarvester.lib.api.run_worker',
-        '--execute',
-        run_id,
-        '--database',
-        str(database),
-    )
-    if os.name == 'nt':
-        process = await asyncio.create_subprocess_exec(
-            *command,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            creationflags=getattr(subprocess, 'CREATE_NEW_PROCESS_GROUP', 0),
-        )
-    else:
-        process = await asyncio.create_subprocess_exec(
-            *command,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            start_new_session=True,
-        )
-    if process.pid is not None:
-        _process_groups[process] = process.pid
-    return process
-
-
-_process_factory: Callable[[str, Path, Path], Awaitable[asyncio.subprocess.Process]] = _default_process_factory
 
 
 async def _process_output(process: asyncio.subprocess.Process) -> str:
@@ -87,199 +75,330 @@ async def _process_output(process: asyncio.subprocess.Process) -> str:
     return '\n'.join(part.decode('utf-8', errors='replace').strip() for part in (stdout, stderr) if part).strip()
 
 
-async def _signal_process_tree(process: asyncio.subprocess.Process, *, force: bool) -> None:
-    process_group = _process_groups.get(process)
-    if process_group is not None and os.name != 'nt':
+class RunWorker:
+    """Own the durable-queue worker lifecycle for one FastAPI application.
+
+    The previous implementation kept the task, events, lease owner, process
+    factory, and process-group registry in module globals. Keeping those values
+    on this instance makes ownership explicit, isolates app/test lifecycles, and
+    lets dependencies be injected without monkeypatching module internals.
+    """
+
+    def __init__(
+        self,
+        *,
+        process_factory: ProcessFactory | None = None,
+        store_factory: RunStoreFactory = RunStore,
+        enabled_check: EnabledCheck = _enabled_from_environment,
+    ) -> None:
+        self._custom_process_factory = process_factory
+        self._store_factory = store_factory
+        self._enabled_check = enabled_check
+        self._session: _WorkerSession | None = None
+        self._process_groups: WeakKeyDictionary[asyncio.subprocess.Process, int] = WeakKeyDictionary()
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled_check()
+
+    @property
+    def available(self) -> bool:
+        session = self._session
+        return session is not None and session.task is not None and not session.task.done()
+
+    async def start(self) -> None:
+        if not self.enabled:
+            return
+        if self.available:
+            return
+        if self._session is not None:
+            await self.stop()
+
+        session = _WorkerSession(
+            store=self._store_factory(),
+            owner_id=str(uuid4()),
+            stop_event=asyncio.Event(),
+            wakeup_event=asyncio.Event(),
+        )
+        self._session = session
+        session.task = asyncio.create_task(
+            self._supervise_worker(session),
+            name=f'theharvester-run-worker-{session.owner_id}',
+        )
+        session.task.add_done_callback(_log_task_failure)
+
+    async def stop(self) -> None:
+        session = self._session
+        if session is None:
+            return
+        task = session.task
         try:
-            os.killpg(process_group, signal.SIGKILL if force else signal.SIGTERM)
-        except ProcessLookupError:
-            pass
-        return
-    if process_group is not None and os.name == 'nt':
-        if force:
-            killer = await asyncio.create_subprocess_exec(
-                'taskkill',
-                '/PID',
-                str(process.pid),
-                '/T',
-                '/F',
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
-            )
-            await killer.wait()
-        else:
+            session.stop_event.set()
+            session.wakeup_event.set()
+            if task is not None:
+                try:
+                    await asyncio.shield(task)
+                except asyncio.CancelledError:
+                    task.cancel()
+                    await asyncio.gather(task, return_exceptions=True)
+                    raise
+        finally:
             try:
-                process.send_signal(getattr(signal, 'CTRL_BREAK_EVENT', 1))
+                await session.store.release_worker_lease(session.owner_id)
+            finally:
+                if self._session is session:
+                    self._session = None
+
+    def wake(self) -> None:
+        session = self._session
+        if session is not None:
+            session.wakeup_event.set()
+
+    async def _default_process_factory(
+        self,
+        run_id: str,
+        database: Path,
+        _artifact_dir_path: Path,
+    ) -> asyncio.subprocess.Process:
+        command = (
+            sys.executable,
+            '-m',
+            'theHarvester.lib.api.run_worker',
+            '--execute',
+            run_id,
+            '--database',
+            str(database),
+        )
+        if os.name == 'nt':
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                creationflags=getattr(subprocess, 'CREATE_NEW_PROCESS_GROUP', 0),
+            )
+        else:
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
+            )
+        if process.pid is not None:
+            self._process_groups[process] = process.pid
+        return process
+
+    async def _spawn_process(self, run_id: str, database: Path, artifact_dir: Path) -> asyncio.subprocess.Process:
+        factory = self._custom_process_factory
+        if factory is not None:
+            return await factory(run_id, database, artifact_dir)
+        return await self._default_process_factory(run_id, database, artifact_dir)
+
+    async def _signal_process_tree(self, process: asyncio.subprocess.Process, *, force: bool) -> None:
+        process_group = self._process_groups.get(process)
+        if process_group is not None and os.name != 'nt':
+            try:
+                os.killpg(process_group, signal.SIGKILL if force else signal.SIGTERM)
             except ProcessLookupError:
                 pass
-        return
-    try:
-        process.kill() if force else process.terminate()
-    except ProcessLookupError:
-        pass
+            return
+        if process_group is not None and os.name == 'nt':
+            if force:
+                killer = await asyncio.create_subprocess_exec(
+                    'taskkill',
+                    '/PID',
+                    str(process.pid),
+                    '/T',
+                    '/F',
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                await killer.wait()
+            else:
+                try:
+                    process.send_signal(getattr(signal, 'CTRL_BREAK_EVENT', 1))
+                except ProcessLookupError:
+                    pass
+            return
+        try:
+            process.kill() if force else process.terminate()
+        except ProcessLookupError:
+            pass
 
-
-async def _stop_process(process: asyncio.subprocess.Process, wait_task: asyncio.Task[int]) -> None:
-    if process.returncode is None:
-        await _signal_process_tree(process, force=False)
-    try:
-        await asyncio.wait_for(asyncio.shield(wait_task), timeout=2)
-    except TimeoutError:
+    async def _stop_process(self, process: asyncio.subprocess.Process, wait_task: asyncio.Task[int]) -> None:
         if process.returncode is None:
-            await _signal_process_tree(process, force=True)
-        await wait_task
-
-
-async def _execute_claimed(store: RunStore, run: dict[str, Any], owner_id: str | None = None) -> None:
-    run_id = run['run_id']
-    artifact_dir = store.artifact_directory(run_id)
-    ensure_private_directory(artifact_dir)
-    try:
-        process = await _process_factory(run_id, store.database, artifact_dir)
-    except (OSError, RuntimeError) as error:
-        await store.fail(run_id, f'Could not start child process: {error}', '')
-        return
-    wait_task = asyncio.create_task(process.wait())
-    output_task = asyncio.create_task(_process_output(process))
-    deadline_seconds = run['request'].get('deadline_seconds')
-    deadline = None if deadline_seconds is None else asyncio.get_running_loop().time() + int(deadline_seconds)
-    next_heartbeat = 0.0
-    while not wait_task.done():
-        await asyncio.sleep(0.05)
-        if owner_id is not None and asyncio.get_running_loop().time() >= next_heartbeat:
-            if not await store.heartbeat_worker_lease(owner_id):
-                await _stop_process(process, wait_task)
-                await store.fail(run_id, 'Worker lost its execution lease', await output_task)
-                return
-            next_heartbeat = asyncio.get_running_loop().time() + 5
-        current = await store.get(run_id)
-        stopping = _worker_stop is not None and _worker_stop.is_set()
-        if current is not None and current['status'] == 'cancelling':
-            await _stop_process(process, wait_task)
-            evidence, evidence_error = read_child_evidence(artifact_dir, str(run['target']))
-            failure_message = 'Cancelled by operator' + (f'; {evidence_error}' if evidence_error else '')
-            await store.fail(run_id, failure_message, await output_task, cancelled=True, evidence=evidence)
-            return
-        if stopping:
-            await _stop_process(process, wait_task)
-            evidence, evidence_error = read_child_evidence(artifact_dir, str(run['target']))
-            failure_message = 'theHarvester stopped before child completion' + (f'; {evidence_error}' if evidence_error else '')
-            await store.fail(run_id, failure_message, await output_task, evidence=evidence)
-            return
-        if deadline is not None and asyncio.get_running_loop().time() >= deadline:
-            await _stop_process(process, wait_task)
-            evidence, evidence_error = read_child_evidence(artifact_dir, str(run['target']))
-            failure_message = f'Run exceeded its {deadline_seconds} second deadline'
-            if evidence_error:
-                failure_message += f'; {evidence_error}'
-            await store.fail(
-                run_id,
-                failure_message,
-                await output_task,
-                evidence=evidence,
-            )
-            return
-    log = await output_task
-    current = await store.get(run_id)
-    evidence, evidence_error = read_child_evidence(artifact_dir, str(run['target']))
-    if evidence_error:
-        await store.fail(
-            run_id,
-            evidence_error,
-            log,
-            cancelled=current is not None and current['status'] == 'cancelling',
-        )
-        return
-    if current is not None and current['status'] == 'cancelling':
-        await store.finish(run_id, evidence, log)
-    elif process.returncode == 0 and evidence is not None:
-        await store.finish(run_id, evidence, log)
-    else:
-        await store.fail(
-            run_id, f'Child process exited with status {process.returncode} without terminal completion', log, evidence=evidence
-        )
-
-
-async def _worker_loop(store: RunStore, owner_id: str) -> None:
-    assert _worker_stop is not None
-    assert _worker_wakeup is not None
-    while not _worker_stop.is_set():
-        if not await store.heartbeat_worker_lease(owner_id):
-            return
-        run = await store.claim_next()
-        if run is not None:
-            await _execute_claimed(store, run, owner_id)
-            continue
-        _worker_wakeup.clear()
+            await self._signal_process_tree(process, force=False)
         try:
-            await asyncio.wait_for(_worker_wakeup.wait(), timeout=0.5)
+            await asyncio.wait_for(asyncio.shield(wait_task), timeout=2)
         except TimeoutError:
-            continue
+            if process.returncode is None:
+                await self._signal_process_tree(process, force=True)
+            await wait_task
 
-
-async def _supervise_worker(store: RunStore, owner_id: str) -> None:
-    assert _worker_stop is not None
-    assert _worker_wakeup is not None
-    while not _worker_stop.is_set():
-        if await store.acquire_worker_lease(owner_id):
-            try:
-                await store.recover_orphans()
-            except BaseException:
-                await store.release_worker_lease(owner_id)
-                raise
-            await _worker_loop(store, owner_id)
-            return
-        _worker_wakeup.clear()
+    async def _abort_process_execution(
+        self,
+        process: asyncio.subprocess.Process,
+        wait_task: asyncio.Task[int] | None,
+        output_task: asyncio.Task[str] | None,
+    ) -> None:
+        """Terminate a child and consume its helper tasks after an exceptional exit."""
+        if wait_task is None:
+            wait_task = asyncio.create_task(process.wait())
         try:
-            await asyncio.wait_for(_worker_wakeup.wait(), timeout=0.5)
-        except TimeoutError:
-            continue
-
-
-async def start_worker() -> None:
-    global _worker_owner, _worker_stop, _worker_task, _worker_wakeup
-    if not worker_enabled():
-        return
-    if _worker_task is not None and not _worker_task.done():
-        return
-    store = RunStore()
-    owner_id = str(uuid4())
-    _worker_owner = owner_id
-    _worker_stop = asyncio.Event()
-    _worker_wakeup = asyncio.Event()
-    _worker_task = asyncio.create_task(_supervise_worker(store, owner_id))
-
-
-async def stop_worker() -> None:
-    global _worker_owner, _worker_stop, _worker_task, _worker_wakeup
-    task = _worker_task
-    owner_id = _worker_owner
-    try:
-        if task is not None:
-            if _worker_stop is not None:
-                _worker_stop.set()
-            if _worker_wakeup is not None:
-                _worker_wakeup.set()
-            await task
-    finally:
-        try:
-            if owner_id is not None:
-                await RunStore().release_worker_lease(owner_id)
+            await self._stop_process(process, wait_task)
         finally:
-            _worker_task = None
-            _worker_owner = None
-            _worker_stop = None
-            _worker_wakeup = None
+            tasks = [task for task in (wait_task, output_task) if task is not None]
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
 
+    async def execute_claimed(
+        self,
+        store: RunStore,
+        run: dict[str, Any],
+        owner_id: str | None = None,
+        *,
+        stop_event: asyncio.Event | None = None,
+    ) -> None:
+        run_id = run['run_id']
+        artifact_dir = store.artifact_directory(run_id)
+        ensure_private_directory(artifact_dir)
+        try:
+            process = await self._spawn_process(run_id, store.database, artifact_dir)
+        except (OSError, RuntimeError) as error:
+            await store.fail(run_id, f'Could not start child process: {error}', '')
+            return
 
-def wake_worker() -> None:
-    if _worker_wakeup is not None:
-        _worker_wakeup.set()
+        wait_task: asyncio.Task[int] | None = None
+        output_task: asyncio.Task[str] | None = None
+        try:
+            wait_task = asyncio.create_task(process.wait())
+            output_task = asyncio.create_task(_process_output(process))
+            deadline_seconds = run['request'].get('deadline_seconds')
+            deadline = None if deadline_seconds is None else asyncio.get_running_loop().time() + int(deadline_seconds)
+            next_heartbeat = 0.0
+            while not wait_task.done():
+                await asyncio.sleep(0.05)
+                if owner_id is not None and asyncio.get_running_loop().time() >= next_heartbeat:
+                    if not await store.heartbeat_worker_lease(owner_id):
+                        await self._stop_process(process, wait_task)
+                        await store.fail(run_id, 'Worker lost its execution lease', await output_task)
+                        return
+                    next_heartbeat = asyncio.get_running_loop().time() + 5
+                current = await store.get(run_id)
+                stopping = stop_event is not None and stop_event.is_set()
+                if current is not None and current['status'] == 'cancelling':
+                    await self._stop_process(process, wait_task)
+                    evidence, evidence_error = read_child_evidence(artifact_dir, str(run['target']))
+                    failure_message = 'Cancelled by operator' + (f'; {evidence_error}' if evidence_error else '')
+                    await store.fail(run_id, failure_message, await output_task, cancelled=True, evidence=evidence)
+                    return
+                if stopping:
+                    await self._stop_process(process, wait_task)
+                    evidence, evidence_error = read_child_evidence(artifact_dir, str(run['target']))
+                    failure_message = 'theHarvester stopped before child completion' + (
+                        f'; {evidence_error}' if evidence_error else ''
+                    )
+                    await store.fail(run_id, failure_message, await output_task, evidence=evidence)
+                    return
+                if deadline is not None and asyncio.get_running_loop().time() >= deadline:
+                    await self._stop_process(process, wait_task)
+                    evidence, evidence_error = read_child_evidence(artifact_dir, str(run['target']))
+                    failure_message = f'Run exceeded its {deadline_seconds} second deadline'
+                    if evidence_error:
+                        failure_message += f'; {evidence_error}'
+                    await store.fail(
+                        run_id,
+                        failure_message,
+                        await output_task,
+                        evidence=evidence,
+                    )
+                    return
+            log = await output_task
+            current = await store.get(run_id)
+            evidence, evidence_error = read_child_evidence(artifact_dir, str(run['target']))
+            if evidence_error:
+                await store.fail(
+                    run_id,
+                    evidence_error,
+                    log,
+                    cancelled=current is not None and current['status'] == 'cancelling',
+                )
+                return
+            if current is not None and current['status'] == 'cancelling':
+                await store.finish(run_id, evidence, log)
+            elif process.returncode == 0 and evidence is not None:
+                await store.finish(run_id, evidence, log)
+            else:
+                await store.fail(
+                    run_id,
+                    f'Child process exited with status {process.returncode} without terminal completion',
+                    log,
+                    evidence=evidence,
+                )
+        except asyncio.CancelledError:
+            await self._abort_process_execution(process, wait_task, output_task)
+            raise
+        except BaseException:
+            await self._abort_process_execution(process, wait_task, output_task)
+            raise
+        finally:
+            self._process_groups.pop(process, None)
+
+    async def _worker_loop(self, session: _WorkerSession) -> None:
+        while not session.stop_event.is_set():
+            if not await session.store.heartbeat_worker_lease(session.owner_id):
+                return
+            run = await session.store.claim_next()
+            if run is not None:
+                await self.execute_claimed(
+                    session.store,
+                    run,
+                    session.owner_id,
+                    stop_event=session.stop_event,
+                )
+                continue
+            session.wakeup_event.clear()
+            try:
+                await asyncio.wait_for(session.wakeup_event.wait(), timeout=0.5)
+            except TimeoutError:
+                continue
+
+    async def _supervise_worker(self, session: _WorkerSession) -> None:
+        while not session.stop_event.is_set():
+            if await session.store.acquire_worker_lease(session.owner_id):
+                try:
+                    await session.store.recover_orphans()
+                except BaseException:
+                    await session.store.release_worker_lease(session.owner_id)
+                    raise
+                await self._worker_loop(session)
+                return
+            session.wakeup_event.clear()
+            try:
+                await asyncio.wait_for(session.wakeup_event.wait(), timeout=0.5)
+            except TimeoutError:
+                continue
 
 
 async def _child_execute(run_id: str, database: Path) -> None:
+    import anyio
+
     from theHarvester import __main__ as main_module
     from theHarvester.lib.completed_result import CompletedResult
+    from theHarvester.lib.enumeration import (
+        DEFAULT_RESULT_START,
+        DEFAULT_SOURCE_WORKERS,
+        EnumerationOptions,
+    )
+    from theHarvester.lib.resolver_selection import DEFAULT_DNS_RESOLVERS
+    from theHarvester.lib.virtual_host import (
+        DEFAULT_VHOST_CONCURRENCY,
+        DEFAULT_VHOST_REQUEST_LIMIT,
+        DEFAULT_VHOST_RUNTIME_SECONDS,
+        DEFAULT_VHOST_TIMEOUT_SECONDS,
+    )
 
     store = RunStore(database)
     run = await store.get(run_id)

--- a/theHarvester/lib/api/runs.py
+++ b/theHarvester/lib/api/runs.py
@@ -14,7 +14,6 @@ from starlette.background import BackgroundTask
 from theHarvester.lib.api.auth import get_api_key
 from theHarvester.lib.source_catalog import ACTION_ACTIVITIES, SOURCE_SPECS, SourceSpec, get_source_spec, resolve_sources
 
-from . import run_worker
 from .run_evidence import parse_jsonl_import
 from .run_models import (
     DATABASE_EXPORT_RESPONSES,
@@ -32,6 +31,8 @@ from .run_models import (
 )
 from .run_projection import source_spec
 from .run_store import RunStore
+from .run_worker import RunWorkerService  # noqa: TC001 - FastAPI resolves dependency annotations at runtime
+from .runtime import get_run_worker
 
 router = APIRouter(prefix='/api/v1', tags=['Runs'])
 MAX_IMPORT_BYTES = 10 * 1024 * 1024
@@ -137,6 +138,7 @@ async def list_sources(_api_key: Annotated[str, Depends(get_api_key)]) -> Source
 )
 async def create_run(
     request: Request,
+    worker: Annotated[RunWorkerService, Depends(get_run_worker)],
     _api_key: Annotated[str, Depends(get_api_key)],
 ) -> RunDetail:
     body = await _read_limited_body(request, MAX_RUN_REQUEST_BYTES, 'Run request exceeds the 64 KiB limit')
@@ -148,18 +150,18 @@ async def create_run(
             detail=error.errors(include_url=False, include_context=False),
         ) from error
     run_request.sources = canonical_run_sources(run_request.sources)
-    if not run_worker.worker_enabled():
+    if not worker.enabled:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail='theHarvester execution worker is disabled',
         )
-    if not run_worker.worker_available():
+    if not worker.available:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail='theHarvester execution worker is unavailable',
         )
     run = await RunStore().create(run_request)
-    run_worker.wake_worker()
+    worker.wake()
     return RunDetail.model_validate(run)
 
 

--- a/theHarvester/lib/api/runtime.py
+++ b/theHarvester/lib/api/runtime.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import Request  # noqa: TC002 - FastAPI resolves dependency annotations at runtime
+
+from .run_worker import RunWorker, RunWorkerService
+from .schedule_service import SchedulerService
+
+
+@dataclass(slots=True)
+class ApiRuntime:
+    """Application-owned background services for one FastAPI lifespan."""
+
+    worker: RunWorkerService
+    scheduler: SchedulerService
+
+    async def start(self) -> None:
+        await self.worker.start()
+        try:
+            await self.scheduler.start()
+        except BaseException:
+            await self.worker.stop()
+            raise
+
+    async def stop(self) -> None:
+        try:
+            await self.scheduler.stop()
+        finally:
+            await self.worker.stop()
+
+
+def create_runtime() -> ApiRuntime:
+    worker = RunWorker()
+    return ApiRuntime(worker=worker, scheduler=SchedulerService(worker))
+
+
+def get_runtime(request: Request) -> ApiRuntime:
+    runtime = getattr(request.app.state, 'runtime', None)
+    if not isinstance(runtime, ApiRuntime):
+        raise RuntimeError('theHarvester API runtime is not initialized')
+    return runtime
+
+
+def get_run_worker(request: Request) -> RunWorkerService:
+    return get_runtime(request).worker
+
+
+def get_scheduler(request: Request) -> SchedulerService:
+    return get_runtime(request).scheduler

--- a/theHarvester/lib/api/schedule_service.py
+++ b/theHarvester/lib/api/schedule_service.py
@@ -1,44 +1,58 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-from . import run_worker
 from .run_models import RunRequest
 from .run_store import RunStore
+from .run_worker import RunWorkerService  # noqa: TC001 - runtime type-hint resolution requires this import
 from .schedule_models import DispatchState, ScheduleDispatchResponse, ScheduleResponse, parse_utc, utc_iso, utc_now_datetime
 from .schedule_store import ScheduleStore
 
 if TYPE_CHECKING:
     from datetime import datetime
 
-_scheduler_task: asyncio.Task[None] | None = None
-_scheduler_stop: asyncio.Event | None = None
-_scheduler_wakeup: asyncio.Event | None = None
-_scheduler_owner: str | None = None
+ScheduleStoreFactory = Callable[[], ScheduleStore]
+RunStoreFactory = Callable[[], RunStore]
+EnabledCheck = Callable[[], bool]
+_LOGGER = logging.getLogger(__name__)
 
 
-def scheduler_enabled() -> bool:
+def _log_task_failure(task: asyncio.Task[None]) -> None:
+    """Report a crashed scheduler as soon as the task finishes."""
+    if task.cancelled():
+        return
+    error = task.exception()
+    if error is not None:
+        _LOGGER.error(
+            '%s exited unexpectedly',
+            task.get_name(),
+            exc_info=(type(error), error, error.__traceback__),
+        )
+
+
+def _enabled_from_environment() -> bool:
     return os.getenv('THEHARVESTER_SCHEDULER', 'enabled').casefold() != 'disabled'
-
-
-def scheduler_available() -> bool:
-    return _scheduler_task is not None and not _scheduler_task.done()
-
-
-def wake_scheduler() -> None:
-    if _scheduler_wakeup is not None:
-        _scheduler_wakeup.set()
 
 
 class ScheduleDispatcher:
     """Reserve one scheduled occurrence and submit its ordinary run records."""
 
-    def __init__(self, schedule_store: ScheduleStore | None = None, run_store: RunStore | None = None) -> None:
+    def __init__(
+        self,
+        schedule_store: ScheduleStore | None = None,
+        run_store: RunStore | None = None,
+        *,
+        worker: RunWorkerService,
+    ) -> None:
         self.schedule_store = schedule_store or ScheduleStore()
         self.run_store = run_store or RunStore()
+        self.worker = worker
 
     async def refresh(self, schedule_id: str) -> None:
         await self._reconcile_pending(schedule_id)
@@ -47,7 +61,7 @@ class ScheduleDispatcher:
         schedule = await self.schedule_store.get(schedule_id)
         if schedule is None:
             return None
-        if not run_worker.worker_enabled() or not run_worker.worker_available():
+        if not self.worker.enabled or not self.worker.available:
             raise RuntimeError('theHarvester execution worker is unavailable')
         return await self._enqueue_targets(schedule, scheduled_for=utc_now_datetime())
 
@@ -65,7 +79,7 @@ class ScheduleDispatcher:
             return
         scheduled_for = parse_utc(schedule.next_run_at)
 
-        if not run_worker.worker_enabled() or not run_worker.worker_available():
+        if not self.worker.enabled or not self.worker.available:
             await self.schedule_store.defer_claim(
                 schedule.schedule_id,
                 owner_id,
@@ -201,7 +215,7 @@ class ScheduleDispatcher:
                 await asyncio.sleep(0)
 
         if run_ids:
-            run_worker.wake_worker()
+            self.worker.wake()
         return ScheduleDispatchResponse(
             schedule_id=schedule.schedule_id,
             scheduled_for=utc_iso(scheduled_for),
@@ -211,72 +225,127 @@ class ScheduleDispatcher:
         )
 
 
-async def _wait_for_work(store: ScheduleStore) -> None:
-    assert _scheduler_wakeup is not None
-    _scheduler_wakeup.clear()
-    next_due = await store.next_due_at()
-    if next_due is None:
-        timeout = 5.0
-    else:
-        timeout = max(0.5, min(5.0, (next_due - utc_now_datetime()).total_seconds()))
-    try:
-        await asyncio.wait_for(_scheduler_wakeup.wait(), timeout=timeout)
-    except TimeoutError:
-        pass
+@dataclass(slots=True)
+class _SchedulerSession:
+    """Loop-bound state for one started scheduler instance."""
+
+    store: ScheduleStore
+    owner_id: str
+    stop_event: asyncio.Event
+    wakeup_event: asyncio.Event
+    task: asyncio.Task[None] | None = None
 
 
-async def _scheduler_loop(owner_id: str) -> None:
-    assert _scheduler_stop is not None
-    store = ScheduleStore()
-    dispatcher = ScheduleDispatcher(store, RunStore())
-    await store.initialize()
-    while not _scheduler_stop.is_set():
-        claimed = await store.claim_due(owner_id, limit=1)
-        if claimed:
-            for schedule in claimed:
-                if _scheduler_stop.is_set():
-                    break
+class SchedulerService:
+    """Own scheduler lifecycle state and its explicit worker dependency."""
+
+    def __init__(
+        self,
+        worker: RunWorkerService,
+        *,
+        schedule_store_factory: ScheduleStoreFactory = ScheduleStore,
+        run_store_factory: RunStoreFactory = RunStore,
+        enabled_check: EnabledCheck = _enabled_from_environment,
+    ) -> None:
+        self.worker = worker
+        self._schedule_store_factory = schedule_store_factory
+        self._run_store_factory = run_store_factory
+        self._enabled_check = enabled_check
+        self._session: _SchedulerSession | None = None
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled_check()
+
+    @property
+    def available(self) -> bool:
+        session = self._session
+        return session is not None and session.task is not None and not session.task.done()
+
+    def wake(self) -> None:
+        session = self._session
+        if session is not None:
+            session.wakeup_event.set()
+
+    def dispatcher(
+        self,
+        schedule_store: ScheduleStore | None = None,
+        run_store: RunStore | None = None,
+    ) -> ScheduleDispatcher:
+        return ScheduleDispatcher(schedule_store, run_store, worker=self.worker)
+
+    async def start(self) -> None:
+        if not self.enabled:
+            return
+        if self.available:
+            return
+        if self._session is not None:
+            await self.stop()
+
+        session = _SchedulerSession(
+            store=self._schedule_store_factory(),
+            owner_id=str(uuid4()),
+            stop_event=asyncio.Event(),
+            wakeup_event=asyncio.Event(),
+        )
+        self._session = session
+        session.task = asyncio.create_task(
+            self._scheduler_loop(session),
+            name=f'theharvester-scheduler-{session.owner_id}',
+        )
+        session.task.add_done_callback(_log_task_failure)
+
+    async def stop(self) -> None:
+        session = self._session
+        if session is None:
+            return
+        task = session.task
+        try:
+            session.stop_event.set()
+            session.wakeup_event.set()
+            if task is not None:
                 try:
-                    await dispatcher.dispatch_claimed(schedule, owner_id)
-                except Exception as error:
-                    await store.defer_claim(
-                        schedule.schedule_id,
-                        owner_id,
-                        seconds=60,
-                        error=f'{type(error).__name__}: {error}',
-                    )
-            continue
-        await _wait_for_work(store)
+                    await asyncio.shield(task)
+                except asyncio.CancelledError:
+                    task.cancel()
+                    await asyncio.gather(task, return_exceptions=True)
+                    raise
+        finally:
+            try:
+                await session.store.release_claims(session.owner_id)
+            finally:
+                if self._session is session:
+                    self._session = None
 
+    async def _wait_for_work(self, session: _SchedulerSession) -> None:
+        session.wakeup_event.clear()
+        next_due = await session.store.next_due_at()
+        if next_due is None:
+            timeout = 5.0
+        else:
+            timeout = max(0.5, min(5.0, (next_due - utc_now_datetime()).total_seconds()))
+        try:
+            await asyncio.wait_for(session.wakeup_event.wait(), timeout=timeout)
+        except TimeoutError:
+            pass
 
-async def start_scheduler() -> None:
-    global _scheduler_owner, _scheduler_stop, _scheduler_task, _scheduler_wakeup
-    if not scheduler_enabled():
-        return
-    if _scheduler_task is not None and not _scheduler_task.done():
-        return
-    owner_id = str(uuid4())
-    _scheduler_owner = owner_id
-    _scheduler_stop = asyncio.Event()
-    _scheduler_wakeup = asyncio.Event()
-    _scheduler_task = asyncio.create_task(_scheduler_loop(owner_id))
-
-
-async def stop_scheduler() -> None:
-    global _scheduler_owner, _scheduler_stop, _scheduler_task, _scheduler_wakeup
-    task = _scheduler_task
-    owner_id = _scheduler_owner
-    try:
-        if task is not None:
-            if _scheduler_stop is not None:
-                _scheduler_stop.set()
-            if _scheduler_wakeup is not None:
-                _scheduler_wakeup.set()
-            await task
-    finally:
-        if owner_id is not None:
-            await ScheduleStore().release_claims(owner_id)
-        _scheduler_task = None
-        _scheduler_owner = None
-        _scheduler_stop = None
-        _scheduler_wakeup = None
+    async def _scheduler_loop(self, session: _SchedulerSession) -> None:
+        dispatcher = self.dispatcher(session.store, self._run_store_factory())
+        await session.store.initialize()
+        while not session.stop_event.is_set():
+            claimed = await session.store.claim_due(session.owner_id, limit=1)
+            if claimed:
+                for schedule in claimed:
+                    if session.stop_event.is_set():
+                        break
+                    try:
+                        await dispatcher.dispatch_claimed(schedule, session.owner_id)
+                    except Exception as error:
+                        await session.store.defer_claim(
+                            schedule.schedule_id,
+                            session.owner_id,
+                            seconds=60,
+                            error=f'{type(error).__name__}: {error}',
+                        )
+                continue
+            await self._wait_for_work(session)

--- a/theHarvester/lib/api/schedules.py
+++ b/theHarvester/lib/api/schedules.py
@@ -4,9 +4,9 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
-from . import run_worker
 from .auth import get_api_key
 from .runs import canonical_run_sources
+from .runtime import get_scheduler
 from .schedule_models import (
     ScheduleCreate,
     ScheduleDispatchRecord,
@@ -14,12 +14,7 @@ from .schedule_models import (
     ScheduleHealthResponse,
     ScheduleResponse,
 )
-from .schedule_service import (
-    ScheduleDispatcher,
-    scheduler_available,
-    scheduler_enabled,
-    wake_scheduler,
-)
+from .schedule_service import SchedulerService  # noqa: TC001 - FastAPI resolves dependency annotations at runtime
 from .schedule_store import ScheduleStore, ScheduleStoreError
 
 router = APIRouter(prefix='/api/v1/schedules', tags=['Schedules'])
@@ -49,26 +44,28 @@ async def list_schedules(
 
 @router.get('/health')
 async def schedule_health(
+    scheduler: Annotated[SchedulerService, Depends(get_scheduler)],
     _api_key: Annotated[str, Depends(get_api_key)],
 ) -> ScheduleHealthResponse:
     return ScheduleHealthResponse(
-        scheduler_enabled=scheduler_enabled(),
-        scheduler_available=scheduler_available(),
-        worker_enabled=run_worker.worker_enabled(),
-        worker_available=run_worker.worker_available(),
+        scheduler_enabled=scheduler.enabled,
+        scheduler_available=scheduler.available,
+        worker_enabled=scheduler.worker.enabled,
+        worker_available=scheduler.worker.available,
     )
 
 
 @router.post('', status_code=status.HTTP_201_CREATED)
 async def create_schedule(
     request: ScheduleCreate,
+    scheduler: Annotated[SchedulerService, Depends(get_scheduler)],
     _api_key: Annotated[str, Depends(get_api_key)],
 ) -> ScheduleResponse:
     try:
         created = await ScheduleStore().create(_canonicalize_schedule(request))
     except ScheduleStoreError as error:
         raise _store_error(error) from error
-    wake_scheduler()
+    scheduler.wake()
     return created
 
 
@@ -90,6 +87,7 @@ async def get_schedule(
 async def replace_schedule(
     schedule_id: str,
     request: ScheduleCreate,
+    scheduler: Annotated[SchedulerService, Depends(get_scheduler)],
     _api_key: Annotated[str, Depends(get_api_key)],
 ) -> ScheduleResponse:
     try:
@@ -98,13 +96,14 @@ async def replace_schedule(
         raise _store_error(error) from error
     if schedule is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Schedule not found')
-    wake_scheduler()
+    scheduler.wake()
     return schedule
 
 
 @router.delete('/{schedule_id}', status_code=status.HTTP_204_NO_CONTENT)
 async def delete_schedule(
     schedule_id: str,
+    scheduler: Annotated[SchedulerService, Depends(get_scheduler)],
     _api_key: Annotated[str, Depends(get_api_key)],
 ) -> Response:
     try:
@@ -113,13 +112,14 @@ async def delete_schedule(
         raise _store_error(error) from error
     if not deleted:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Schedule not found')
-    wake_scheduler()
+    scheduler.wake()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.post('/{schedule_id}/pause')
 async def pause_schedule(
     schedule_id: str,
+    scheduler: Annotated[SchedulerService, Depends(get_scheduler)],
     _api_key: Annotated[str, Depends(get_api_key)],
 ) -> ScheduleResponse:
     try:
@@ -128,13 +128,14 @@ async def pause_schedule(
         raise _store_error(error) from error
     if schedule is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Schedule not found')
-    wake_scheduler()
+    scheduler.wake()
     return schedule
 
 
 @router.post('/{schedule_id}/resume')
 async def resume_schedule(
     schedule_id: str,
+    scheduler: Annotated[SchedulerService, Depends(get_scheduler)],
     _api_key: Annotated[str, Depends(get_api_key)],
 ) -> ScheduleResponse:
     try:
@@ -143,22 +144,23 @@ async def resume_schedule(
         raise _store_error(error) from error
     if schedule is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Schedule not found')
-    wake_scheduler()
+    scheduler.wake()
     return schedule
 
 
 @router.post('/{schedule_id}/run-now', status_code=status.HTTP_202_ACCEPTED)
 async def run_schedule_now(
     schedule_id: str,
+    scheduler: Annotated[SchedulerService, Depends(get_scheduler)],
     _api_key: Annotated[str, Depends(get_api_key)],
 ) -> ScheduleDispatchResponse:
-    if not run_worker.worker_enabled() or not run_worker.worker_available():
+    if not scheduler.worker.enabled or not scheduler.worker.available:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail='theHarvester execution worker is unavailable',
         )
     try:
-        dispatch = await ScheduleDispatcher().dispatch_now(schedule_id)
+        dispatch = await scheduler.dispatcher().dispatch_now(schedule_id)
     except (RuntimeError, ScheduleStoreError) as error:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(error)) from error
     if dispatch is None:
@@ -169,6 +171,7 @@ async def run_schedule_now(
 @router.get('/{schedule_id}/dispatches')
 async def list_schedule_dispatches(
     schedule_id: str,
+    scheduler: Annotated[SchedulerService, Depends(get_scheduler)],
     _api_key: Annotated[str, Depends(get_api_key)],
     limit: Annotated[int, Query(ge=1, le=5000)] = 500,
     offset: Annotated[int, Query(ge=0)] = 0,
@@ -177,7 +180,7 @@ async def list_schedule_dispatches(
     try:
         if await store.get(schedule_id) is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Schedule not found')
-        await ScheduleDispatcher(store).refresh(schedule_id)
+        await scheduler.dispatcher(schedule_store=store).refresh(schedule_id)
         return await store.list_dispatches(schedule_id, limit=limit, offset=offset)
     except ScheduleStoreError as error:
         raise _store_error(error) from error


### PR DESCRIPTION
## Summary

- replace module-level worker and scheduler lifecycle globals with app-owned `RunWorker`, `SchedulerService`, and `ApiRuntime` instances
- inject the per-lifespan runtime through `create_app(runtime_factory=...)` and FastAPI dependencies while preserving the durable SQLite worker lease and public contracts
- make child cancellation cleanup and unexpected background-task failure reporting explicit, with focused isolation and lifecycle coverage
- record the ownership decision in ADR 0010 (0010 avoids colliding with the proxy-scope ADR already present on `master`)

## Verification

- `uv sync --all-groups`
- focused runtime/schedule/run/API suites: `169 passed`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- full non-browser suite: `1988 passed, 6 skipped, 36 deselected`
- HarvestView browser E2E: `36 passed`
- focused documentation checks: `16 passed`

No REST schema, database schema, environment variable, CLI flag, or discovery-activity boundary changes.