### PR TITLE
Make source yield reports target-aware and track hostname changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added target-aware `harvest-yields` reporting with canonical target inventory, safe one-target defaults, and explicit all-target aggregation.
+- Added read-only hostname change tracking across finalized runs with matching target and source cohort in `harvest-yields`, the REST API, and HarvestView, including fail-closed source-health and retained DNS-evidence interpretation.
 - Added authenticated REST and HarvestView export of every completed run as a portable SQLite database without queue, cancellation, worker-lease, or legacy-observation state.
 - Added a catalog-derived offline provider-contract gate that fails on missing, unknown, or duplicate source coverage while keeping live checks outside routine CI.
 - Added sourced ASN organization attribution from URLScan, ONYPHE, and Shodan, linked to the exact hostname or IP evidence and retained in SQLite, JSONL, the API, CLI output, and HarvestView without claiming ownership or scope.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -236,19 +236,19 @@ The set of canonical sources represented by source executions in one enumeration
 _Avoid_: Successful sources, source results, source selection text
 
 **Comparable source-yield run**:
-A finalized enumeration run for the same canonical target and source cohort as another run. Unhealthy source executions may retain evidence but cannot support a missing-hostname claim.
+A finalized enumeration run for the same canonical target and source cohort as another run. Unhealthy source executions may retain evidence but cannot support a sound one-sided hostname claim.
 _Avoid_: Previous run, similar run, matching run
 
 **Hostname tracking change**:
-The relationship of one canonical hostname between two comparable enumeration runs: new when retained only in the later run, persisting when retained in both, missing when reliably absent from the later run, and inconclusive when relevant source outcomes cannot support the comparison. Missing is an evidence difference, not proof that the hostname ceased to exist or resolve.
+The relationship of one canonical hostname between two comparable enumeration runs: new when reliably absent from the earlier run and retained in the later run, persisting when retained in both, missing when reliably absent from the later run, and inconclusive when relevant source outcomes cannot support a one-sided comparison. Missing is an evidence difference, not proof that the hostname ceased to exist or resolve.
 _Avoid_: Added host, removed host, gone host
 
 **Relevant source health**:
-The outcomes in the later run of the sources that previously contributed a hostname. A hostname absent from the later run is missing only when every relevant source completed successfully; otherwise its change is inconclusive. Failures by unrelated sources do not affect that hostname.
+The outcomes on the side where a hostname is absent for the sources that contributed it on the other side. A one-sided hostname is new or missing only when every relevant source completed successfully on the absent side; otherwise its change is inconclusive. Failures by unrelated sources do not affect that hostname.
 _Avoid_: Run health, all-source success, provider reliability
 
 **Inconclusive hostname change**:
-A hostname absent from the later run when at least one source that previously contributed it was partial, failed, rate limited, or skipped. The blocking source outcomes and retained failure reasons explain the uncertainty; the state does not mean the comparison logic failed.
+A hostname retained on exactly one side when at least one source that contributed it there was partial, failed, rate limited, or skipped on the side where it was absent. The blocking source outcomes and retained failure reasons explain the uncertainty; the state does not mean the comparison logic failed.
 _Avoid_: Unknown result, missing hostname, comparison error
 
 **Source-exclusive hostname**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -155,6 +155,10 @@ _Avoid_: DNS result, resolved host, validation status
 One finite execution of theHarvester against an explicit target and selected options, identified independently from every other execution.
 _Avoid_: Scan, monitoring cycle, session, job
 
+**Enumeration target**:
+The operator-supplied identifier that scopes one enumeration run. It is ordinarily a canonical hostname and may instead be a canonical IP address, ASN, or CIDR for supported routing activity, or an exact free-text company query for a source that accepts one.
+_Avoid_: Domain, hostname when the target is not a DNS name, target alias
+
 **Run schedule**:
 A durable local plan that combines an explicit authorized target inventory, one validated run template, recurrence timing, and an overlap policy. It creates enumeration runs but is never itself an enumeration run or evidence record.
 _Avoid_: Scan schedule, cron job, monitoring run
@@ -218,6 +222,10 @@ _Avoid_: Source result, provider response
 **Source hostname yield**:
 One source's normalized hostname counts within one enumeration run: observed, unique, shared, DNS-resolved, and unique DNS-resolved. A hostname is unique when exactly one source reported it in that run. It is DNS-resolved when the run's resolution action retained an A, AAAA, or CNAME answer. The counts measure marginal coverage and current DNS evidence, not independent corroboration, ownership, or service reachability.
 _Avoid_: Source quality score, authoritative result count, independent confirmation
+
+**Source yield report scope**:
+The explicit finalized evidence records summarized by a source-yield report: one enumeration run, selected runs for one canonical authorized target, or runs across every stored target only by deliberate operator choice.
+_Avoid_: Implicit database aggregate, target alias
 
 **Source capability**:
 A declared class of normalized result that a source can contribute to consolidated enumeration output, independent of whether one source execution yields any data.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -227,6 +227,42 @@ _Avoid_: Source quality score, authoritative result count, independent confirmat
 The explicit finalized evidence records summarized by a source-yield report: one enumeration run, selected runs for one canonical authorized target, or runs across every stored target only by deliberate operator choice.
 _Avoid_: Implicit database aggregate, target alias
 
+**Source yield tracking view**:
+A longitudinal view of finalized evidence for one enumeration target that highlights actionable hostname changes and their retained DNS evidence. It is observational and never initiates discovery or DNS activity.
+_Avoid_: Discovery run, live DNS check, evidence export
+
+**Source cohort**:
+The set of canonical sources represented by source executions in one enumeration run, independent of their individual outcomes.
+_Avoid_: Successful sources, source results, source selection text
+
+**Comparable source-yield run**:
+A finalized enumeration run for the same canonical target and source cohort as another run. Unhealthy source executions may retain evidence but cannot support a missing-hostname claim.
+_Avoid_: Previous run, similar run, matching run
+
+**Hostname tracking change**:
+The relationship of one canonical hostname between two comparable enumeration runs: new when retained only in the later run, persisting when retained in both, missing when reliably absent from the later run, and inconclusive when relevant source outcomes cannot support the comparison. Missing is an evidence difference, not proof that the hostname ceased to exist or resolve.
+_Avoid_: Added host, removed host, gone host
+
+**Relevant source health**:
+The outcomes in the later run of the sources that previously contributed a hostname. A hostname absent from the later run is missing only when every relevant source completed successfully; otherwise its change is inconclusive. Failures by unrelated sources do not affect that hostname.
+_Avoid_: Run health, all-source success, provider reliability
+
+**Inconclusive hostname change**:
+A hostname absent from the later run when at least one source that previously contributed it was partial, failed, rate limited, or skipped. The blocking source outcomes and retained failure reasons explain the uncertainty; the state does not mean the comparison logic failed.
+_Avoid_: Unknown result, missing hostname, comparison error
+
+**Source-exclusive hostname**:
+A hostname attributed to exactly one canonical source within one enumeration run. Exclusivity is run-scoped and does not claim that no other source has ever observed the hostname.
+_Avoid_: Globally unique hostname, proprietary hostname, unique subdomain
+
+**Retained resolution evidence**:
+What finalized evidence establishes about DNS resolution for one hostname in one run: a retained positive answer, no retained positive answer, or no recorded check. It remains separate from richer addressability classifications such as currently addressable, not currently addressable, resolver disputed, or wildcard indistinguishable.
+_Avoid_: Boolean resolved state, live-host status, reachability
+
+**Hostname tracking projection**:
+A read-only comparison derived from one or more selected finalized runs and each run's previous comparable run. It is not stored as new canonical evidence and may be rendered by multiple operator interfaces.
+_Avoid_: Tracking artifact, discovery result, DNS refresh
+
 **Source capability**:
 A declared class of normalized result that a source can contribute to consolidated enumeration output, independent of whether one source execution yields any data.
 _Avoid_: Guaranteed result, module return type, source category

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,7 +56,7 @@ When a change alters one of these boundaries, update this document and the neare
 
 ### Deferred boundaries
 
-- Cross-run change detection, alerts, and automatic reactions remain separate future product decisions. A scheduled occurrence only submits finite enumeration runs.
+- Read-only cross-run change projections over finalized evidence are part of the release contract. Alerts and automatic reactions remain deferred, and a scheduled occurrence only submits finite enumeration runs.
 - Cross-run source ranking remains a reporting decision. One run's hostname-yield summary does not automatically select, disable, or rank sources.
 - Distributed workers, multi-host operation, PostgreSQL, and hosted multi-user authorization require measured demand and new decisions. The release remains SQLite-first and local-operator focused.
 - Automatic scope expansion remains deferred. Evidence can suggest a later target, while the operator controls every scope change.

--- a/docs/wiki/Rest-API.md
+++ b/docs/wiki/Rest-API.md
@@ -148,7 +148,7 @@ The object contains:
 - `comparisons`, with the current and baseline run IDs and completion times, exact `source_cohort`, `new`, `persisting`, `missing`, and `inconclusive` counts, and a message when no baseline exists.
 - `hostname_changes`, with change state, hostname, previous and current sources, relevant-side source exclusivity, blocking source outcomes, previous and current resolution evidence, DNS action statuses, and addressability classifications.
 
-Run details include persisting rows so HarvestView can show or hide them locally. `missing` requires every previous contributing source to have completed in the selected run. Otherwise the absence is `inconclusive`, with the relevant partial, failed, rate-limited, or skipped outcomes retained in `blocking_sources`. Unrelated source failures do not change the row.
+Run details include persisting rows so HarvestView can show or hide them locally. `new` requires every current contributing source to have completed in the baseline, while `missing` requires every previous contributing source to have completed in the selected run. Otherwise the one-sided observation is `inconclusive`, with the relevant partial, failed, rate-limited, or skipped outcomes retained in `blocking_sources`. Unrelated source failures do not change the row.
 
 Resolution evidence is `positive`, `not-retained`, or `not-checked`; no ambiguous unknown state is emitted. Addressability is a separate retained recursive-DNS classification or `null` when no classification exists. See [Track hostname changes across finalized runs](Results-and-Local-Data#track-hostname-changes-across-finalized-runs) for CLI examples and full interpretation rules.
 

--- a/docs/wiki/Rest-API.md
+++ b/docs/wiki/Rest-API.md
@@ -33,7 +33,7 @@ Treat the runtime OpenAPI document as the exact request and response reference.
 | `GET /api/v1/sources` | List discovery sources, capabilities, activity classes, and credential names. |
 | `POST /api/v1/runs` | Submit one finite enumeration run. |
 | `GET /api/v1/runs` | List run records with `limit` and `offset` pagination. |
-| `GET /api/v1/runs/{run_id}` | Retrieve lifecycle state, options, results, source outcomes, source yields, and artifacts. |
+| `GET /api/v1/runs/{run_id}` | Retrieve lifecycle state, options, results, source outcomes, source yields, hostname changes, and artifacts. |
 | `POST /api/v1/runs/{run_id}/cancel` | Cancel queued work or request cancellation of running work. |
 | `POST /api/v1/runs/import` | Import a JSONL result file without executing discovery. |
 | `POST /api/v1/runs/import-database` | Import completed runs from a theHarvester SQLite database. |
@@ -122,7 +122,7 @@ run_id="$(curl -s http://127.0.0.1:5000/api/v1/runs \
 
 curl -s "http://127.0.0.1:5000/api/v1/runs/$run_id" \
   -H "X-API-Key: $THEHARVESTER_API_KEY" \
-  | jq '{status, evidence_status, results, source_executions, source_yields, action_executions, artifacts}'
+  | jq '{status, evidence_status, results, source_executions, source_yields, hostname_tracking, action_executions, artifacts}'
 ```
 
 Run submission is asynchronous. Read the two status fields separately:
@@ -137,6 +137,20 @@ Run submission is asynchronous. Read the two status fields separately:
 `limit` defaults to 500 per source. A value of `0` removes the shared cap on results and pages, so adapters continue until their provider is exhausted. There is no numeric maximum. Provider quotas, protocol maxima, response-size guards, and runtime limits still apply. If a provider or safety limit stops a source after it retained results, the run keeps those results and records the source as partial with the stop reason.
 
 `source_yields` reports normalized hostname contributions within the run. `unique_result_count` counts hostnames reported by exactly one selected source. When `dns_resolve` ran, `resolved_hostname_count` and `unique_resolved_hostname_count` show which of those hostnames had retained A, AAAA, or CNAME answers. Read these counts with the source's execution status and stop reason. The [results guide](Results-and-Local-Data#compare-source-hostname-yield) explains how to compare fixed runs over time.
+
+### Read hostname changes
+
+Finalized run details include an additive `hostname_tracking` object derived only from persisted SQLite evidence. Reading the endpoint never starts discovery or DNS. The selected run is compared with the previous finalized run that has the same canonical target and exact source cohort.
+
+The object contains:
+
+- `target` and `comparison_count`.
+- `comparisons`, with the current and baseline run IDs and completion times, exact `source_cohort`, `new`, `persisting`, `missing`, and `inconclusive` counts, and a message when no baseline exists.
+- `hostname_changes`, with change state, hostname, previous and current sources, relevant-side source exclusivity, blocking source outcomes, previous and current resolution evidence, DNS action statuses, and addressability classifications.
+
+Run details include persisting rows so HarvestView can show or hide them locally. `missing` requires every previous contributing source to have completed in the selected run. Otherwise the absence is `inconclusive`, with the relevant partial, failed, rate-limited, or skipped outcomes retained in `blocking_sources`. Unrelated source failures do not change the row.
+
+Resolution evidence is `positive`, `not-retained`, or `not-checked`; no ambiguous unknown state is emitted. Addressability is a separate retained recursive-DNS classification or `null` when no classification exists. See [Track hostname changes across finalized runs](Results-and-Local-Data#track-hostname-changes-across-finalized-runs) for CLI examples and full interpretation rules.
 
 P1 DNS and P2 direct options are fields on the same run request. The OpenAPI schema shows their current defaults, limits, and descriptions. The server uses the operator-selected target and does not impose a public-only egress policy.
 

--- a/docs/wiki/Results-and-Local-Data.md
+++ b/docs/wiki/Results-and-Local-Data.md
@@ -229,8 +229,8 @@ Every change row includes previous and current source lists plus `source_exclusi
 Resolution evidence uses only three explicit values:
 
 - `positive`: the run retained an A, AAAA, or CNAME answer for the hostname.
-- `not-retained`: DNS resolution ran for the sourced hostname but retained no positive answer.
-- `not-checked`: the run has no applicable retained DNS-resolution attempt.
+- `not-retained`: DNS resolution completed for the sourced hostname but retained no positive answer.
+- `not-checked`: the run has no applicable completed DNS-resolution attempt.
 
 There is no ambiguous `unknown` value. Recursive DNS addressability is separate and is either one of its retained classifications (`currently-addressable`, `not-currently-addressable`, `resolver-disputed`, or `wildcard-indistinguishable`) or `null` when no classification was retained. Neither resolution evidence nor addressability proves service reachability.
 

--- a/docs/wiki/Results-and-Local-Data.md
+++ b/docs/wiki/Results-and-Local-Data.md
@@ -217,14 +217,14 @@ A baseline is the previous finalized run with the same canonical target and exac
 
 Each comparison reports four counts:
 
-- `new`: present now and absent from the baseline.
+- `new`: present now and absent from the baseline after every current contributing source completed in the baseline.
 - `persisting`: present in both runs. Rows are hidden by default; add `--include-persisting` to return them.
 - `missing`: absent now after every source that previously contributed the hostname completed successfully in the current run.
-- `inconclusive`: absent now, but at least one previous contributing source was partial, failed, rate-limited, or skipped. The row retains each blocking source's status, error type, and stop reason.
+- `inconclusive`: present on only one side, but a source that contributed it there was partial, failed, rate-limited, or skipped on the side where it was absent. The row retains each blocking source's status, error type, and stop reason.
 
-The missing and inconclusive decision is hostname-specific. An unrelated source failure does not poison a row, and a positive current observation remains new or persisting even if another source was unhealthy.
+The decision is hostname-specific. A positive current observation remains new or persisting when only unrelated sources were unhealthy; failures by a source that contributed the hostname make the one-sided claim inconclusive.
 
-Every change row includes previous and current source lists plus `source_exclusive`. Exclusivity applies to the current sources for new and persisting rows, and to the baseline sources for missing and inconclusive rows. It means exactly one source contributed that hostname on the relevant side of the comparison; it does not claim that the provider is independent or authoritative.
+Every change row includes previous and current source lists plus `source_exclusive`. Exclusivity applies to the side with retained hostname evidence: current for new and persisting, baseline for missing, and whichever side has evidence for inconclusive. It means exactly one source contributed that hostname on the relevant side of the comparison; it does not claim that the provider is independent or authoritative.
 
 Resolution evidence uses only three explicit values:
 

--- a/docs/wiki/Results-and-Local-Data.md
+++ b/docs/wiki/Results-and-Local-Data.md
@@ -168,7 +168,7 @@ Run details derive `source_yields` from persisted normalized hostname provenance
 
 Read the counts with the matching source execution status and stop reason. A source that failed, was rate-limited or skipped, or stopped at a provider boundary cannot be compared with a source that completed with zero results. Sources in the same certificate-transparency or passive-DNS family may overlap because they depend on the same upstream evidence.
 
-To compare runs, keep the authorized target, source set, requested limit, release version, resolver set, and collection window fixed. Set the limit to `0` only when the comparison should have no shared local result cap. Save completed runs in SQLite and repeat the test across several authorized targets and dates. Compare median unique count, median unique-resolved count, resolution rate, and successful-run rate. Record provider and adapter ceilings as execution evidence instead of treating truncated runs as zero yield. Do not commit target results. Add cross-run aggregation only after you have enough comparable runs to justify it.
+To compare runs, keep the authorized target, source set, requested limit, release version, resolver set, and collection window fixed. Set the limit to `0` only when the comparison should have no shared local result cap. Save completed runs in SQLite and repeat the test across several authorized targets and dates. Compare median unique count, median unique-resolved count, resolution rate, and successful-run rate. Record provider and adapter ceilings as execution evidence instead of treating truncated runs as zero yield. Do not commit target results.
 
 #### Analyze yields from SQLite
 
@@ -183,6 +183,9 @@ harvest-yields --database results.sqlite --kind asn
 harvest-yields --database results.sqlite --run-id 11111111-1111-4111-8111-111111111111
 harvest-yields --database results.sqlite --target example.test
 harvest-yields --database results.sqlite --target example.test --format json
+harvest-yields --database results.sqlite --target example.test --changes
+harvest-yields --database results.sqlite --run-id 11111111-1111-4111-8111-111111111111 --changes --format json
+harvest-yields --database results.sqlite --target example.test --changes --include-persisting
 harvest-yields --database results.sqlite --list-targets
 harvest-yields --database results.sqlite --list-targets --format json
 harvest-yields --database results.sqlite --all-targets
@@ -198,6 +201,40 @@ Use `--all-targets` only when a deliberate whole-database aggregate is required.
 The top-level `run_count` shows how many runs were selected. Each source row has its own `run_count`, including executions that produced no results. `UNIQUE/RUN` divides the summed unique count by that source's run count and is the default ranking key. The JSON field is `unique_result_count_per_run`.
 
 "Unique" always means unique within one run, so aggregate totals add the per-run counts instead of recalculating uniqueness across targets or dates. Hostname output also includes resolved and unique-resolved counts plus `UNIQUE-RESOLVED/RUN`, named `unique_resolved_hostname_count_per_run` in JSON. Other result kinds omit the DNS-specific fields.
+
+### Track hostname changes across finalized runs
+
+`harvest-yields --changes` compares retained hostname evidence without running discovery or DNS and without creating another report format. It reads only finalized runs already stored in SQLite. Use a canonical target to return every comparable run in chronological order, or a run ID to compare just that run with its baseline:
+
+```console
+harvest-yields --target example.test --changes
+harvest-yields --target example.test --changes --format json
+harvest-yields --run-id 11111111-1111-4111-8111-111111111111 --changes
+harvest-yields --target example.test --changes --include-persisting
+```
+
+A baseline is the previous finalized run with the same canonical target and exact `source_cohort`. Runs are ordered by `completed_at` and then `run_id`, so the choice is deterministic. A run with no comparable predecessor is still returned with `baseline_run_id: null`, zero counts, and a clear message. `--all-targets --changes` is refused because one mixed timeline would hide the target boundary.
+
+Each comparison reports four counts:
+
+- `new`: present now and absent from the baseline.
+- `persisting`: present in both runs. Rows are hidden by default; add `--include-persisting` to return them.
+- `missing`: absent now after every source that previously contributed the hostname completed successfully in the current run.
+- `inconclusive`: absent now, but at least one previous contributing source was partial, failed, rate-limited, or skipped. The row retains each blocking source's status, error type, and stop reason.
+
+The missing and inconclusive decision is hostname-specific. An unrelated source failure does not poison a row, and a positive current observation remains new or persisting even if another source was unhealthy.
+
+Every change row includes previous and current source lists plus `source_exclusive`. Exclusivity applies to the current sources for new and persisting rows, and to the baseline sources for missing and inconclusive rows. It means exactly one source contributed that hostname on the relevant side of the comparison; it does not claim that the provider is independent or authoritative.
+
+Resolution evidence uses only three explicit values:
+
+- `positive`: the run retained an A, AAAA, or CNAME answer for the hostname.
+- `not-retained`: DNS resolution ran for the sourced hostname but retained no positive answer.
+- `not-checked`: the run has no applicable retained DNS-resolution attempt.
+
+There is no ambiguous `unknown` value. Recursive DNS addressability is separate and is either one of its retained classifications (`currently-addressable`, `not-currently-addressable`, `resolver-disputed`, or `wildcard-indistinguishable`) or `null` when no classification was retained. Neither resolution evidence nor addressability proves service reachability.
+
+HarvestView shows the same projection on a selected finalized run. Its filters cover change state, relevant source, relevant-side resolution evidence, source-exclusive rows, and optional persisting rows. The panel refreshes through the existing terminal-run refresh path and never starts collection or DNS.
 
 ## Handling and sharing
 

--- a/docs/wiki/Results-and-Local-Data.md
+++ b/docs/wiki/Results-and-Local-Data.md
@@ -185,12 +185,15 @@ harvest-yields --database results.sqlite --target example.test
 harvest-yields --database results.sqlite --target example.test --format json
 harvest-yields --database results.sqlite --list-targets
 harvest-yields --database results.sqlite --list-targets --format json
+harvest-yields --database results.sqlite --all-targets
 harvest-yields --database results.sqlite --format json
 ```
 
 Use `--list-targets` to discover the canonical enumeration targets in finalized runs and the run count for each one. The inventory coalesces equivalent hostname spellings and canonical network identifiers without rewriting stored evidence; exact free-text company queries remain case-sensitive. Listing does not run discovery or DNS.
 
 Use `--target` to add source yields only from finalized runs for one exact canonical target. An unknown target fails with a `--list-targets` recovery hint. Without a scope selector, an empty database returns an empty report, one stored canonical target is selected automatically, and multiple stored targets are refused rather than silently mixed. `--run-id` still selects one finalized run. One-target and run-ID reports identify their canonical target in both table and JSON output.
+
+Use `--all-targets` only when a deliberate whole-database aggregate is required. Its table and JSON output enumerate every included canonical target and finalized-run count so the mixed scope remains visible. Meaningful comparisons normally keep the enumeration target fixed.
 
 The top-level `run_count` shows how many runs were selected. Each source row has its own `run_count`, including executions that produced no results. `UNIQUE/RUN` divides the summed unique count by that source's run count and is the default ranking key. The JSON field is `unique_result_count_per_run`.
 

--- a/docs/wiki/Results-and-Local-Data.md
+++ b/docs/wiki/Results-and-Local-Data.md
@@ -181,6 +181,8 @@ harvest-yields --database results.sqlite --kind hostname
 harvest-yields --database results.sqlite --kind ip
 harvest-yields --database results.sqlite --kind asn
 harvest-yields --database results.sqlite --run-id 11111111-1111-4111-8111-111111111111
+harvest-yields --database results.sqlite --target example.test
+harvest-yields --database results.sqlite --target example.test --format json
 harvest-yields --database results.sqlite --list-targets
 harvest-yields --database results.sqlite --list-targets --format json
 harvest-yields --database results.sqlite --format json
@@ -188,7 +190,9 @@ harvest-yields --database results.sqlite --format json
 
 Use `--list-targets` to discover the canonical enumeration targets in finalized runs and the run count for each one. The inventory coalesces equivalent hostname spellings and canonical network identifiers without rewriting stored evidence; exact free-text company queries remain case-sensitive. Listing does not run discovery or DNS.
 
-Without `--run-id`, the command adds each run's source yields. The top-level `run_count` shows how many runs were selected. Each source row has its own `run_count`, including executions that produced no results. `UNIQUE/RUN` divides the summed unique count by that source's run count and is the default ranking key. The JSON field is `unique_result_count_per_run`.
+Use `--target` to add source yields only from finalized runs for one exact canonical target. An unknown target fails with a `--list-targets` recovery hint. Without a scope selector, an empty database returns an empty report, one stored canonical target is selected automatically, and multiple stored targets are refused rather than silently mixed. `--run-id` still selects one finalized run. One-target and run-ID reports identify their canonical target in both table and JSON output.
+
+The top-level `run_count` shows how many runs were selected. Each source row has its own `run_count`, including executions that produced no results. `UNIQUE/RUN` divides the summed unique count by that source's run count and is the default ranking key. The JSON field is `unique_result_count_per_run`.
 
 "Unique" always means unique within one run, so aggregate totals add the per-run counts instead of recalculating uniqueness across targets or dates. Hostname output also includes resolved and unique-resolved counts plus `UNIQUE-RESOLVED/RUN`, named `unique_resolved_hostname_count_per_run` in JSON. Other result kinds omit the DNS-specific fields.
 

--- a/docs/wiki/Results-and-Local-Data.md
+++ b/docs/wiki/Results-and-Local-Data.md
@@ -204,7 +204,15 @@ The top-level `run_count` shows how many runs were selected. Each source row has
 
 ### Track hostname changes across finalized runs
 
-`harvest-yields --changes` compares retained hostname evidence without running discovery or DNS and without creating another report format. It reads only finalized runs already stored in SQLite. Use a canonical target to return every comparable run in chronological order, or a run ID to compare just that run with its baseline:
+`harvest-yields --changes` reads retained hostname evidence from finalized SQLite runs. It does not run discovery or DNS, and it does not let you choose an arbitrary pair of run IDs. The command uses the existing table or JSON output instead of creating another report format.
+
+| View | What it compares |
+| --- | --- |
+| `--run-id RUN_ID --changes` | The selected run and its automatically chosen comparable baseline. |
+| `--target TARGET --changes` | Every finalized run for that canonical target and each run's comparable baseline, in chronological order. |
+| HarvestView | The selected finalized run and its comparable baseline. |
+
+Use either a canonical target to review changes over time or a run ID to inspect one comparison:
 
 ```console
 harvest-yields --target example.test --changes
@@ -213,7 +221,11 @@ harvest-yields --run-id 11111111-1111-4111-8111-111111111111 --changes
 harvest-yields --target example.test --changes --include-persisting
 ```
 
-A baseline is the previous finalized run with the same canonical target and exact `source_cohort`. Runs are ordered by `completed_at` and then `run_id`, so the choice is deterministic. A run with no comparable predecessor is still returned with `baseline_run_id: null`, zero counts, and a clear message. `--all-targets --changes` is refused because one mixed timeline would hide the target boundary.
+A baseline is the latest earlier finalized run with the same canonical target and exact `source_cohort`. Runs are ordered by `completed_at` and then `run_id`, so the choice is deterministic. Each exact source cohort has its own comparison chain. The first run in a chain has `baseline_run_id: null`, zero counts, and a clear message. `--all-targets --changes` is refused because one mixed timeline would hide the target boundary.
+
+The pairing rule checks the target and source cohort. It does not prove that every other collection setting was equivalent. Keep the requested limit, release version, resolver set, and collection window consistent when those differences could affect the result.
+
+For a red team, this provides a repeatable delta review without sending new discovery or DNS traffic. `new` rows identify names that appeared in retained evidence after the comparable baseline and may deserve in-scope validation. `missing` rows show names that no longer appear in comparable collection evidence. `inconclusive` rows keep partial, failed, rate-limited, or skipped source executions from looking like an asset disappeared. Source attribution, source exclusivity, and retained DNS or addressability evidence help decide what to investigate next and what still needs corroboration. The view does not authorize follow-up or prove ownership or reachability.
 
 Each comparison reports four counts:
 

--- a/docs/wiki/Results-and-Local-Data.md
+++ b/docs/wiki/Results-and-Local-Data.md
@@ -181,8 +181,12 @@ harvest-yields --database results.sqlite --kind hostname
 harvest-yields --database results.sqlite --kind ip
 harvest-yields --database results.sqlite --kind asn
 harvest-yields --database results.sqlite --run-id 11111111-1111-4111-8111-111111111111
+harvest-yields --database results.sqlite --list-targets
+harvest-yields --database results.sqlite --list-targets --format json
 harvest-yields --database results.sqlite --format json
 ```
+
+Use `--list-targets` to discover the canonical enumeration targets in finalized runs and the run count for each one. The inventory coalesces equivalent hostname spellings and canonical network identifiers without rewriting stored evidence; exact free-text company queries remain case-sensitive. Listing does not run discovery or DNS.
 
 Without `--run-id`, the command adds each run's source yields. The top-level `run_count` shows how many runs were selected. Each source row has its own `run_count`, including executions that produced no results. `UNIQUE/RUN` divides the summed unique count by that source's run count and is the default ranking key. The JSON field is `unique_result_count_per_run`.
 

--- a/tests/e2e/test_harvestview.py
+++ b/tests/e2e/test_harvestview.py
@@ -533,6 +533,14 @@ def test_hostname_tracking_filters_persisted_run_changes(
     expect(panel).to_contain_text('TimeoutError')
     expect(panel).not_to_contain_text('stable.example.test')
 
+    page.locator('#tracking-change-filter').select_option('persisting')
+    expect(page.locator('#tracking-persisting-filter')).to_be_checked()
+    expect(rows).to_have_count(1)
+    expect(panel).to_contain_text('stable.example.test')
+    page.locator('#tracking-persisting-filter').uncheck()
+    expect(page.locator('#tracking-change-filter')).to_have_value('')
+    expect(rows).to_have_count(3)
+
     page.locator('#tracking-exclusive-filter').check()
     expect(rows).to_have_count(2)
     expect(panel).not_to_contain_text('missing.example.test')

--- a/tests/e2e/test_harvestview.py
+++ b/tests/e2e/test_harvestview.py
@@ -460,11 +460,11 @@ def test_hostname_tracking_filters_persisted_run_changes(
         {
             'change': 'inconclusive',
             'hostname': 'uncertain.example.test',
-            'previous_sources': ['beta'],
-            'current_sources': [],
+            'previous_sources': [],
+            'current_sources': ['beta'],
             'source_exclusive': True,
-            'previous_resolution_evidence': 'not-retained',
-            'current_resolution_evidence': 'not-checked',
+            'previous_resolution_evidence': 'not-checked',
+            'current_resolution_evidence': 'not-retained',
             'previous_addressability': None,
             'current_addressability': None,
             'blocking_sources': [

--- a/tests/e2e/test_harvestview.py
+++ b/tests/e2e/test_harvestview.py
@@ -428,6 +428,130 @@ def test_imported_run_separates_original_execution_from_local_import(
     expect(page.locator('#lifecycle-note')).to_contain_text('original execution timing')
 
 
+def test_hostname_tracking_filters_persisted_run_changes(
+    harvestview_server_url: str,
+    page: Page,
+) -> None:
+    changes = [
+        {
+            'change': 'new',
+            'hostname': 'new.example.test',
+            'previous_sources': [],
+            'current_sources': ['beta'],
+            'source_exclusive': True,
+            'previous_resolution_evidence': 'not-checked',
+            'current_resolution_evidence': 'positive',
+            'previous_addressability': None,
+            'current_addressability': 'currently-addressable',
+            'blocking_sources': [],
+        },
+        {
+            'change': 'missing',
+            'hostname': 'missing.example.test',
+            'previous_sources': ['alpha', 'beta'],
+            'current_sources': [],
+            'source_exclusive': False,
+            'previous_resolution_evidence': 'positive',
+            'current_resolution_evidence': 'not-checked',
+            'previous_addressability': 'currently-addressable',
+            'current_addressability': None,
+            'blocking_sources': [],
+        },
+        {
+            'change': 'inconclusive',
+            'hostname': 'uncertain.example.test',
+            'previous_sources': ['beta'],
+            'current_sources': [],
+            'source_exclusive': True,
+            'previous_resolution_evidence': 'not-retained',
+            'current_resolution_evidence': 'not-checked',
+            'previous_addressability': None,
+            'current_addressability': None,
+            'blocking_sources': [
+                {'source': 'beta', 'status': 'partial', 'error_type': 'TimeoutError', 'stop_reason': 'timeout'}
+            ],
+        },
+        {
+            'change': 'persisting',
+            'hostname': 'stable.example.test',
+            'previous_sources': ['alpha'],
+            'current_sources': ['alpha'],
+            'source_exclusive': True,
+            'previous_resolution_evidence': 'positive',
+            'current_resolution_evidence': 'positive',
+            'previous_addressability': 'currently-addressable',
+            'current_addressability': 'currently-addressable',
+            'blocking_sources': [],
+        },
+    ]
+    run = {
+        'run_id': 'tracking-run',
+        'target': 'example.test',
+        'status': 'completed',
+        'origin': 'local',
+        'created_at': '2026-08-20T12:00:00+00:00',
+        'started_at': '2026-08-20T12:00:00+00:00',
+        'completed_at': '2026-08-20T12:01:00+00:00',
+        'cancellation_requested_at': None,
+        'evidence_status': 'complete',
+        'result_count': 0,
+        'activities': ['P0'],
+        'sources': ['alpha', 'beta'],
+        'request': {'target': 'example.test', 'sources': ['alpha', 'beta']},
+        'source_executions': [],
+        'action_executions': [],
+        'results': [],
+        'screenshots': [],
+        'log': '',
+        'error': None,
+        'hostname_tracking': {
+            'target': 'example.test',
+            'comparison_count': 1,
+            'comparisons': [
+                {
+                    'run_id': 'tracking-run',
+                    'completed_at': '2026-08-20T12:01:00+00:00',
+                    'baseline_run_id': 'baseline-run',
+                    'baseline_completed_at': '2026-08-19T12:01:00+00:00',
+                    'source_cohort': ['alpha', 'beta'],
+                    'counts': {'new': 1, 'persisting': 1, 'missing': 1, 'inconclusive': 1},
+                }
+            ],
+            'hostname_changes': changes,
+        },
+    }
+    page.route(f'{harvestview_server_url}/api/v1/runs', lambda route: route.fulfill(json=[run]))
+    page.route(f'{harvestview_server_url}/api/v1/runs/tracking-run', lambda route: route.fulfill(json=run))
+
+    page.goto(f'{harvestview_server_url}/')
+
+    panel = page.locator('#hostname-tracking-section')
+    rows = page.locator('#hostname-tracking-body tr')
+    expect(panel).to_be_visible()
+    expect(panel).to_contain_text('INCONCLUSIVE means')
+    expect(rows).to_have_count(3)
+    expect(panel).to_contain_text('TimeoutError')
+    expect(panel).not_to_contain_text('stable.example.test')
+
+    page.locator('#tracking-exclusive-filter').check()
+    expect(rows).to_have_count(2)
+    expect(panel).not_to_contain_text('missing.example.test')
+
+    page.locator('#tracking-exclusive-filter').uncheck()
+    page.locator('#tracking-persisting-filter').check()
+    expect(rows).to_have_count(4)
+    expect(panel).to_contain_text('stable.example.test')
+
+    page.locator('#tracking-source-filter').select_option('alpha')
+    expect(rows).to_have_count(2)
+    expect(panel).not_to_contain_text('new.example.test')
+
+    page.locator('#tracking-source-filter').select_option('')
+    page.locator('#tracking-resolution-filter').select_option('not-retained')
+    expect(rows).to_have_count(1)
+    expect(panel).to_contain_text('uncertain.example.test')
+
+
 def test_disabled_worker_rejects_submission_without_creating_a_run(
     harvestview_server_url: str,
     page: Page,

--- a/tests/lib/test_api_v1.py
+++ b/tests/lib/test_api_v1.py
@@ -1071,6 +1071,67 @@ def test_run_detail_reports_unique_hostname_contribution_per_source(tmp_path, mo
     ]
 
 
+def test_run_detail_exposes_persisted_hostname_changes_against_the_previous_source_cohort(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from theHarvester.lib.api import api
+
+    source_execution = {
+        'source': 'crtsh',
+        'status': 'completed',
+        'duration_ms': 1,
+        'result_count': 1,
+        'error_type': None,
+        'stop_reason': None,
+    }
+    monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
+    monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
+    monkeypatch.setenv('THEHARVESTER_RUN_WORKER', 'disabled')
+    headers = {'X-API-Key': 'test-key'}
+
+    with TestClient(api.app) as client:
+        baseline = client.post(
+            '/api/v1/runs/import',
+            params={'filename': 'baseline.jsonl'},
+            headers=headers,
+            content=_jsonl_result(
+                finding_type='hostname',
+                value='old.example.test',
+                finding_fields={'sources': ['crtsh']},
+                summary_fields={
+                    'completed_at': '2026-08-08T01:01:00Z',
+                    'source_executions': [source_execution],
+                },
+            ),
+        )
+        current = client.post(
+            '/api/v1/runs/import',
+            params={'filename': 'current.jsonl'},
+            headers=headers,
+            content=_jsonl_result(
+                finding_type='hostname',
+                value='new.example.test',
+                finding_fields={'sources': ['crtsh']},
+                summary_fields={
+                    'completed_at': '2026-08-08T02:01:00Z',
+                    'source_executions': [source_execution],
+                },
+            ),
+        )
+
+    assert baseline.status_code == 201
+    assert current.status_code == 201
+    tracking = current.json()['hostname_tracking']
+    assert tracking['target'] == 'example.test'
+    assert tracking['comparison_count'] == 1
+    assert tracking['comparisons'][0]['baseline_run_id'] == baseline.json()['run_id']
+    assert [(row['change'], row['hostname']) for row in tracking['hostname_changes']] == [
+        ('new', 'new.example.test'),
+        ('missing', 'old.example.test'),
+    ]
+
+
 def test_api_jsonl_export_uses_evidence_timestamps_not_lifecycle_timestamps(tmp_path, monkeypatch) -> None:
     from theHarvester.lib.api import api
     from theHarvester.lib.api.run_models import RunRequest

--- a/tests/lib/test_harvestview_ui.py
+++ b/tests/lib/test_harvestview_ui.py
@@ -61,6 +61,31 @@ def test_harvestview_assets_load_outside_the_repository_directory(tmp_path, monk
     assert "request.limit === 0 ? 'Unlimited'" in response.text
 
 
+def test_harvestview_explains_and_filters_persisted_hostname_changes(tmp_path, monkeypatch) -> None:
+    from theHarvester.lib.api import api
+
+    monkeypatch.setenv('THEHARVESTER_API_KEY', 'test-key')
+    monkeypatch.setenv('THEHARVESTER_RUN_DB', str(tmp_path / 'runs.sqlite'))
+    monkeypatch.setenv('THEHARVESTER_RUN_WORKER', 'disabled')
+
+    with TestClient(api.app, base_url='http://127.0.0.1', client=('127.0.0.1', 50000)) as client:
+        root = client.get('/')
+        script = client.get('/static/harvestview/app.js')
+
+    assert root.status_code == 200
+    assert 'id="hostname-tracking-section"' in root.text
+    assert 'id="tracking-change-filter"' in root.text
+    assert 'id="tracking-source-filter"' in root.text
+    assert 'id="tracking-resolution-filter"' in root.text
+    assert 'id="tracking-exclusive-filter"' in root.text
+    assert 'id="tracking-persisting-filter"' in root.text
+    assert 'INCONCLUSIVE means a source that previously found the hostname did not complete reliably' in root.text
+    assert 'This view reads finalized evidence only and performs no discovery or DNS.' in root.text
+    assert script.status_code == 200
+    assert 'function renderHostnameTracking' in script.text
+    assert 'blocking_sources' in script.text
+
+
 def test_harvestview_exposes_local_schedule_page_and_assets(tmp_path, monkeypatch) -> None:
     from theHarvester.lib.api import api
 

--- a/tests/lib/test_harvestview_ui.py
+++ b/tests/lib/test_harvestview_ui.py
@@ -79,7 +79,7 @@ def test_harvestview_explains_and_filters_persisted_hostname_changes(tmp_path, m
     assert 'id="tracking-resolution-filter"' in root.text
     assert 'id="tracking-exclusive-filter"' in root.text
     assert 'id="tracking-persisting-filter"' in root.text
-    assert 'INCONCLUSIVE means a source that previously found the hostname did not complete reliably' in root.text
+    assert 'INCONCLUSIVE means a contributing source did not complete reliably' in root.text
     assert 'This view reads finalized evidence only and performs no discovery or DNS.' in root.text
     assert script.status_code == 200
     assert 'function renderHostnameTracking' in script.text

--- a/tests/test_source_yields_cli.py
+++ b/tests/test_source_yields_cli.py
@@ -16,6 +16,7 @@ from theHarvester.lib.database import ResultStore
 from theHarvester.lib.evidence_types import RESULT_KINDS, ExecutionStatus
 
 RUN_ONE = UUID('11111111-1111-4111-8111-111111111111')
+RUN_TIE_LATER = UUID('11111111-1111-4111-8111-111111111112')
 RUN_TWO = UUID('22222222-2222-4222-8222-222222222222')
 
 
@@ -572,6 +573,42 @@ def test_target_changes_reports_every_run_pair_and_a_clear_null_baseline(
     assert {row['run_id'] for row in payload['hostname_changes']} == {str(RUN_TWO)}
 
 
+def test_run_id_breaks_an_equal_completion_time_tie_deterministically(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    store = ResultStore(database)
+    asyncio.run(store.initialize())
+    asyncio.run(
+        store.save_run(
+            _completed_run(
+                RUN_TIE_LATER,
+                observations=(ResultObservation('alpha', 'hostname', 'later.example.test'),),
+            )
+        )
+    )
+    asyncio.run(
+        store.save_run(
+            _completed_run(
+                RUN_ONE,
+                observations=(ResultObservation('alpha', 'hostname', 'earlier.example.test'),),
+            )
+        )
+    )
+    asyncio.run(store.dispose())
+
+    assert (
+        source_yields.main(
+            ['--database', str(database), '--run-id', str(RUN_TIE_LATER), '--changes', '--format', 'json']
+        )
+        == 0
+    )
+
+    comparison = json.loads(capsys.readouterr().out)['comparisons'][0]
+    assert comparison['baseline_run_id'] == str(RUN_ONE)
+
+
 def test_include_persisting_adds_unchanged_hostname_rows_without_changing_counts(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -728,6 +765,9 @@ def test_unscoped_empty_database_reports_an_explicit_empty_scope(
 
     assert source_yields.main(['--database', str(database)]) == 0
     assert capsys.readouterr().out.splitlines()[:3] == ['Targets: none', 'Kind: hostname', 'Run count: 0']
+
+    assert source_yields.main(['--database', str(database), '--changes']) == 0
+    assert capsys.readouterr().out.startswith('Targets: none\nComparison count: 0\n')
 
 
 def test_missing_database_fails_without_creating_file(

--- a/tests/test_source_yields_cli.py
+++ b/tests/test_source_yields_cli.py
@@ -13,7 +13,7 @@ from theHarvester.lib import database as database_module
 from theHarvester.lib.active_evidence import ActionExecution, ActiveEvidence
 from theHarvester.lib.completed_result import CompletedResult, ResultObservation, SourceExecution
 from theHarvester.lib.database import ResultStore
-from theHarvester.lib.evidence_types import RESULT_KINDS
+from theHarvester.lib.evidence_types import RESULT_KINDS, ExecutionStatus
 
 RUN_ONE = UUID('11111111-1111-4111-8111-111111111111')
 RUN_TWO = UUID('22222222-2222-4222-8222-222222222222')
@@ -31,23 +31,42 @@ def _completed_run(
     target: str = 'example.test',
     observations: tuple[ResultObservation, ...],
     resolved_hostnames: tuple[str, ...] = (),
+    source_statuses: dict[str, tuple[ExecutionStatus, str | None, str | None]] | None = None,
+    dns_status: ExecutionStatus | None = None,
+    addressability: dict[str, str] | None = None,
 ) -> CompletedResult:
     started_at = datetime(2026, 8, 23, 12, tzinfo=UTC) + timedelta(minutes=int(str(run_id)[0]))
-    sources = sorted({observation.source for observation in observations})
-    active_evidence = (
-        ActiveEvidence(
-            executions=(
-                ActionExecution.finish(
-                    action='dns-resolve',
-                    status='completed',
-                    duration_ms=1,
-                    groups={'hostname': resolved_hostnames},
-                ),
+    source_statuses = source_statuses or {}
+    sources = sorted({observation.source for observation in observations} | set(source_statuses))
+    action_executions = []
+    if dns_status is not None or resolved_hostnames:
+        action_executions.append(
+            ActionExecution.finish(
+                action='dns-resolve',
+                status=dns_status or 'completed',
+                duration_ms=1,
+                groups={'hostname': resolved_hostnames},
             )
         )
-        if resolved_hostnames
-        else ActiveEvidence()
-    )
+    if addressability:
+        action_executions.append(
+            ActionExecution.finish(
+                action='dns-recursive',
+                status='completed',
+                duration_ms=1,
+                groups={
+                    'dns-recursive-classification': (
+                        json.dumps(
+                            {'addressability': classification, 'hostname': hostname},
+                            separators=(',', ':'),
+                            sort_keys=True,
+                        )
+                        for hostname, classification in addressability.items()
+                    )
+                },
+            )
+        )
+    active_evidence = ActiveEvidence(executions=tuple(action_executions))
     return CompletedResult.finish(
         run_id=run_id,
         target=target,
@@ -60,15 +79,49 @@ def _completed_run(
         source_executions=tuple(
             SourceExecution(
                 source=source,
-                status='completed',
+                status=source_statuses.get(source, ('completed', None, None))[0],
                 duration_ms=1,
                 result_count=sum(observation.source == source for observation in observations),
+                error_type=source_statuses.get(source, ('completed', None, None))[1],
+                stop_reason=source_statuses.get(source, ('completed', None, None))[2],
             )
             for source in sources
         ),
         observations=observations,
         active_evidence=active_evidence,
     )
+
+
+async def _create_tracking_database(database: Path) -> None:
+    store = ResultStore(database)
+    await store.initialize()
+    await store.save_run(
+        _completed_run(
+            RUN_ONE,
+            target='EXAMPLE.TEST.',
+            observations=(
+                ResultObservation('alpha', 'hostname', 'missing.example.test'),
+                ResultObservation('alpha', 'hostname', 'persist.example.test'),
+                ResultObservation('beta', 'hostname', 'inconclusive.example.test'),
+            ),
+            resolved_hostnames=('missing.example.test',),
+            dns_status='completed',
+        )
+    )
+    await store.save_run(
+        _completed_run(
+            RUN_TWO,
+            observations=(
+                ResultObservation('alpha', 'hostname', 'persist.example.test'),
+                ResultObservation('beta', 'hostname', 'new.example.test'),
+            ),
+            resolved_hostnames=('new.example.test', 'persist.example.test'),
+            source_statuses={'beta': ('partial', 'TimeoutError', 'request-errors')},
+            dns_status='completed',
+            addressability={'new.example.test': 'currently-addressable'},
+        )
+    )
+    await store.dispose()
 
 
 async def _create_database(database: Path) -> None:
@@ -417,6 +470,195 @@ def test_all_targets_rejects_a_run_selector(
 
     assert error.value.code == 2
     assert 'not allowed with argument' in capsys.readouterr().err
+
+
+def test_run_changes_distinguish_missing_from_inconclusive_using_persisted_source_outcomes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_tracking_database(database))
+
+    assert source_yields.main(['--database', str(database), '--run-id', str(RUN_TWO), '--changes', '--format', 'json']) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload['target'] == 'example.test'
+    assert payload['comparison_count'] == 1
+    assert payload['comparisons'][0] == {
+        'baseline_completed_at': '2026-08-23T12:01:01+00:00',
+        'baseline_run_id': str(RUN_ONE),
+        'completed_at': '2026-08-23T12:02:01+00:00',
+        'counts': {'inconclusive': 1, 'missing': 1, 'new': 1, 'persisting': 1},
+        'run_id': str(RUN_TWO),
+        'source_cohort': ['alpha', 'beta'],
+    }
+    changes = {row['hostname']: row for row in payload['hostname_changes']}
+    assert set(changes) == {
+        'inconclusive.example.test',
+        'missing.example.test',
+        'new.example.test',
+    }
+    assert changes['new.example.test'] == {
+        'baseline_run_id': str(RUN_ONE),
+        'blocking_sources': [],
+        'change': 'new',
+        'current_addressability': 'currently-addressable',
+        'current_dns_action_status': 'completed',
+        'current_resolution_evidence': 'positive',
+        'current_sources': ['beta'],
+        'hostname': 'new.example.test',
+        'previous_addressability': None,
+        'previous_dns_action_status': 'completed',
+        'previous_resolution_evidence': 'not-checked',
+        'previous_sources': [],
+        'run_id': str(RUN_TWO),
+        'source_exclusive': True,
+    }
+    assert changes['missing.example.test']['change'] == 'missing'
+    assert changes['missing.example.test']['blocking_sources'] == []
+    assert changes['missing.example.test']['previous_resolution_evidence'] == 'positive'
+    assert changes['inconclusive.example.test']['change'] == 'inconclusive'
+    assert changes['inconclusive.example.test']['blocking_sources'] == [
+        {
+            'error_type': 'TimeoutError',
+            'source': 'beta',
+            'status': 'partial',
+            'stop_reason': 'request-errors',
+        }
+    ]
+
+
+def test_target_changes_reports_every_run_pair_and_a_clear_null_baseline(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_tracking_database(database))
+
+    assert source_yields.main(['--database', str(database), '--target', 'example.test', '--changes', '--format', 'json']) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload['comparison_count'] == 2
+    assert payload['comparisons'][0] == {
+        'baseline_completed_at': None,
+        'baseline_run_id': None,
+        'completed_at': '2026-08-23T12:01:01+00:00',
+        'counts': {'inconclusive': 0, 'missing': 0, 'new': 0, 'persisting': 0},
+        'message': 'No previous finalized run has the same source cohort.',
+        'run_id': str(RUN_ONE),
+        'source_cohort': ['alpha', 'beta'],
+    }
+    assert payload['comparisons'][1]['baseline_run_id'] == str(RUN_ONE)
+    assert {row['run_id'] for row in payload['hostname_changes']} == {str(RUN_TWO)}
+
+
+def test_include_persisting_adds_unchanged_hostname_rows_without_changing_counts(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_tracking_database(database))
+
+    assert (
+        source_yields.main(
+            [
+                '--database',
+                str(database),
+                '--run-id',
+                str(RUN_TWO),
+                '--changes',
+                '--include-persisting',
+                '--format',
+                'json',
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    persisting = [row for row in payload['hostname_changes'] if row['change'] == 'persisting']
+    assert [(row['hostname'], row['source_exclusive']) for row in persisting] == [('persist.example.test', True)]
+    assert payload['comparisons'][0]['counts']['persisting'] == 1
+
+
+def test_changes_table_is_human_readable_and_explains_inconclusive_rows(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_tracking_database(database))
+
+    assert source_yields.main(['--database', str(database), '--run-id', str(RUN_TWO), '--changes']) == 0
+
+    output = capsys.readouterr().out
+    assert output.startswith('Target: example.test\nComparison count: 1\n')
+    assert 'NEW  PERSISTING  MISSING  INCONCLUSIVE' in output
+    lines = output.splitlines()
+    assert lines[4].split() == [
+        'CHANGE',
+        'HOSTNAME',
+        'SOURCES',
+        'EXCLUSIVE',
+        'RESOLUTION',
+        'ADDRESSABILITY',
+        'BLOCKING',
+        'SOURCES',
+    ]
+    assert [line.split()[:2] for line in lines[5:]] == [
+        ['NEW', 'new.example.test'],
+        ['MISSING', 'missing.example.test'],
+        ['INCONCLUSIVE', 'inconclusive.example.test'],
+    ]
+    assert 'beta:partial:TimeoutError:request-errors' in output
+
+
+def test_changes_table_explains_when_a_run_has_no_comparable_baseline(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_tracking_database(database))
+
+    assert source_yields.main(['--database', str(database), '--run-id', str(RUN_ONE), '--changes']) == 0
+
+    output = capsys.readouterr().out
+    assert f'{RUN_ONE}: No previous finalized run has the same source cohort.' in output
+
+
+@pytest.mark.parametrize(
+    'args',
+    [
+        ['--include-persisting'],
+        ['--changes', '--kind', 'ip'],
+        ['--changes', '--all-targets'],
+        ['--changes', '--list-targets'],
+    ],
+)
+def test_changes_rejects_ambiguous_or_non_hostname_arguments(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    args: list[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_tracking_database(database))
+
+    with pytest.raises(SystemExit) as error:
+        source_yields.main(['--database', str(database), *args])
+
+    assert error.value.code == 2
+    assert capsys.readouterr().err
+
+
+def test_help_makes_persisted_read_only_change_modes_obvious(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as error:
+        source_yields.main(['--help'])
+
+    assert error.value.code == 0
+    help_text = capsys.readouterr().out
+    assert 'never runs discovery or DNS' in help_text
+    assert 'harvest-yields --target example.test --changes' in help_text
+    assert 'harvest-yields --run-id RUN_ID --changes' in help_text
+    assert '--include-persisting' in help_text
 
 
 def test_unscoped_empty_database_reports_an_explicit_empty_scope(

--- a/tests/test_source_yields_cli.py
+++ b/tests/test_source_yields_cli.py
@@ -334,6 +334,91 @@ def test_unscoped_report_refuses_to_mix_multiple_targets(
     assert '--list-targets' in message
 
 
+def test_all_targets_explicitly_restores_mixed_target_json_report(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_multi_target_database(database))
+
+    assert source_yields.main(['--database', str(database), '--all-targets', '--format', 'json']) == 0
+
+    assert json.loads(capsys.readouterr().out) == {
+        'kind': 'hostname',
+        'run_count': 2,
+        'source_yields': [
+            {
+                'observed_result_count': 2,
+                'resolved_hostname_count': 0,
+                'run_count': 2,
+                'shared_result_count': 0,
+                'source': 'alpha',
+                'unique_resolved_hostname_count': 0,
+                'unique_resolved_hostname_count_per_run': 0.0,
+                'unique_result_count': 2,
+                'unique_result_count_per_run': 1.0,
+            }
+        ],
+        'targets': [
+            {'run_count': 1, 'target': 'example.test'},
+            {'run_count': 1, 'target': 'other.example'},
+        ],
+    }
+
+
+def test_all_targets_table_labels_scope_and_lists_every_target(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_multi_target_database(database))
+
+    assert source_yields.main(['--database', str(database), '--all-targets']) == 0
+
+    assert capsys.readouterr().out.splitlines()[:7] == [
+        'Scope: all targets',
+        'TARGET         RUNS',
+        'example.test   1',
+        'other.example  1',
+        'Kind: hostname',
+        'Run count: 2',
+        'SOURCE  RUNS  OBSERVED  UNIQUE  UNIQUE/RUN  SHARED  RESOLVED  UNIQUE-RESOLVED  UNIQUE-RESOLVED/RUN',
+    ]
+
+
+@pytest.mark.parametrize('conflicting', ['--list-targets', '--target'])
+def test_all_targets_rejects_other_scope_selectors(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    conflicting: str,
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_multi_target_database(database))
+    args = ['--database', str(database), '--all-targets', conflicting]
+    if conflicting == '--target':
+        args.append('example.test')
+
+    with pytest.raises(SystemExit) as error:
+        source_yields.main(args)
+
+    assert error.value.code == 2
+    assert 'not allowed with argument' in capsys.readouterr().err
+
+
+def test_all_targets_rejects_a_run_selector(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_multi_target_database(database))
+
+    with pytest.raises(SystemExit) as error:
+        source_yields.main(['--database', str(database), '--all-targets', '--run-id', str(RUN_ONE)])
+
+    assert error.value.code == 2
+    assert 'not allowed with argument' in capsys.readouterr().err
+
+
 def test_unscoped_empty_database_reports_an_explicit_empty_scope(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_source_yields_cli.py
+++ b/tests/test_source_yields_cli.py
@@ -124,6 +124,26 @@ async def _create_tracking_database(database: Path) -> None:
     await store.dispose()
 
 
+async def _create_unreliable_dns_tracking_database(database: Path) -> None:
+    hostname = 'unchecked.example.test'
+    store = ResultStore(database)
+    await store.initialize()
+    await store.save_run(
+        _completed_run(
+            RUN_ONE,
+            observations=(ResultObservation('alpha', 'hostname', hostname),),
+        )
+    )
+    await store.save_run(
+        _completed_run(
+            RUN_TWO,
+            observations=(ResultObservation('alpha', 'hostname', hostname),),
+            dns_status='failed',
+        )
+    )
+    await store.dispose()
+
+
 async def _create_database(database: Path) -> None:
     store = ResultStore(database)
     await store.initialize()
@@ -579,6 +599,34 @@ def test_include_persisting_adds_unchanged_hostname_rows_without_changing_counts
     persisting = [row for row in payload['hostname_changes'] if row['change'] == 'persisting']
     assert [(row['hostname'], row['source_exclusive']) for row in persisting] == [('persist.example.test', True)]
     assert payload['comparisons'][0]['counts']['persisting'] == 1
+
+
+def test_failed_dns_action_does_not_claim_a_sourced_hostname_was_checked(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_unreliable_dns_tracking_database(database))
+
+    assert (
+        source_yields.main(
+            [
+                '--database',
+                str(database),
+                '--run-id',
+                str(RUN_TWO),
+                '--changes',
+                '--include-persisting',
+                '--format',
+                'json',
+            ]
+        )
+        == 0
+    )
+
+    row = json.loads(capsys.readouterr().out)['hostname_changes'][0]
+    assert row['current_dns_action_status'] == 'failed'
+    assert row['current_resolution_evidence'] == 'not-checked'
 
 
 def test_changes_table_is_human_readable_and_explains_inconclusive_rows(

--- a/tests/test_source_yields_cli.py
+++ b/tests/test_source_yields_cli.py
@@ -106,6 +106,7 @@ async def _create_tracking_database(database: Path) -> None:
                 ResultObservation('beta', 'hostname', 'inconclusive.example.test'),
             ),
             resolved_hostnames=('missing.example.test',),
+            source_statuses={'beta': ('partial', 'BaselineTimeout', 'baseline-errors')},
             dns_status='completed',
         )
     )
@@ -114,7 +115,8 @@ async def _create_tracking_database(database: Path) -> None:
             RUN_TWO,
             observations=(
                 ResultObservation('alpha', 'hostname', 'persist.example.test'),
-                ResultObservation('beta', 'hostname', 'new.example.test'),
+                ResultObservation('alpha', 'hostname', 'new.example.test'),
+                ResultObservation('beta', 'hostname', 'uncertain-new.example.test'),
             ),
             resolved_hostnames=('new.example.test', 'persist.example.test'),
             source_statuses={'beta': ('partial', 'TimeoutError', 'request-errors')},
@@ -509,7 +511,7 @@ def test_run_changes_distinguish_missing_from_inconclusive_using_persisted_sourc
         'baseline_completed_at': '2026-08-23T12:01:01+00:00',
         'baseline_run_id': str(RUN_ONE),
         'completed_at': '2026-08-23T12:02:01+00:00',
-        'counts': {'inconclusive': 1, 'missing': 1, 'new': 1, 'persisting': 1},
+        'counts': {'inconclusive': 2, 'missing': 1, 'new': 1, 'persisting': 1},
         'run_id': str(RUN_TWO),
         'source_cohort': ['alpha', 'beta'],
     }
@@ -518,6 +520,7 @@ def test_run_changes_distinguish_missing_from_inconclusive_using_persisted_sourc
         'inconclusive.example.test',
         'missing.example.test',
         'new.example.test',
+        'uncertain-new.example.test',
     }
     assert changes['new.example.test'] == {
         'baseline_run_id': str(RUN_ONE),
@@ -526,7 +529,7 @@ def test_run_changes_distinguish_missing_from_inconclusive_using_persisted_sourc
         'current_addressability': 'currently-addressable',
         'current_dns_action_status': 'completed',
         'current_resolution_evidence': 'positive',
-        'current_sources': ['beta'],
+        'current_sources': ['alpha'],
         'hostname': 'new.example.test',
         'previous_addressability': None,
         'previous_dns_action_status': 'completed',
@@ -545,6 +548,17 @@ def test_run_changes_distinguish_missing_from_inconclusive_using_persisted_sourc
             'source': 'beta',
             'status': 'partial',
             'stop_reason': 'request-errors',
+        }
+    ]
+    assert changes['uncertain-new.example.test']['change'] == 'inconclusive'
+    assert changes['uncertain-new.example.test']['current_sources'] == ['beta']
+    assert changes['uncertain-new.example.test']['source_exclusive'] is True
+    assert changes['uncertain-new.example.test']['blocking_sources'] == [
+        {
+            'error_type': 'BaselineTimeout',
+            'source': 'beta',
+            'status': 'partial',
+            'stop_reason': 'baseline-errors',
         }
     ]
 
@@ -693,8 +707,10 @@ def test_changes_table_is_human_readable_and_explains_inconclusive_rows(
         ['NEW', 'new.example.test'],
         ['MISSING', 'missing.example.test'],
         ['INCONCLUSIVE', 'inconclusive.example.test'],
+        ['INCONCLUSIVE', 'uncertain-new.example.test'],
     ]
     assert 'beta:partial:TimeoutError:request-errors' in output
+    assert 'beta:partial:BaselineTimeout:baseline-errors' in output
 
 
 def test_changes_table_explains_when_a_run_has_no_comparable_baseline(

--- a/tests/test_source_yields_cli.py
+++ b/tests/test_source_yields_cli.py
@@ -104,6 +104,26 @@ async def _create_database(database: Path) -> None:
     await store.dispose()
 
 
+async def _create_multi_target_database(database: Path) -> None:
+    store = ResultStore(database)
+    await store.initialize()
+    await store.save_run(
+        _completed_run(
+            RUN_ONE,
+            target='EXAMPLE.TEST.',
+            observations=(ResultObservation('alpha', 'hostname', 'alpha.example.test'),),
+        )
+    )
+    await store.save_run(
+        _completed_run(
+            RUN_TWO,
+            target='other.example',
+            observations=(ResultObservation('alpha', 'hostname', 'alpha.other.example'),),
+        )
+    )
+    await store.dispose()
+
+
 async def _create_target_inventory_database(database: Path) -> None:
     store = ResultStore(database)
     await store.initialize()
@@ -213,6 +233,128 @@ def test_list_targets_rejects_a_run_selector(
     assert 'not allowed with argument' in capsys.readouterr().err
 
 
+def test_target_selects_only_matching_canonical_target(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_multi_target_database(database))
+
+    assert source_yields.main(['--database', str(database), '--target', 'example.test', '--format', 'json']) == 0
+
+    assert json.loads(capsys.readouterr().out) == {
+        'kind': 'hostname',
+        'run_count': 1,
+        'source_yields': [
+            {
+                'observed_result_count': 1,
+                'resolved_hostname_count': 0,
+                'run_count': 1,
+                'shared_result_count': 0,
+                'source': 'alpha',
+                'unique_resolved_hostname_count': 0,
+                'unique_resolved_hostname_count_per_run': 0.0,
+                'unique_result_count': 1,
+                'unique_result_count_per_run': 1.0,
+            }
+        ],
+        'target': 'example.test',
+    }
+
+
+@pytest.mark.parametrize(
+    ('requested', 'canonical', 'run_count'),
+    [
+        ('EXAMPLE.TEST.', 'example.test', 2),
+        ('BÜCHER.EXAMPLE.', 'xn--bcher-kva.example', 2),
+        ('2001:0db8::1', '2001:db8::1', 1),
+        ('AS064496', 'AS64496', 1),
+        ('198.51.100.23/24', '198.51.100.0/24', 1),
+        ('  Example Company  ', 'Example Company', 1),
+    ],
+)
+def test_target_selection_uses_canonical_identity_without_aliasing_free_text(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    requested: str,
+    canonical: str,
+    run_count: int,
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_target_inventory_database(database))
+
+    assert source_yields.main(['--database', str(database), '--target', requested, '--format', 'json']) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload['target'] == canonical
+    assert payload['run_count'] == run_count
+
+
+def test_unknown_target_fails_with_inventory_hint(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_multi_target_database(database))
+
+    with pytest.raises(SystemExit) as error:
+        source_yields.main(['--database', str(database), '--target', 'missing.example'])
+
+    assert error.value.code == 2
+    assert 'target not found: missing.example; use --list-targets' in capsys.readouterr().err
+
+
+def test_target_rejects_a_run_selector(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_database(database))
+
+    with pytest.raises(SystemExit) as error:
+        source_yields.main(['--database', str(database), '--target', 'example.test', '--run-id', str(RUN_ONE)])
+
+    assert error.value.code == 2
+    assert 'not allowed with argument' in capsys.readouterr().err
+
+
+def test_unscoped_report_refuses_to_mix_multiple_targets(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_multi_target_database(database))
+
+    with pytest.raises(SystemExit) as error:
+        source_yields.main(['--database', str(database)])
+
+    assert error.value.code == 2
+    message = capsys.readouterr().err
+    assert '2 canonical targets' in message
+    assert '--list-targets' in message
+
+
+def test_unscoped_empty_database_reports_an_explicit_empty_scope(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    store = ResultStore(database)
+    asyncio.run(store.initialize())
+    asyncio.run(store.dispose())
+
+    assert source_yields.main(['--database', str(database), '--format', 'json']) == 0
+    assert json.loads(capsys.readouterr().out) == {
+        'kind': 'hostname',
+        'run_count': 0,
+        'source_yields': [],
+        'targets': [],
+    }
+
+    assert source_yields.main(['--database', str(database)]) == 0
+    assert capsys.readouterr().out.splitlines()[:3] == ['Targets: none', 'Kind: hostname', 'Run count: 0']
+
+
 def test_missing_database_fails_without_creating_file(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -238,7 +380,7 @@ def test_default_database_uses_the_standard_result_store(
 
     assert source_yields.main([]) == 0
 
-    assert capsys.readouterr().out.startswith('Kind: hostname\nRun count: 2\n')
+    assert capsys.readouterr().out.startswith('Target: example.test\nKind: hostname\nRun count: 2\n')
 
 
 def test_default_table_ranks_by_unique_per_run_and_aligns_columns(
@@ -251,6 +393,7 @@ def test_default_table_ranks_by_unique_per_run_and_aligns_columns(
     assert source_yields.main(['--database', str(database)]) == 0
 
     assert capsys.readouterr().out.splitlines() == [
+        'Target: example.test',
         'Kind: hostname',
         'Run count: 2',
         'SOURCE  RUNS  OBSERVED  UNIQUE  UNIQUE/RUN  SHARED  RESOLVED  UNIQUE-RESOLVED  UNIQUE-RESOLVED/RUN',
@@ -272,10 +415,10 @@ def test_kind_accepts_every_result_kind_and_only_hostname_shows_resolution_colum
     assert source_yields.main(['--database', str(database), '--kind', kind]) == 0
 
     lines = capsys.readouterr().out.splitlines()
-    assert lines[0] == f'Kind: {kind}'
-    assert ('RESOLVED' in lines[2]) is (kind == 'hostname')
+    assert lines[:2] == ['Target: example.test', f'Kind: {kind}']
+    assert ('RESOLVED' in lines[3]) is (kind == 'hostname')
     if kind == 'ip':
-        assert [line.split() for line in lines[3:]] == [
+        assert [line.split() for line in lines[4:]] == [
             ['gamma', '1', '1', '1', '1.00', '0'],
             ['alpha', '2', '1', '0', '0.00', '1'],
             ['beta', '2', '1', '0', '0.00', '1'],
@@ -292,8 +435,8 @@ def test_run_id_selects_one_run(
     assert source_yields.main(['--database', str(database), '--run-id', str(RUN_ONE)]) == 0
 
     lines = capsys.readouterr().out.splitlines()
-    assert lines[1] == 'Run count: 1'
-    assert [line.split() for line in lines[3:]] == [
+    assert lines[:3] == ['Target: example.test', 'Kind: hostname', 'Run count: 1']
+    assert [line.split() for line in lines[4:]] == [
         ['alpha', '1', '2', '1', '1.00', '1', '2', '1', '1.00'],
         ['beta', '1', '2', '1', '1.00', '1', '1', '0', '0.00'],
     ]
@@ -326,6 +469,7 @@ def test_json_format_is_machine_readable_and_uses_kind_specific_fields(
     assert source_yields.main(['--database', str(database), '--kind', kind, '--format', 'json']) == 0
 
     payload = json.loads(capsys.readouterr().out)
+    assert payload['target'] == 'example.test'
     assert payload['kind'] == kind
     assert payload['run_count'] == 2
     assert [row['source'] for row in payload['source_yields']] == ['gamma', 'alpha', 'beta']

--- a/tests/test_source_yields_cli.py
+++ b/tests/test_source_yields_cli.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import sqlite3
 import tomllib
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -27,6 +28,7 @@ def test_project_installs_harvest_yields_command() -> None:
 def _completed_run(
     run_id: UUID,
     *,
+    target: str = 'example.test',
     observations: tuple[ResultObservation, ...],
     resolved_hostnames: tuple[str, ...] = (),
 ) -> CompletedResult:
@@ -48,7 +50,7 @@ def _completed_run(
     )
     return CompletedResult.finish(
         run_id=run_id,
-        target='example.test',
+        target=target,
         started_at=started_at,
         completed_at=started_at + timedelta(seconds=1),
         groups={
@@ -100,6 +102,115 @@ async def _create_database(database: Path) -> None:
         )
     )
     await store.dispose()
+
+
+async def _create_target_inventory_database(database: Path) -> None:
+    store = ResultStore(database)
+    await store.initialize()
+    targets = (
+        'EXAMPLE.TEST.',
+        'example.test',
+        'www.Example.test.',
+        'bücher.example',
+        'XN--BCHER-KVA.EXAMPLE.',
+        '2001:0DB8:0:0::1',
+        'as064496',
+        '198.51.100.23/24',
+        '  Example Company  ',
+        'example company',
+    )
+    for index, target in enumerate(targets, start=3):
+        await store.save_run(
+            _completed_run(
+                UUID(f'{index:08d}-0000-4000-8000-000000000000'),
+                target=target,
+                observations=(),
+            )
+        )
+    await store.dispose()
+
+
+def test_list_targets_table_canonicalizes_counts_and_sorts(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_target_inventory_database(database))
+
+    assert source_yields.main(['--database', str(database), '--list-targets']) == 0
+
+    lines = capsys.readouterr().out.splitlines()
+    assert lines[0].split() == ['TARGET', 'RUNS']
+    assert [line.rsplit(maxsplit=1) for line in lines[1:]] == [
+        ['198.51.100.0/24', '1'],
+        ['2001:db8::1', '1'],
+        ['AS64496', '1'],
+        ['Example Company', '1'],
+        ['example company', '1'],
+        ['example.test', '2'],
+        ['www.example.test', '1'],
+        ['xn--bcher-kva.example', '2'],
+    ]
+
+
+def test_list_targets_json_preserves_stored_targets_and_schema_version(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_target_inventory_database(database))
+    with sqlite3.connect(database) as connection:
+        stored_targets = connection.execute('SELECT target FROM runs ORDER BY run_id').fetchall()
+        connection.execute('PRAGMA user_version = 7')
+
+    assert source_yields.main(['--database', str(database), '--list-targets', '--format', 'json']) == 0
+
+    output = capsys.readouterr().out
+    assert output.endswith('\n')
+    assert json.loads(output) == {
+        'targets': [
+            {'target': '198.51.100.0/24', 'run_count': 1},
+            {'target': '2001:db8::1', 'run_count': 1},
+            {'target': 'AS64496', 'run_count': 1},
+            {'target': 'Example Company', 'run_count': 1},
+            {'target': 'example company', 'run_count': 1},
+            {'target': 'example.test', 'run_count': 2},
+            {'target': 'www.example.test', 'run_count': 1},
+            {'target': 'xn--bcher-kva.example', 'run_count': 2},
+        ]
+    }
+    with sqlite3.connect(database) as connection:
+        assert connection.execute('PRAGMA user_version').fetchone() == (7,)
+        assert connection.execute('SELECT target FROM runs ORDER BY run_id').fetchall() == stored_targets
+
+
+def test_list_targets_empty_database_succeeds(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    store = ResultStore(database)
+    asyncio.run(store.initialize())
+    asyncio.run(store.dispose())
+
+    assert source_yields.main(['--database', str(database), '--list-targets']) == 0
+    assert capsys.readouterr().out == 'TARGET  RUNS\n'
+    assert source_yields.main(['--database', str(database), '--list-targets', '--format', 'json']) == 0
+    assert capsys.readouterr().out == '{"targets": []}\n'
+
+
+def test_list_targets_rejects_a_run_selector(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    database = tmp_path / 'runs.sqlite'
+    asyncio.run(_create_database(database))
+
+    with pytest.raises(SystemExit) as error:
+        source_yields.main(['--database', str(database), '--list-targets', '--run-id', str(RUN_ONE)])
+
+    assert error.value.code == 2
+    assert 'not allowed with argument' in capsys.readouterr().err
 
 
 def test_missing_database_fails_without_creating_file(

--- a/theHarvester/lib/api/run_models.py
+++ b/theHarvester/lib/api/run_models.py
@@ -7,13 +7,21 @@ from typing import Any, Literal, Self
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from theHarvester.lib.completed_result import parse_virtual_host_details
+from theHarvester.lib.dns_consensus import Addressability  # noqa: TC001 - Pydantic resolves this annotation at runtime
 from theHarvester.lib.enumeration import (
     DEFAULT_DNS_RECURSIVE_QUERY_LIMIT,
     DEFAULT_DNS_RECURSIVE_RUNTIME_SECONDS,
     DEFAULT_RESULT_START,
     DEFAULT_SOURCE_WORKERS,
 )
-from theHarvester.lib.evidence_types import EvidenceStatus  # noqa: TC001 - Pydantic resolves this annotation at runtime
+from theHarvester.lib.evidence_types import (  # noqa: TC001 - Pydantic resolves these annotations at runtime
+    EvidenceStatus,
+    ExecutionStatus,
+)
+from theHarvester.lib.hostname_tracking import (  # noqa: TC001 - Pydantic resolves these annotations at runtime
+    ChangeStatus,
+    ResolutionEvidence,
+)
 from theHarvester.lib.resolver_selection import DEFAULT_DNS_RESOLVERS, normalize_resolver_addresses
 from theHarvester.lib.result_values import normalize_asn
 from theHarvester.lib.source_catalog import (
@@ -601,6 +609,54 @@ class SourceYieldSummary(BaseModel):
     unique_resolved_hostname_count: int = Field(ge=0)
 
 
+class HostnameTrackingCounts(BaseModel):
+    new: int = Field(ge=0)
+    persisting: int = Field(ge=0)
+    missing: int = Field(ge=0)
+    inconclusive: int = Field(ge=0)
+
+
+class HostnameTrackingComparison(BaseModel):
+    run_id: str
+    completed_at: str
+    baseline_run_id: str | None
+    baseline_completed_at: str | None
+    source_cohort: list[str]
+    counts: HostnameTrackingCounts
+    message: str | None = None
+
+
+class HostnameTrackingBlocker(BaseModel):
+    source: str
+    status: ExecutionStatus
+    error_type: str | None
+    stop_reason: str | None
+
+
+class HostnameTrackingChange(BaseModel):
+    run_id: str
+    baseline_run_id: str
+    change: ChangeStatus
+    hostname: str
+    previous_sources: list[str]
+    current_sources: list[str]
+    source_exclusive: bool
+    blocking_sources: list[HostnameTrackingBlocker]
+    previous_resolution_evidence: ResolutionEvidence
+    current_resolution_evidence: ResolutionEvidence
+    previous_dns_action_status: ExecutionStatus | None
+    current_dns_action_status: ExecutionStatus | None
+    previous_addressability: Addressability | None
+    current_addressability: Addressability | None
+
+
+class HostnameTrackingSummary(BaseModel):
+    target: str
+    comparison_count: int = Field(ge=0)
+    comparisons: list[HostnameTrackingComparison]
+    hostname_changes: list[HostnameTrackingChange]
+
+
 RunStatus = Literal['queued', 'running', 'cancelling', 'cancelled', 'completed', 'failed']
 Activity = Literal['P0', 'P1', 'P2']
 
@@ -633,6 +689,7 @@ class RunDetail(RunSummary):
     results: list[RunResult]
     source_executions: list[dict[str, Any]]
     source_yields: list[SourceYieldSummary]
+    hostname_tracking: HostnameTrackingSummary
     action_executions: list[dict[str, Any]]
     artifacts: list[dict[str, Any]]
     screenshots: list[ScreenshotRecord]

--- a/theHarvester/lib/api/run_store.py
+++ b/theHarvester/lib/api/run_store.py
@@ -18,6 +18,7 @@ from theHarvester.lib.completed_result import (
 )
 from theHarvester.lib.database import DuplicateRunError, ResultStore, ResultStoreError, RunLifecycleStore
 from theHarvester.lib.evidence_types import EXECUTION_STATUSES, EvidenceStatus, ExecutionStatus, ResultKind
+from theHarvester.lib.hostname_tracking import canonical_target, hostname_tracking_projection
 from theHarvester.lib.network_evidence import NetworkObservation, parse_network_observation_details
 from theHarvester.lib.shodan_evidence import ShodanHostObservation
 from theHarvester.lib.takeover_evidence import TakeoverCandidateOutcome, parse_takeover_details
@@ -255,6 +256,20 @@ class RunStore:
                 results=normalized_results(evidence),
                 source_executions=source_executions(evidence),
                 source_yields=source_yields,
+                hostname_tracking=(
+                    await hostname_tracking_projection(
+                        self.results,
+                        run_id=UUID(str(record['evidence_run_id'])),
+                        include_persisting=True,
+                    )
+                    if evidence
+                    else {
+                        'target': canonical_target(record['target']),
+                        'comparison_count': 0,
+                        'comparisons': [],
+                        'hostname_changes': [],
+                    }
+                ),
                 action_executions=evidence.get('action_executions', []) if evidence else [],
                 artifacts=evidence.get('artifacts', []) if evidence else [],
                 screenshots=screenshots(evidence, str(record['run_id']), self.artifact_directory(str(record['run_id']))),

--- a/theHarvester/lib/api/static/harvestview/app.css
+++ b/theHarvester/lib/api/static/harvestview/app.css
@@ -513,6 +513,31 @@ a:focus-visible {
 .request-options dt { color: var(--muted); font-size: 12px; }
 .request-options dd { margin: 2px 0 0; overflow-wrap: anywhere; font: 12px/1.4 var(--font-mono); }
 
+.hostname-tracking { margin-block: 30px 8px; padding-block-start: 26px; border-block-start: 1px solid var(--line-strong); }
+.tracking-heading { align-items: start; }
+.tracking-counts { display: flex; flex-wrap: wrap; justify-content: end; gap: 6px; }
+.tracking-count { padding: 6px 8px; color: var(--ink-soft); background: var(--surface-muted); border: 1px solid var(--line); border-radius: 5px; font: 700 11px/1.2 var(--font-mono); text-transform: uppercase; }
+.tracking-count.new { color: var(--success); }
+.tracking-count.missing, .tracking-count.inconclusive { color: var(--warning); }
+.tracking-explanation { margin-block: 12px; padding: 12px 14px; color: var(--ink-soft); background: var(--info-soft); border-inline-start: 3px solid var(--info); }
+.tracking-explanation strong { color: var(--ink); }
+.tracking-explanation p { margin: 4px 0 0; font-size: 13px; line-height: 1.55; }
+.tracking-filters { display: grid; grid-template-columns: repeat(3, minmax(150px, 1fr)) auto auto; gap: 9px; margin-block: 14px; align-items: end; }
+.tracking-filters label { display: grid; gap: 5px; color: var(--muted); font-size: 12px; font-weight: 700; }
+.tracking-filters select { min-height: 44px; padding: 7px 9px; color: var(--ink); background: var(--surface-raised); border: 1px solid var(--line); border-radius: 6px; }
+.tracking-filters .tracking-checkbox { display: flex; min-height: 44px; align-items: center; gap: 7px; color: var(--ink-soft); }
+.tracking-checkbox input { width: 18px; height: 18px; accent-color: var(--accent-strong); }
+.tracking-table-wrap { max-height: 430px; overflow: auto; border: 1px solid var(--line-strong); }
+.tracking-table { width: 100%; min-width: 980px; background: var(--surface); }
+.tracking-table th, .tracking-table td { padding: 9px 10px; text-align: start; vertical-align: top; border-block-end: 1px solid var(--line); }
+.tracking-table th { position: sticky; z-index: 1; inset-block-start: 0; color: var(--muted); background: var(--surface-muted); font: 700 11px/1.2 var(--font-mono); letter-spacing: 0.05em; text-transform: uppercase; }
+.tracking-table td { font-size: 12px; line-height: 1.45; }
+.tracking-table td small { display: block; margin-block-start: 3px; color: var(--accent-text); font-weight: 750; }
+.tracking-hostname { overflow-wrap: anywhere; font-family: var(--font-mono); }
+.tracking-state { display: inline-block; padding: 4px 6px; border-radius: 4px; background: var(--surface-muted); font: 800 11px/1.2 var(--font-mono); text-transform: uppercase; }
+.tracking-state.new { color: var(--success); background: var(--accent-soft); }
+.tracking-state.missing, .tracking-state.inconclusive { color: var(--warning); background: var(--warning-soft); }
+
 .provider-table-wrap { max-height: 264px; overflow: auto; }
 .provider-details { margin-block-start: 28px; padding: 0 20px 20px; background: var(--surface); border: 1px solid var(--line-strong); }
 .provider-details summary { display: flex; min-height: 58px; align-items: center; justify-content: space-between; gap: 12px; cursor: pointer; font-size: 18px; font-weight: 760; }
@@ -773,6 +798,8 @@ dialog[open] { animation: dialog-in 180ms cubic-bezier(0.22, 1, 0.36, 1); }
   .lifecycle-step { min-height: 65px; padding: 0 0 18px 24px; border-block-start: 0; border-inline-start: 2px solid var(--line); }
   .lifecycle-step::before { inset: 0 auto auto -6px; }
   .activity-bands { grid-template-columns: 1fr; }
+  .tracking-counts { justify-content: start; }
+  .tracking-filters { grid-template-columns: 1fr; }
   .request-options { grid-template-columns: 1fr; }
   .source-groups { max-height: none; grid-template-columns: 1fr; overflow: visible; }
   .source-selection-summary { position: static; }

--- a/theHarvester/lib/api/static/harvestview/app.js
+++ b/theHarvester/lib/api/static/harvestview/app.js
@@ -1422,10 +1422,19 @@
     const query = event.target.value.trim().toLowerCase();
     state.resultTable?.setFilter(row => !query || row.value.toLowerCase().includes(query));
   });
-  for (const filter of [
-    nodes.trackingChange, nodes.trackingSource, nodes.trackingResolution,
-    nodes.trackingExclusive, nodes.trackingPersisting
-  ]) filter.addEventListener('change', () => renderHostnameTracking(state.detail));
+  nodes.trackingChange.addEventListener('change', () => {
+    if (nodes.trackingChange.value === 'persisting') nodes.trackingPersisting.checked = true;
+    renderHostnameTracking(state.detail);
+  });
+  nodes.trackingPersisting.addEventListener('change', () => {
+    if (!nodes.trackingPersisting.checked && nodes.trackingChange.value === 'persisting') {
+      nodes.trackingChange.value = '';
+    }
+    renderHostnameTracking(state.detail);
+  });
+  for (const filter of [nodes.trackingSource, nodes.trackingResolution, nodes.trackingExclusive]) {
+    filter.addEventListener('change', () => renderHostnameTracking(state.detail));
+  }
   nodes.sourceSearch.addEventListener('input', event => renderSourceGroups(event.target.value));
   nodes.selectCapability.addEventListener('click', selectCapability);
   nodes.selectP0.addEventListener('click', () => setP0Selection(true));

--- a/theHarvester/lib/api/static/harvestview/app.js
+++ b/theHarvester/lib/api/static/harvestview/app.js
@@ -824,12 +824,16 @@
     screenshots.forEach((screenshot, index) => loadScreenshot(screenshot, nodes.screenshotGallery.children[index].querySelector('.screenshot-frame')));
   }
 
+  function trackingUsesCurrentEvidence(row) {
+    return (row.current_sources || []).length > 0;
+  }
+
   function trackingSources(row) {
-    return row.change === 'new' || row.change === 'persisting' ? row.current_sources || [] : row.previous_sources || [];
+    return trackingUsesCurrentEvidence(row) ? row.current_sources || [] : row.previous_sources || [];
   }
 
   function trackingResolution(row) {
-    return row.change === 'new' || row.change === 'persisting'
+    return trackingUsesCurrentEvidence(row)
       ? row.current_resolution_evidence
       : row.previous_resolution_evidence;
   }

--- a/theHarvester/lib/api/static/harvestview/app.js
+++ b/theHarvester/lib/api/static/harvestview/app.js
@@ -42,6 +42,11 @@
     lifecycleTrack: $('#lifecycle-track'), lifecycleNote: $('#lifecycle-note'),
     assessmentEvidence: $('#assessment-evidence'), assessmentProducers: $('#assessment-producers'),
     assessmentReview: $('#assessment-review'), reviewOutcomes: $('#review-outcomes-button'),
+    trackingSection: $('#hostname-tracking-section'), trackingSummary: $('#hostname-tracking-summary'),
+    trackingCounts: $('#hostname-tracking-counts'), trackingBody: $('#hostname-tracking-body'),
+    trackingEmpty: $('#hostname-tracking-empty'), trackingChange: $('#tracking-change-filter'),
+    trackingSource: $('#tracking-source-filter'), trackingResolution: $('#tracking-resolution-filter'),
+    trackingExclusive: $('#tracking-exclusive-filter'), trackingPersisting: $('#tracking-persisting-filter'),
     resultsSection: $('#results-section'),
     activityBands: $('#activity-bands'), requestOptions: $('#request-options'), providerBody: $('#provider-body'),
     providerSummary: $('#provider-summary'), providerOutcomeSummary: $('#provider-outcome-summary'), providerEmpty: $('#provider-empty'),
@@ -819,6 +824,63 @@
     screenshots.forEach((screenshot, index) => loadScreenshot(screenshot, nodes.screenshotGallery.children[index].querySelector('.screenshot-frame')));
   }
 
+  function trackingSources(row) {
+    return row.change === 'new' || row.change === 'persisting' ? row.current_sources || [] : row.previous_sources || [];
+  }
+
+  function trackingResolution(row) {
+    return row.change === 'new' || row.change === 'persisting'
+      ? row.current_resolution_evidence
+      : row.previous_resolution_evidence;
+  }
+
+  function renderHostnameTracking(run) {
+    const tracking = run.hostname_tracking;
+    nodes.trackingSection.hidden = !run.evidence_status || !tracking;
+    if (nodes.trackingSection.hidden) return;
+    const comparison = tracking.comparisons?.[0];
+    const counts = comparison?.counts || {new: 0, persisting: 0, missing: 0, inconclusive: 0};
+    nodes.trackingCounts.innerHTML = ['new', 'missing', 'inconclusive', 'persisting']
+      .map(change => `<span class="tracking-count ${change}"><b>${Number(counts[change] || 0).toLocaleString()}</b> ${escapeHtml(change)}</span>`)
+      .join('');
+    nodes.trackingSummary.textContent = comparison?.baseline_run_id
+      ? `Compared with ${comparison.baseline_run_id} · ${formatDate(comparison.baseline_completed_at)}.`
+      : comparison?.message || 'No comparable baseline is available.';
+    const allRows = tracking.hostname_changes || [];
+    const selectedSource = nodes.trackingSource.value;
+    const sources = [...new Set(allRows.flatMap(trackingSources))].sort();
+    nodes.trackingSource.innerHTML = '<option value="">All sources</option>'
+      + sources.map(source => `<option value="${escapeHtml(source)}">${escapeHtml(source)}</option>`).join('');
+    nodes.trackingSource.value = sources.includes(selectedSource) ? selectedSource : '';
+    const rows = allRows.filter(row => {
+      if (row.change === 'persisting' && !nodes.trackingPersisting.checked) return false;
+      if (nodes.trackingChange.value && row.change !== nodes.trackingChange.value) return false;
+      if (nodes.trackingSource.value && !trackingSources(row).includes(nodes.trackingSource.value)) return false;
+      if (nodes.trackingResolution.value && trackingResolution(row) !== nodes.trackingResolution.value) return false;
+      return !nodes.trackingExclusive.checked || row.source_exclusive;
+    });
+    nodes.trackingBody.innerHTML = rows.map(row => {
+      const blockers = (row.blocking_sources || []).map(blocker => {
+        const reason = [blocker.status, blocker.error_type, blocker.stop_reason].filter(Boolean).join(' · ');
+        return `${escapeHtml(blocker.source)}${reason ? `: ${escapeHtml(reason)}` : ''}`;
+      }).join('<br>') || '—';
+      const previousDns = row.previous_resolution_evidence || 'not-checked';
+      const currentDns = row.current_resolution_evidence || 'not-checked';
+      const previousAddressability = row.previous_addressability || 'not classified';
+      const currentAddressability = row.current_addressability || 'not classified';
+      return `<tr>
+        <td><span class="tracking-state ${safeClass(row.change)}">${escapeHtml(row.change)}</span></td>
+        <td class="tracking-hostname">${escapeHtml(row.hostname)}</td>
+        <td>${escapeHtml(trackingSources(row).join(', ') || '—')}${row.source_exclusive ? '<small>Source-exclusive</small>' : ''}</td>
+        <td>${escapeHtml(previousDns)} <span aria-hidden="true">→</span> ${escapeHtml(currentDns)}</td>
+        <td>${escapeHtml(previousAddressability)} <span aria-hidden="true">→</span> ${escapeHtml(currentAddressability)}</td>
+        <td>${blockers}</td>
+      </tr>`;
+    }).join('');
+    nodes.trackingEmpty.hidden = rows.length > 0;
+    nodes.trackingBody.closest('table').hidden = rows.length === 0;
+  }
+
   function renderDetail(previousRun = null) {
     const run = state.detail;
     nodes.loading.hidden = true;
@@ -842,6 +904,7 @@
     renderAuthorization(run);
     renderExecutions(run);
     renderAssessment(run);
+    renderHostnameTracking(run);
     if (!previousRun || previousRun.status !== run.status || JSON.stringify(previousRun.results) !== JSON.stringify(run.results)) {
       renderResults(run);
     }
@@ -1359,6 +1422,10 @@
     const query = event.target.value.trim().toLowerCase();
     state.resultTable?.setFilter(row => !query || row.value.toLowerCase().includes(query));
   });
+  for (const filter of [
+    nodes.trackingChange, nodes.trackingSource, nodes.trackingResolution,
+    nodes.trackingExclusive, nodes.trackingPersisting
+  ]) filter.addEventListener('change', () => renderHostnameTracking(state.detail));
   nodes.sourceSearch.addEventListener('input', event => renderSourceGroups(event.target.value));
   nodes.selectCapability.addEventListener('click', selectCapability);
   nodes.selectP0.addEventListener('click', () => setP0Selection(true));

--- a/theHarvester/lib/api/static/harvestview/index.html
+++ b/theHarvester/lib/api/static/harvestview/index.html
@@ -129,6 +129,58 @@
             <ol id="lifecycle-track" class="lifecycle-track"></ol>
           </section>
 
+          <section id="hostname-tracking-section" class="hostname-tracking" aria-labelledby="hostname-tracking-title" hidden>
+            <div class="section-heading tracking-heading">
+              <div>
+                <div class="heading-with-help">
+                  <h3 id="hostname-tracking-title">Hostname changes</h3>
+                  <button class="help-tip" type="button" aria-label="Explain hostname change tracking" data-tooltip="Compares this finalized run with the previous finalized run for the same canonical target and exact source cohort. It never starts discovery or DNS.">?</button>
+                </div>
+                <p id="hostname-tracking-summary" class="section-note"></p>
+              </div>
+              <div id="hostname-tracking-counts" class="tracking-counts" aria-label="Hostname change counts"></div>
+            </div>
+            <div class="tracking-explanation">
+              <strong>How to read this</strong>
+              <p>INCONCLUSIVE means a source that previously found the hostname did not complete reliably, so absence cannot support a missing claim. Its status and retained reason appear below. MISSING means absent from a comparable completed collection—not that the hostname stopped existing or resolving. This view reads finalized evidence only and performs no discovery or DNS.</p>
+            </div>
+            <div class="tracking-filters" aria-label="Filter hostname changes">
+              <label for="tracking-change-filter">Change
+                <select id="tracking-change-filter">
+                  <option value="">All changes</option>
+                  <option value="new">New</option>
+                  <option value="missing">Missing</option>
+                  <option value="inconclusive">Inconclusive</option>
+                  <option value="persisting">Persisting</option>
+                </select>
+              </label>
+              <label for="tracking-source-filter">Source
+                <select id="tracking-source-filter"><option value="">All sources</option></select>
+              </label>
+              <label for="tracking-resolution-filter">Resolution evidence
+                <select id="tracking-resolution-filter">
+                  <option value="">All resolution evidence</option>
+                  <option value="positive">Positive</option>
+                  <option value="not-retained">No positive retained</option>
+                  <option value="not-checked">Not checked</option>
+                </select>
+              </label>
+              <label class="tracking-checkbox" for="tracking-exclusive-filter">
+                <input id="tracking-exclusive-filter" type="checkbox"> Source-exclusive only
+              </label>
+              <label class="tracking-checkbox" for="tracking-persisting-filter">
+                <input id="tracking-persisting-filter" type="checkbox"> Include persisting
+              </label>
+            </div>
+            <div class="tracking-table-wrap">
+              <table class="tracking-table">
+                <thead><tr><th>Change</th><th>Hostname</th><th>Sources</th><th>DNS evidence</th><th>Addressability</th><th>Blocking sources</th></tr></thead>
+                <tbody id="hostname-tracking-body"></tbody>
+              </table>
+            </div>
+            <p id="hostname-tracking-empty" class="panel-empty" hidden>No hostname changes match these filters.</p>
+          </section>
+
           <div class="overview-grid">
             <section class="overview-panel authorization-panel" aria-labelledby="authorization-title">
               <div class="section-heading compact">

--- a/theHarvester/lib/api/static/harvestview/index.html
+++ b/theHarvester/lib/api/static/harvestview/index.html
@@ -142,7 +142,7 @@
             </div>
             <div class="tracking-explanation">
               <strong>How to read this</strong>
-              <p>INCONCLUSIVE means a source that previously found the hostname did not complete reliably, so absence cannot support a missing claim. Its status and retained reason appear below. MISSING means absent from a comparable completed collection—not that the hostname stopped existing or resolving. This view reads finalized evidence only and performs no discovery or DNS.</p>
+              <p>INCONCLUSIVE means a contributing source did not complete reliably on the comparison side needed to prove NEW or MISSING. Its status and retained reason appear below. MISSING means absent from a comparable completed collection—not that the hostname stopped existing or resolving. This view reads finalized evidence only and performs no discovery or DNS.</p>
             </div>
             <div class="tracking-filters" aria-label="Filter hostname changes">
               <label for="tracking-change-filter">Change

--- a/theHarvester/lib/database.py
+++ b/theHarvester/lib/database.py
@@ -52,6 +52,8 @@ from theHarvester.lib.completed_result import (
     parse_virtual_host_details,
     virtual_host_details,
 )
+from theHarvester.lib.dns_consensus import Addressability
+from theHarvester.lib.hostname_tracking import TrackingRunEvidence, TrackingSourceOutcome
 from theHarvester.lib.network_evidence import (
     NetworkObservation,
     network_observation_details,
@@ -1218,6 +1220,68 @@ class ResultStore:
             )
             for name, observed, unique, shared, resolved, unique_resolved in yields
         ]
+
+    async def load_hostname_tracking_run(self, run_id: UUID) -> TrackingRunEvidence:
+        """Load only the persisted evidence needed for hostname change tracking."""
+        async with self._session() as session:
+            parent = await session.get(_RunRow, str(run_id))
+            execution_rows = (await session.scalars(select(_ExecutionRow).where(_ExecutionRow.run_id == str(run_id)))).all()
+            result_rows = (await session.scalars(select(_ResultRow).where(_ResultRow.run_id == str(run_id)))).all()
+            origin_rows = (await session.scalars(select(_ResultOriginRow).where(_ResultOriginRow.run_id == str(run_id)))).all()
+        if parent is None:
+            raise LookupError(f'completed result not found: {run_id}')
+        executions = {row.position: row for row in execution_rows}
+        results = {row.position: row for row in result_rows}
+        hostname_sources: dict[str, set[str]] = {}
+        resolved_hostnames: set[str] = set()
+        for origin in origin_rows:
+            execution = executions.get(origin.execution_position)
+            result = results.get(origin.result_position)
+            if execution is None or result is None or result.kind != 'hostname':
+                continue
+            if execution.producer_kind == 'source':
+                hostname_sources.setdefault(result.value, set()).add(execution.name)
+            elif execution.producer_kind == 'action' and execution.name == 'dns-resolve':
+                resolved_hostnames.add(result.value)
+        addressability: dict[str, str] = {}
+        allowed_addressability = {value.value for value in Addressability}
+        for result in result_rows:
+            if result.kind != 'dns-recursive-classification':
+                continue
+            try:
+                classification = json.loads(result.value)
+            except json.JSONDecodeError, TypeError:
+                continue
+            if (
+                isinstance(classification, dict)
+                and isinstance(classification.get('hostname'), str)
+                and classification.get('addressability') in allowed_addressability
+            ):
+                addressability[classification['hostname']] = classification['addressability']
+        source_outcomes = tuple(
+            TrackingSourceOutcome(
+                source=row.name,
+                status=cast('ExecutionStatus', row.status),
+                error_type=row.error_type,
+                stop_reason=row.stop_reason,
+            )
+            for row in sorted(execution_rows, key=lambda row: row.name)
+            if row.producer_kind == 'source'
+        )
+        dns_execution = next(
+            (row for row in execution_rows if row.producer_kind == 'action' and row.name == 'dns-resolve'),
+            None,
+        )
+        return TrackingRunEvidence(
+            run_id=UUID(parent.run_id),
+            target=parent.target,
+            completed_at=datetime.datetime.fromisoformat(parent.completed_at),
+            source_outcomes=source_outcomes,
+            hostname_sources=tuple((hostname, tuple(sorted(sources))) for hostname, sources in sorted(hostname_sources.items())),
+            resolved_hostnames=frozenset(resolved_hostnames),
+            dns_action_status=cast('ExecutionStatus', dns_execution.status) if dns_execution else None,
+            addressability=tuple(sorted(addressability.items())),
+        )
 
     async def action_yields(self, run_id: UUID) -> list[ActionYield]:
         yields = await self._producer_yields(run_id, 'action')

--- a/theHarvester/lib/hostname_tracking.py
+++ b/theHarvester/lib/hostname_tracking.py
@@ -73,7 +73,7 @@ class TrackingRunEvidence:
 def _resolution(run: TrackingRunEvidence, hostname: str) -> ResolutionEvidence:
     if hostname in run.resolved_hostnames:
         return 'positive'
-    if hostname not in dict(run.hostname_sources) or run.dns_action_status is None:
+    if hostname not in dict(run.hostname_sources) or run.dns_action_status != 'completed':
         return 'not-checked'
     return 'not-retained'
 

--- a/theHarvester/lib/hostname_tracking.py
+++ b/theHarvester/lib/hostname_tracking.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+from uuid import UUID
+
+from theHarvester.lib.hostnames import normalize_hostname
+from theHarvester.lib.result_values import normalize_asn, normalize_ip, normalize_prefix
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from theHarvester.lib.database import ResultStore
+    from theHarvester.lib.evidence_types import ExecutionStatus
+
+
+ChangeStatus = Literal['new', 'persisting', 'missing', 'inconclusive']
+ResolutionEvidence = Literal['positive', 'not-retained', 'not-checked']
+
+
+def canonical_target(value: object) -> str:
+    target = str(value).strip()
+    if target[:2].casefold() == 'as' and target[2:].isascii() and target[2:].isdecimal():
+        return normalize_asn(target)
+    if '/' in target:
+        try:
+            return normalize_prefix(target)
+        except ValueError:
+            pass
+    try:
+        return normalize_ip(target, label='target')
+    except ValueError:
+        pass
+    try:
+        hostname = normalize_hostname(target)
+    except ValueError:
+        return target
+    return hostname if '.' in hostname else target
+
+
+@dataclass(frozen=True, slots=True)
+class TrackingSourceOutcome:
+    source: str
+    status: ExecutionStatus
+    error_type: str | None
+    stop_reason: str | None
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {
+            'source': self.source,
+            'status': self.status,
+            'error_type': self.error_type,
+            'stop_reason': self.stop_reason,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TrackingRunEvidence:
+    run_id: UUID
+    target: str
+    completed_at: datetime
+    source_outcomes: tuple[TrackingSourceOutcome, ...]
+    hostname_sources: tuple[tuple[str, tuple[str, ...]], ...]
+    resolved_hostnames: frozenset[str]
+    dns_action_status: ExecutionStatus | None
+    addressability: tuple[tuple[str, str], ...]
+
+    @property
+    def source_cohort(self) -> tuple[str, ...]:
+        return tuple(outcome.source for outcome in self.source_outcomes)
+
+
+def _resolution(run: TrackingRunEvidence, hostname: str) -> ResolutionEvidence:
+    if hostname in run.resolved_hostnames:
+        return 'positive'
+    if hostname not in dict(run.hostname_sources) or run.dns_action_status is None:
+        return 'not-checked'
+    return 'not-retained'
+
+
+def _change_row(
+    current: TrackingRunEvidence,
+    baseline: TrackingRunEvidence,
+    hostname: str,
+) -> tuple[ChangeStatus, dict[str, object]]:
+    previous_sources = dict(baseline.hostname_sources).get(hostname, ())
+    current_sources = dict(current.hostname_sources).get(hostname, ())
+    blocking_sources: list[TrackingSourceOutcome] = []
+    if not previous_sources:
+        change: ChangeStatus = 'new'
+    elif current_sources:
+        change = 'persisting'
+    else:
+        current_outcomes = {outcome.source: outcome for outcome in current.source_outcomes}
+        blocking_sources = [
+            current_outcomes[source] for source in previous_sources if current_outcomes[source].status != 'completed'
+        ]
+        change = 'inconclusive' if blocking_sources else 'missing'
+    exclusive_sources = current_sources if change in {'new', 'persisting'} else previous_sources
+    return change, {
+        'run_id': str(current.run_id),
+        'baseline_run_id': str(baseline.run_id),
+        'change': change,
+        'hostname': hostname,
+        'previous_sources': list(previous_sources),
+        'current_sources': list(current_sources),
+        'source_exclusive': len(exclusive_sources) == 1,
+        'blocking_sources': [outcome.to_dict() for outcome in blocking_sources],
+        'previous_resolution_evidence': _resolution(baseline, hostname),
+        'current_resolution_evidence': _resolution(current, hostname),
+        'previous_dns_action_status': baseline.dns_action_status,
+        'current_dns_action_status': current.dns_action_status,
+        'previous_addressability': dict(baseline.addressability).get(hostname),
+        'current_addressability': dict(current.addressability).get(hostname),
+    }
+
+
+async def hostname_tracking_projection(
+    store: ResultStore,
+    *,
+    target: str | None = None,
+    run_id: UUID | None = None,
+    include_persisting: bool = False,
+) -> dict[str, object]:
+    summaries = await store.list_runs(limit=None)
+    if run_id is not None:
+        current = await store.load_hostname_tracking_run(run_id)
+        selected_target = canonical_target(current.target)
+        selected_ids = {run_id}
+    elif target is not None:
+        selected_target = canonical_target(target)
+        selected_ids = {
+            UUID(str(summary['run_id'])) for summary in summaries if canonical_target(summary['target']) == selected_target
+        }
+    else:
+        raise ValueError('target or run_id is required')
+    target_runs = [
+        await store.load_hostname_tracking_run(UUID(str(summary['run_id'])))
+        for summary in summaries
+        if canonical_target(summary['target']) == selected_target
+    ]
+    target_runs.sort(key=lambda run: (run.completed_at, str(run.run_id)))
+    previous_by_cohort: dict[tuple[str, ...], TrackingRunEvidence] = {}
+    comparisons: list[dict[str, object]] = []
+    rows: list[dict[str, object]] = []
+    change_order = {'new': 0, 'missing': 1, 'inconclusive': 2, 'persisting': 3}
+    for current in target_runs:
+        baseline = previous_by_cohort.get(current.source_cohort)
+        previous_by_cohort[current.source_cohort] = current
+        if current.run_id not in selected_ids:
+            continue
+        counts = {'new': 0, 'persisting': 0, 'missing': 0, 'inconclusive': 0}
+        comparison: dict[str, object] = {
+            'run_id': str(current.run_id),
+            'completed_at': current.completed_at.isoformat(),
+            'baseline_run_id': str(baseline.run_id) if baseline else None,
+            'baseline_completed_at': baseline.completed_at.isoformat() if baseline else None,
+            'source_cohort': list(current.source_cohort),
+            'counts': counts,
+        }
+        if baseline is None:
+            comparison['message'] = 'No previous finalized run has the same source cohort.'
+        else:
+            hostnames = sorted(set(dict(baseline.hostname_sources)) | set(dict(current.hostname_sources)))
+            comparison_rows = []
+            for hostname in hostnames:
+                change, row = _change_row(current, baseline, hostname)
+                counts[change] += 1
+                if change != 'persisting' or include_persisting:
+                    comparison_rows.append(row)
+            rows.extend(sorted(comparison_rows, key=lambda row: (change_order[str(row['change'])], str(row['hostname']))))
+        comparisons.append(comparison)
+    return {
+        'target': selected_target,
+        'comparison_count': len(comparisons),
+        'comparisons': comparisons,
+        'hostname_changes': rows,
+    }

--- a/theHarvester/lib/hostname_tracking.py
+++ b/theHarvester/lib/hostname_tracking.py
@@ -78,6 +78,11 @@ def _resolution(run: TrackingRunEvidence, hostname: str) -> ResolutionEvidence:
     return 'not-retained'
 
 
+def _blocking_outcomes(run: TrackingRunEvidence, sources: tuple[str, ...]) -> list[TrackingSourceOutcome]:
+    outcomes = {outcome.source: outcome for outcome in run.source_outcomes}
+    return [outcomes[source] for source in sources if outcomes[source].status != 'completed']
+
+
 def _change_row(
     current: TrackingRunEvidence,
     baseline: TrackingRunEvidence,
@@ -87,16 +92,14 @@ def _change_row(
     current_sources = dict(current.hostname_sources).get(hostname, ())
     blocking_sources: list[TrackingSourceOutcome] = []
     if not previous_sources:
-        change: ChangeStatus = 'new'
+        blocking_sources = _blocking_outcomes(baseline, current_sources)
+        change: ChangeStatus = 'inconclusive' if blocking_sources else 'new'
     elif current_sources:
         change = 'persisting'
     else:
-        current_outcomes = {outcome.source: outcome for outcome in current.source_outcomes}
-        blocking_sources = [
-            current_outcomes[source] for source in previous_sources if current_outcomes[source].status != 'completed'
-        ]
+        blocking_sources = _blocking_outcomes(current, previous_sources)
         change = 'inconclusive' if blocking_sources else 'missing'
-    exclusive_sources = current_sources if change in {'new', 'persisting'} else previous_sources
+    exclusive_sources = current_sources or previous_sources
     return change, {
         'run_id': str(current.run_id),
         'baseline_run_id': str(baseline.run_id),

--- a/theHarvester/source_yields.py
+++ b/theHarvester/source_yields.py
@@ -11,15 +11,25 @@ from uuid import UUID
 
 from theHarvester.lib.database import ResultStore
 from theHarvester.lib.evidence_types import RESULT_KINDS, ResultKind
-from theHarvester.lib.hostnames import normalize_hostname
-from theHarvester.lib.result_values import normalize_asn, normalize_ip, normalize_prefix
+from theHarvester.lib.hostname_tracking import canonical_target, hostname_tracking_projection
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
 def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description='Report per-source result yields from a theHarvester database.')
+    parser = argparse.ArgumentParser(
+        prog='harvest-yields',
+        description='Report per-source result yields from a theHarvester database.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""Examples:
+  harvest-yields --target example.test
+  harvest-yields --target example.test --changes
+  harvest-yields --run-id RUN_ID --changes
+  harvest-yields --target example.test --changes --include-persisting --format json
+
+Change reports read finalized local evidence only and never run discovery or DNS.""",
+    )
     parser.add_argument(
         '--database',
         type=Path,
@@ -32,35 +42,44 @@ def _parser() -> argparse.ArgumentParser:
     scope.add_argument('--list-targets', action='store_true', help='List canonical targets and finalized-run counts.')
     scope.add_argument('--target', help='Report finalized runs for one exact canonical target.')
     scope.add_argument('--all-targets', action='store_true', help='Explicitly aggregate finalized runs across all targets.')
+    parser.add_argument(
+        '--changes',
+        action='store_true',
+        help='Compare persisted hostname evidence between comparable finalized runs; never runs discovery or DNS.',
+    )
+    parser.add_argument(
+        '--include-persisting',
+        action='store_true',
+        help='Include persisting hostname rows in a --changes report.',
+    )
     parser.add_argument('--format', choices=('table', 'json'), default='table', help='Output format.')
     return parser
-
-
-def _canonical_target(value: object) -> str:
-    target = str(value).strip()
-    if target[:2].casefold() == 'as' and target[2:].isascii() and target[2:].isdecimal():
-        return normalize_asn(target)
-    if '/' in target:
-        try:
-            return normalize_prefix(target)
-        except ValueError:
-            pass
-    try:
-        return normalize_ip(target, label='target')
-    except ValueError:
-        pass
-    try:
-        hostname = normalize_hostname(target)
-    except ValueError:
-        return target
-    return hostname if '.' in hostname else target
 
 
 async def _list_targets(database: Path) -> list[dict[str, str | int]]:
     store = ResultStore(database)
     try:
-        counts = Counter(_canonical_target(run['target']) for run in await store.list_runs(limit=None))
+        counts = Counter(canonical_target(run['target']) for run in await store.list_runs(limit=None))
         return [{'target': target, 'run_count': counts[target]} for target in sorted(counts)]
+    finally:
+        await store.dispose()
+
+
+async def _changes(
+    database: Path,
+    *,
+    target: str | None = None,
+    run_id: UUID | None = None,
+    include_persisting: bool = False,
+) -> dict[str, object]:
+    store = ResultStore(database)
+    try:
+        return await hostname_tracking_projection(
+            store,
+            target=target,
+            run_id=run_id,
+            include_persisting=include_persisting,
+        )
     finally:
         await store.dispose()
 
@@ -76,20 +95,20 @@ async def _collect(
     try:
         target_rows: list[dict[str, str | int]] = []
         if run_id is not None:
-            selected_target = _canonical_target((await store.load_run(run_id)).target)
+            selected_target = canonical_target((await store.load_run(run_id)).target)
             run_ids = [run_id]
         else:
             summaries = await store.list_runs(limit=None)
-            selected_target = _canonical_target(target) if target is not None else None
+            selected_target = canonical_target(target) if target is not None else None
             if all_targets:
-                counts = Counter(_canonical_target(run['target']) for run in summaries)
+                counts = Counter(canonical_target(run['target']) for run in summaries)
                 target_rows = [{'target': value, 'run_count': counts[value]} for value in sorted(counts)]
             elif selected_target is not None:
-                summaries = [run for run in summaries if _canonical_target(run['target']) == selected_target]
+                summaries = [run for run in summaries if canonical_target(run['target']) == selected_target]
                 if not summaries:
                     raise LookupError(f'target not found: {selected_target}; use --list-targets')
             else:
-                targets = {_canonical_target(run['target']) for run in summaries}
+                targets = {canonical_target(run['target']) for run in summaries}
                 if len(targets) > 1:
                     raise LookupError(f'database contains {len(targets)} canonical targets; use --list-targets')
                 selected_target = next(iter(targets), None)
@@ -188,17 +207,122 @@ def _targets_table(rows: list[dict[str, str | int]]) -> str:
     return '\n'.join(lines) + '\n'
 
 
+def _tracking_table(payload: dict[str, object]) -> str:
+    comparisons = cast('list[dict[str, object]]', payload['comparisons'])
+    changes = cast('list[dict[str, object]]', payload['hostname_changes'])
+    lines = [f'Target: {payload["target"]}', f'Comparison count: {payload["comparison_count"]}']
+    summary_columns = (
+        ('run_id', 'CURRENT RUN'),
+        ('baseline_run_id', 'BASELINE RUN'),
+        ('new', 'NEW'),
+        ('persisting', 'PERSISTING'),
+        ('missing', 'MISSING'),
+        ('inconclusive', 'INCONCLUSIVE'),
+    )
+    summary_rows = [
+        {
+            'run_id': comparison['run_id'],
+            'baseline_run_id': comparison['baseline_run_id'] or '-',
+            **cast('dict[str, int]', comparison['counts']),
+        }
+        for comparison in comparisons
+    ]
+    summary_widths = [max(len(label), *(len(str(row[key])) for row in summary_rows)) for key, label in summary_columns]
+    lines.append('  '.join(label.ljust(summary_widths[index]) for index, (_key, label) in enumerate(summary_columns)))
+    lines.extend(
+        '  '.join(str(row[key]).ljust(summary_widths[index]) for index, (key, _label) in enumerate(summary_columns))
+        for row in summary_rows
+    )
+    lines.extend(f'{comparison["run_id"]}: {message}' for comparison in comparisons if (message := comparison.get('message')))
+    change_columns = (
+        ('change', 'CHANGE'),
+        ('hostname', 'HOSTNAME'),
+        ('sources', 'SOURCES'),
+        ('exclusive', 'EXCLUSIVE'),
+        ('resolution', 'RESOLUTION'),
+        ('addressability', 'ADDRESSABILITY'),
+        ('blocking', 'BLOCKING SOURCES'),
+    )
+    change_rows = []
+    for row in changes:
+        sources = row['current_sources'] if row['change'] in {'new', 'persisting'} else row['previous_sources']
+        blockers = cast('list[dict[str, object]]', row['blocking_sources'])
+        change_rows.append(
+            {
+                'change': str(row['change']).upper(),
+                'hostname': row['hostname'],
+                'sources': ','.join(cast('list[str]', sources)) or '-',
+                'exclusive': 'yes' if row['source_exclusive'] else 'no',
+                'resolution': f'{row["previous_resolution_evidence"]} -> {row["current_resolution_evidence"]}',
+                'addressability': f'{row["previous_addressability"] or "-"} -> {row["current_addressability"] or "-"}',
+                'blocking': ','.join(
+                    ':'.join(
+                        str(value or '-')
+                        for value in (blocker['source'], blocker['status'], blocker['error_type'], blocker['stop_reason'])
+                    )
+                    for blocker in blockers
+                )
+                or '-',
+            }
+        )
+    if not change_rows:
+        lines.append('No hostname changes to display.')
+        return '\n'.join(lines) + '\n'
+    change_widths = [max(len(label), *(len(str(row[key])) for row in change_rows)) for key, label in change_columns]
+    lines.append('  '.join(label.ljust(change_widths[index]) for index, (_key, label) in enumerate(change_columns)))
+    lines.extend(
+        '  '.join(str(row[key]).ljust(change_widths[index]) for index, (key, _label) in enumerate(change_columns)).rstrip()
+        for row in change_rows
+    )
+    return '\n'.join(lines) + '\n'
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = _parser()
     args = parser.parse_args(argv)
     if not args.database.is_file():
         parser.error(f'database does not exist: {args.database}')
+    if args.include_persisting and not args.changes:
+        parser.error('--include-persisting requires --changes')
+    if args.changes and args.kind != 'hostname':
+        parser.error('--changes supports hostname evidence only; omit --kind or use --kind hostname')
+    if args.changes and args.list_targets:
+        parser.error('--changes cannot be combined with --list-targets')
+    if args.changes and args.all_targets:
+        parser.error('--changes requires one target and cannot be combined with --all-targets')
     if args.list_targets:
         targets = asyncio.run(_list_targets(args.database))
         output = json.dumps({'targets': targets}, sort_keys=True) + '\n' if args.format == 'json' else _targets_table(targets)
         sys.stdout.write(output)
         return 0
     kind = cast('ResultKind', args.kind)
+    if args.changes:
+        changes: dict[str, object]
+        try:
+            if args.run_id is not None:
+                changes = asyncio.run(_changes(args.database, run_id=args.run_id, include_persisting=args.include_persisting))
+            else:
+                selected_target, _targets, _run_count, _rows = asyncio.run(_collect(args.database, kind, None, args.target))
+                if selected_target is None:
+                    changes = {
+                        'target': None,
+                        'comparison_count': 0,
+                        'comparisons': [],
+                        'hostname_changes': [],
+                    }
+                else:
+                    changes = asyncio.run(
+                        _changes(
+                            args.database,
+                            target=selected_target,
+                            include_persisting=args.include_persisting,
+                        )
+                    )
+        except LookupError as error:
+            parser.error(str(error))
+        output = json.dumps(changes, sort_keys=True) + '\n' if args.format == 'json' else _tracking_table(changes)
+        sys.stdout.write(output)
+        return 0
     try:
         target, targets, run_count, rows = asyncio.run(_collect(args.database, kind, args.run_id, args.target, args.all_targets))
     except LookupError as error:

--- a/theHarvester/source_yields.py
+++ b/theHarvester/source_yields.py
@@ -30,6 +30,7 @@ def _parser() -> argparse.ArgumentParser:
     scope = parser.add_mutually_exclusive_group()
     scope.add_argument('--run-id', type=UUID, help='Report one completed run instead of aggregating every run.')
     scope.add_argument('--list-targets', action='store_true', help='List canonical targets and finalized-run counts.')
+    scope.add_argument('--target', help='Report finalized runs for one exact canonical target.')
     parser.add_argument('--format', choices=('table', 'json'), default='table', help='Output format.')
     return parser
 
@@ -63,14 +64,30 @@ async def _list_targets(database: Path) -> list[dict[str, str | int]]:
         await store.dispose()
 
 
-async def _collect(database: Path, kind: ResultKind, run_id: UUID | None) -> tuple[int, list[dict[str, str | int | float]]]:
+async def _collect(
+    database: Path,
+    kind: ResultKind,
+    run_id: UUID | None,
+    target: str | None = None,
+) -> tuple[str | None, int, list[dict[str, str | int | float]]]:
     store = ResultStore(database)
     try:
         if run_id is not None:
-            await store.load_run(run_id)
+            selected_target = _canonical_target((await store.load_run(run_id)).target)
             run_ids = [run_id]
         else:
-            run_ids = [UUID(str(run['run_id'])) for run in await store.list_runs(limit=None)]
+            summaries = await store.list_runs(limit=None)
+            selected_target = _canonical_target(target) if target is not None else None
+            if selected_target is not None:
+                summaries = [run for run in summaries if _canonical_target(run['target']) == selected_target]
+                if not summaries:
+                    raise LookupError(f'target not found: {selected_target}; use --list-targets')
+            else:
+                targets = {_canonical_target(run['target']) for run in summaries}
+                if len(targets) > 1:
+                    raise LookupError(f'database contains {len(targets)} canonical targets; use --list-targets')
+                selected_target = next(iter(targets), None)
+            run_ids = [UUID(str(run['run_id'])) for run in summaries]
         totals: defaultdict[str, Counter[str]] = defaultdict(Counter)
         for run_id in run_ids:
             for source_yield in await store.source_yields(run_id, kind=kind):
@@ -105,12 +122,17 @@ async def _collect(database: Path, kind: ResultKind, run_id: UUID | None) -> tup
                 str(row['source']),
             )
         )
-        return len(run_ids), rows
+        return selected_target, len(run_ids), rows
     finally:
         await store.dispose()
 
 
-def _table(kind: ResultKind, run_count: int, rows: list[dict[str, str | int | float]]) -> str:
+def _table(
+    kind: ResultKind,
+    run_count: int,
+    rows: list[dict[str, str | int | float]],
+    target: str | None,
+) -> str:
     columns = [
         ('source', 'SOURCE'),
         ('run_count', 'RUNS'),
@@ -134,6 +156,7 @@ def _table(kind: ResultKind, run_count: int, rows: list[dict[str, str | int | fl
         max([len(label), *(len(values[index]) for values in formatted_rows)]) for index, (_key, label) in enumerate(columns)
     ]
     lines = [
+        f'Target: {target}' if target is not None else 'Targets: none',
         f'Kind: {kind}',
         f'Run count: {run_count}',
         '  '.join(label.ljust(widths[index]) for index, (_key, label) in enumerate(columns)).rstrip(),
@@ -163,12 +186,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
     kind = cast('ResultKind', args.kind)
     try:
-        run_count, rows = asyncio.run(_collect(args.database, kind, args.run_id))
+        target, run_count, rows = asyncio.run(_collect(args.database, kind, args.run_id, args.target))
     except LookupError as error:
         parser.error(str(error))
     if args.format == 'json':
-        output = json.dumps({'kind': kind, 'run_count': run_count, 'source_yields': rows}, sort_keys=True) + '\n'
+        payload = {'kind': kind, 'run_count': run_count, 'source_yields': rows}
+        if target is not None:
+            payload['target'] = target
+        else:
+            payload['targets'] = []
+        output = json.dumps(payload, sort_keys=True) + '\n'
     else:
-        output = _table(kind, run_count, rows)
+        output = _table(kind, run_count, rows, target)
     sys.stdout.write(output)
     return 0

--- a/theHarvester/source_yields.py
+++ b/theHarvester/source_yields.py
@@ -11,6 +11,8 @@ from uuid import UUID
 
 from theHarvester.lib.database import ResultStore
 from theHarvester.lib.evidence_types import RESULT_KINDS, ResultKind
+from theHarvester.lib.hostnames import normalize_hostname
+from theHarvester.lib.result_values import normalize_asn, normalize_ip, normalize_prefix
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -25,9 +27,40 @@ def _parser() -> argparse.ArgumentParser:
         help='Existing theHarvester SQLite database (default: %(default)s).',
     )
     parser.add_argument('--kind', choices=sorted(RESULT_KINDS), default='hostname', help='Result kind to compare.')
-    parser.add_argument('--run-id', type=UUID, help='Report one completed run instead of aggregating every run.')
+    scope = parser.add_mutually_exclusive_group()
+    scope.add_argument('--run-id', type=UUID, help='Report one completed run instead of aggregating every run.')
+    scope.add_argument('--list-targets', action='store_true', help='List canonical targets and finalized-run counts.')
     parser.add_argument('--format', choices=('table', 'json'), default='table', help='Output format.')
     return parser
+
+
+def _canonical_target(value: object) -> str:
+    target = str(value).strip()
+    if target[:2].casefold() == 'as' and target[2:].isascii() and target[2:].isdecimal():
+        return normalize_asn(target)
+    if '/' in target:
+        try:
+            return normalize_prefix(target)
+        except ValueError:
+            pass
+    try:
+        return normalize_ip(target, label='target')
+    except ValueError:
+        pass
+    try:
+        hostname = normalize_hostname(target)
+    except ValueError:
+        return target
+    return hostname if '.' in hostname else target
+
+
+async def _list_targets(database: Path) -> list[dict[str, str | int]]:
+    store = ResultStore(database)
+    try:
+        counts = Counter(_canonical_target(run['target']) for run in await store.list_runs(limit=None))
+        return [{'target': target, 'run_count': counts[target]} for target in sorted(counts)]
+    finally:
+        await store.dispose()
 
 
 async def _collect(database: Path, kind: ResultKind, run_id: UUID | None) -> tuple[int, list[dict[str, str | int | float]]]:
@@ -111,11 +144,23 @@ def _table(kind: ResultKind, run_count: int, rows: list[dict[str, str | int | fl
     return '\n'.join(lines) + '\n'
 
 
+def _targets_table(rows: list[dict[str, str | int]]) -> str:
+    target_width = max([len('TARGET'), *(len(str(row['target'])) for row in rows)])
+    lines = [f'{"TARGET".ljust(target_width)}  RUNS'.rstrip()]
+    lines.extend(f'{str(row["target"]).ljust(target_width)}  {row["run_count"]}'.rstrip() for row in rows)
+    return '\n'.join(lines) + '\n'
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = _parser()
     args = parser.parse_args(argv)
     if not args.database.is_file():
         parser.error(f'database does not exist: {args.database}')
+    if args.list_targets:
+        targets = asyncio.run(_list_targets(args.database))
+        output = json.dumps({'targets': targets}, sort_keys=True) + '\n' if args.format == 'json' else _targets_table(targets)
+        sys.stdout.write(output)
+        return 0
     kind = cast('ResultKind', args.kind)
     try:
         run_count, rows = asyncio.run(_collect(args.database, kind, args.run_id))

--- a/theHarvester/source_yields.py
+++ b/theHarvester/source_yields.py
@@ -210,7 +210,8 @@ def _targets_table(rows: list[dict[str, str | int]]) -> str:
 def _tracking_table(payload: dict[str, object]) -> str:
     comparisons = cast('list[dict[str, object]]', payload['comparisons'])
     changes = cast('list[dict[str, object]]', payload['hostname_changes'])
-    lines = [f'Target: {payload["target"]}', f'Comparison count: {payload["comparison_count"]}']
+    scope = f'Target: {payload["target"]}' if payload['target'] is not None else 'Targets: none'
+    lines = [scope, f'Comparison count: {payload["comparison_count"]}']
     summary_columns = (
         ('run_id', 'CURRENT RUN'),
         ('baseline_run_id', 'BASELINE RUN'),
@@ -227,7 +228,7 @@ def _tracking_table(payload: dict[str, object]) -> str:
         }
         for comparison in comparisons
     ]
-    summary_widths = [max(len(label), *(len(str(row[key])) for row in summary_rows)) for key, label in summary_columns]
+    summary_widths = [max([len(label), *(len(str(row[key])) for row in summary_rows)]) for key, label in summary_columns]
     lines.append('  '.join(label.ljust(summary_widths[index]) for index, (_key, label) in enumerate(summary_columns)))
     lines.extend(
         '  '.join(str(row[key]).ljust(summary_widths[index]) for index, (key, _label) in enumerate(summary_columns))

--- a/theHarvester/source_yields.py
+++ b/theHarvester/source_yields.py
@@ -246,7 +246,7 @@ def _tracking_table(payload: dict[str, object]) -> str:
     )
     change_rows = []
     for row in changes:
-        sources = row['current_sources'] if row['change'] in {'new', 'persisting'} else row['previous_sources']
+        sources = row['current_sources'] or row['previous_sources']
         blockers = cast('list[dict[str, object]]', row['blocking_sources'])
         change_rows.append(
             {

--- a/theHarvester/source_yields.py
+++ b/theHarvester/source_yields.py
@@ -31,6 +31,7 @@ def _parser() -> argparse.ArgumentParser:
     scope.add_argument('--run-id', type=UUID, help='Report one completed run instead of aggregating every run.')
     scope.add_argument('--list-targets', action='store_true', help='List canonical targets and finalized-run counts.')
     scope.add_argument('--target', help='Report finalized runs for one exact canonical target.')
+    scope.add_argument('--all-targets', action='store_true', help='Explicitly aggregate finalized runs across all targets.')
     parser.add_argument('--format', choices=('table', 'json'), default='table', help='Output format.')
     return parser
 
@@ -69,16 +70,21 @@ async def _collect(
     kind: ResultKind,
     run_id: UUID | None,
     target: str | None = None,
-) -> tuple[str | None, int, list[dict[str, str | int | float]]]:
+    all_targets: bool = False,
+) -> tuple[str | None, list[dict[str, str | int]], int, list[dict[str, str | int | float]]]:
     store = ResultStore(database)
     try:
+        target_rows: list[dict[str, str | int]] = []
         if run_id is not None:
             selected_target = _canonical_target((await store.load_run(run_id)).target)
             run_ids = [run_id]
         else:
             summaries = await store.list_runs(limit=None)
             selected_target = _canonical_target(target) if target is not None else None
-            if selected_target is not None:
+            if all_targets:
+                counts = Counter(_canonical_target(run['target']) for run in summaries)
+                target_rows = [{'target': value, 'run_count': counts[value]} for value in sorted(counts)]
+            elif selected_target is not None:
                 summaries = [run for run in summaries if _canonical_target(run['target']) == selected_target]
                 if not summaries:
                     raise LookupError(f'target not found: {selected_target}; use --list-targets')
@@ -122,7 +128,7 @@ async def _collect(
                 str(row['source']),
             )
         )
-        return selected_target, len(run_ids), rows
+        return selected_target, target_rows, len(run_ids), rows
     finally:
         await store.dispose()
 
@@ -132,6 +138,7 @@ def _table(
     run_count: int,
     rows: list[dict[str, str | int | float]],
     target: str | None,
+    targets: list[dict[str, str | int]],
 ) -> str:
     columns = [
         ('source', 'SOURCE'),
@@ -155,8 +162,15 @@ def _table(
     widths = [
         max([len(label), *(len(values[index]) for values in formatted_rows)]) for index, (_key, label) in enumerate(columns)
     ]
+    scope_lines = (
+        [f'Target: {target}']
+        if target is not None
+        else ['Scope: all targets', _targets_table(targets).rstrip()]
+        if targets
+        else ['Targets: none']
+    )
     lines = [
-        f'Target: {target}' if target is not None else 'Targets: none',
+        *scope_lines,
         f'Kind: {kind}',
         f'Run count: {run_count}',
         '  '.join(label.ljust(widths[index]) for index, (_key, label) in enumerate(columns)).rstrip(),
@@ -186,7 +200,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
     kind = cast('ResultKind', args.kind)
     try:
-        target, run_count, rows = asyncio.run(_collect(args.database, kind, args.run_id, args.target))
+        target, targets, run_count, rows = asyncio.run(_collect(args.database, kind, args.run_id, args.target, args.all_targets))
     except LookupError as error:
         parser.error(str(error))
     if args.format == 'json':
@@ -194,9 +208,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         if target is not None:
             payload['target'] = target
         else:
-            payload['targets'] = []
+            payload['targets'] = targets
         output = json.dumps(payload, sort_keys=True) + '\n'
     else:
-        output = _table(kind, run_count, rows, target)
+        output = _table(kind, run_count, rows, target, targets)
     sys.stdout.write(output)
     return 0


### PR DESCRIPTION
## Summary

- make `harvest-yields` target-aware with canonical target inventory, safe one-target defaults, and explicit all-target aggregation
- compare persisted hostname evidence across finalized runs with the same canonical target and exact source cohort
- expose new, persisting, missing, and inconclusive changes with source exclusivity and retained DNS evidence through the CLI, REST API, and HarvestView
- document the executable contract in the release context, wiki, API guide, and changelog

## Safety and compatibility

- reporting and tracking read finalized SQLite evidence only; they never start discovery or DNS
- existing aggregate JSON members and source-yield fields remain compatible
- no database schema migration, evidence rewrite, or aggregate JSONL format was added
- tests use RFC-reserved names and TEST-NET addresses

## Verification

- `uv run pytest`: 2,022 passed, 6 skipped
- `uv run pytest -m harvestview_e2e`: 37 passed in real Chromium
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- JavaScript syntax and `git diff --check`
- wheel and sdist builds plus installed `theHarvester` and `harvestview` entry-point smokes
- container build, routes, authentication, JSONL import/export, bundled Chromium, and restart persistence
- final Standards and Spec reviews: no findings

The separate manual Release validation workflow has not been dispatched; the operator deferred it until release preparation.

Related fork issues:

- https://github.com/NotoriousRebel/theHarvester/issues/332
- https://github.com/NotoriousRebel/theHarvester/issues/333
- https://github.com/NotoriousRebel/theHarvester/issues/334
- https://github.com/NotoriousRebel/theHarvester/issues/335
- https://github.com/NotoriousRebel/theHarvester/issues/336
