### PR TITLE
refactor: centralize target identity semantics

### DIFF
--- a/tests/lib/test_target_identity.py
+++ b/tests/lib/test_target_identity.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from theHarvester.lib.target_identity import canonical_target, normalize_target
+from theHarvester.lib.target_identity import normalize_enumeration_target, normalize_saved_target
 
 
 @pytest.mark.parametrize(
@@ -14,8 +14,8 @@ from theHarvester.lib.target_identity import canonical_target, normalize_target
         ('2001:0db8::1', '2001:db8::1'),
     ],
 )
-def test_normalize_target_preserves_execution_admission(value: str, expected: str) -> None:
-    assert normalize_target(value) == expected
+def test_normalize_enumeration_target_preserves_execution_admission(value: str, expected: str) -> None:
+    assert normalize_enumeration_target(value) == expected
 
 
 @pytest.mark.parametrize(
@@ -25,9 +25,9 @@ def test_normalize_target_preserves_execution_admission(value: str, expected: st
         ('192.0.2.0/24', 'Target must be a hostname or IP address'),
     ],
 )
-def test_normalize_target_preserves_current_run_rejections(value: str, message: str) -> None:
+def test_normalize_enumeration_target_preserves_current_run_rejections(value: str, message: str) -> None:
     with pytest.raises(ValueError, match=message):
-        normalize_target(value)
+        normalize_enumeration_target(value)
 
 
 @pytest.mark.parametrize(
@@ -40,5 +40,5 @@ def test_normalize_target_preserves_current_run_rejections(value: str, message: 
         (' Example Company ', 'Example Company'),
     ],
 )
-def test_canonical_target_preserves_persisted_identity(value: object, expected: str) -> None:
-    assert canonical_target(value) == expected
+def test_normalize_saved_target_preserves_persisted_identity(value: object, expected: str) -> None:
+    assert normalize_saved_target(value) == expected

--- a/tests/lib/test_target_identity.py
+++ b/tests/lib/test_target_identity.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from theHarvester.lib.target_identity import canonical_target, normalize_target
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        (' EXAMPLE.TEST. ', 'example.test'),
+        ('AS064496', 'AS64496'),
+        ('BÜCHER.EXAMPLE', 'xn--bcher-kva.example'),
+        ('2001:0db8::1', '2001:db8::1'),
+    ],
+)
+def test_normalize_target_preserves_execution_admission(value: str, expected: str) -> None:
+    assert normalize_target(value) == expected
+
+
+@pytest.mark.parametrize(
+    ('value', 'message'),
+    [
+        ('Example Company', 'Target must be a valid hostname'),
+        ('192.0.2.0/24', 'Target must be a hostname or IP address'),
+    ],
+)
+def test_normalize_target_preserves_current_run_rejections(value: str, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        normalize_target(value)
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        (' EXAMPLE.TEST. ', 'example.test'),
+        ('www.example.test', 'www.example.test'),
+        ('AS064496', 'AS64496'),
+        ('192.0.2.1/24', '192.0.2.0/24'),
+        (' Example Company ', 'Example Company'),
+    ],
+)
+def test_canonical_target_preserves_persisted_identity(value: object, expected: str) -> None:
+    assert canonical_target(value) == expected

--- a/tests/test_source_yields_cli.py
+++ b/tests/test_source_yields_cli.py
@@ -309,7 +309,7 @@ def test_list_targets_rejects_a_run_selector(
     assert 'not allowed with argument' in capsys.readouterr().err
 
 
-def test_target_selects_only_matching_canonical_target(
+def test_target_selects_only_matching_normalized_saved_target(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/theHarvester/lib/api/run_evidence.py
+++ b/theHarvester/lib/api/run_evidence.py
@@ -17,7 +17,7 @@ from theHarvester.lib.network_evidence import (
 from theHarvester.lib.result_values import normalize_prefix
 from theHarvester.lib.shodan_evidence import ShodanHostObservation
 from theHarvester.lib.takeover_evidence import parse_takeover_details
-from theHarvester.lib.target_identity import normalize_target
+from theHarvester.lib.target_identity import normalize_enumeration_target
 
 
 def parse_jsonl_import(body: bytes) -> dict[str, Any]:
@@ -71,7 +71,7 @@ def validate_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
     if not evidence.get('target'):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Result file does not identify a target')
     try:
-        evidence['target'] = normalize_target(str(evidence['target']))
+        evidence['target'] = normalize_enumeration_target(str(evidence['target']))
     except ValueError as error:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
     if evidence.get('status') not in EVIDENCE_STATUSES:

--- a/theHarvester/lib/api/run_evidence.py
+++ b/theHarvester/lib/api/run_evidence.py
@@ -17,8 +17,7 @@ from theHarvester.lib.network_evidence import (
 from theHarvester.lib.result_values import normalize_prefix
 from theHarvester.lib.shodan_evidence import ShodanHostObservation
 from theHarvester.lib.takeover_evidence import parse_takeover_details
-
-from .run_models import _normalize_target
+from theHarvester.lib.target_identity import normalize_target
 
 
 def parse_jsonl_import(body: bytes) -> dict[str, Any]:
@@ -72,7 +71,7 @@ def validate_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
     if not evidence.get('target'):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Result file does not identify a target')
     try:
-        evidence['target'] = _normalize_target(str(evidence['target']))
+        evidence['target'] = normalize_target(str(evidence['target']))
     except ValueError as error:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
     if evidence.get('status') not in EVIDENCE_STATUSES:

--- a/theHarvester/lib/api/run_models.py
+++ b/theHarvester/lib/api/run_models.py
@@ -29,7 +29,7 @@ from theHarvester.lib.source_catalog import (
     hostname_collection_conflicts,
     selected_action_names,
 )
-from theHarvester.lib.target_identity import normalize_target as normalize_enumeration_target
+from theHarvester.lib.target_identity import normalize_enumeration_target
 from theHarvester.lib.virtual_host import (
     DEFAULT_VHOST_CONCURRENCY,
     DEFAULT_VHOST_REQUEST_LIMIT,

--- a/theHarvester/lib/api/run_models.py
+++ b/theHarvester/lib/api/run_models.py
@@ -23,13 +23,13 @@ from theHarvester.lib.hostname_tracking import (  # noqa: TC001 - Pydantic resol
     ResolutionEvidence,
 )
 from theHarvester.lib.resolver_selection import DEFAULT_DNS_RESOLVERS, normalize_resolver_addresses
-from theHarvester.lib.result_values import normalize_asn
 from theHarvester.lib.source_catalog import (
     SOURCE_SPECS,
     ActivityClass,
     hostname_collection_conflicts,
     selected_action_names,
 )
+from theHarvester.lib.target_identity import normalize_target as normalize_enumeration_target
 from theHarvester.lib.virtual_host import (
     DEFAULT_VHOST_CONCURRENCY,
     DEFAULT_VHOST_REQUEST_LIMIT,
@@ -44,33 +44,6 @@ from theHarvester.lib.virtual_host import (
 
 def utc_now() -> str:
     return datetime.now(UTC).isoformat()
-
-
-def _normalize_target(value: str) -> str:
-    target = value.strip().rstrip('.')
-    if target[:2].casefold() == 'as' and target[2:].isascii() and target[2:].isdecimal():
-        return normalize_asn(target)
-    target = target.lower()
-    if not target or len(target) > 253 or any(character in target for character in '/?#@'):
-        raise ValueError('Target must be a hostname or IP address')
-    try:
-        return str(ipaddress.ip_address(target))
-    except ValueError:
-        try:
-            target = target.encode('idna').decode('ascii')
-        except UnicodeError as error:
-            raise ValueError('Target must be a valid hostname') from error
-        labels = target.split('.')
-        if any(
-            not label
-            or len(label) > 63
-            or label.startswith('-')
-            or label.endswith('-')
-            or not all(character.isalnum() or character == '-' for character in label)
-            for label in labels
-        ):
-            raise ValueError('Target must be a valid hostname')
-        return target
 
 
 class RunRequest(BaseModel):
@@ -237,7 +210,7 @@ class RunRequest(BaseModel):
     @field_validator('target')
     @classmethod
     def normalize_target(cls, value: str) -> str:
-        return _normalize_target(value)
+        return normalize_enumeration_target(value)
 
     @field_validator('sources')
     @classmethod

--- a/theHarvester/lib/api/run_store.py
+++ b/theHarvester/lib/api/run_store.py
@@ -22,7 +22,7 @@ from theHarvester.lib.hostname_tracking import hostname_tracking_projection
 from theHarvester.lib.network_evidence import NetworkObservation, parse_network_observation_details
 from theHarvester.lib.shodan_evidence import ShodanHostObservation
 from theHarvester.lib.takeover_evidence import TakeoverCandidateOutcome, parse_takeover_details
-from theHarvester.lib.target_identity import canonical_target, normalize_target
+from theHarvester.lib.target_identity import normalize_enumeration_target, normalize_saved_target
 
 from .run_artifacts import RunPaths, read_child_evidence
 from .run_models import RunRequest, utc_now
@@ -265,7 +265,7 @@ class RunStore:
                     )
                     if evidence
                     else {
-                        'target': canonical_target(record['target']),
+                        'target': normalize_saved_target(record['target']),
                         'comparison_count': 0,
                         'comparisons': [],
                         'hostname_changes': [],
@@ -296,7 +296,7 @@ class RunStore:
     async def import_evidence(self, evidence: dict[str, Any], filename: str) -> dict[str, Any]:
         await self.initialize()
         created_at = utc_now()
-        target = normalize_target(str(evidence['target']))
+        target = normalize_enumeration_target(str(evidence['target']))
         source_run_id = str(evidence['run_id'])
         run_id = str(uuid4())
         try:

--- a/theHarvester/lib/api/run_store.py
+++ b/theHarvester/lib/api/run_store.py
@@ -18,13 +18,14 @@ from theHarvester.lib.completed_result import (
 )
 from theHarvester.lib.database import DuplicateRunError, ResultStore, ResultStoreError, RunLifecycleStore
 from theHarvester.lib.evidence_types import EXECUTION_STATUSES, EvidenceStatus, ExecutionStatus, ResultKind
-from theHarvester.lib.hostname_tracking import canonical_target, hostname_tracking_projection
+from theHarvester.lib.hostname_tracking import hostname_tracking_projection
 from theHarvester.lib.network_evidence import NetworkObservation, parse_network_observation_details
 from theHarvester.lib.shodan_evidence import ShodanHostObservation
 from theHarvester.lib.takeover_evidence import TakeoverCandidateOutcome, parse_takeover_details
+from theHarvester.lib.target_identity import canonical_target, normalize_target
 
 from .run_artifacts import RunPaths, read_child_evidence
-from .run_models import RunRequest, _normalize_target, utc_now
+from .run_models import RunRequest, utc_now
 from .run_projection import activities_for_evidence, activities_for_request, normalized_results, screenshots, source_executions
 
 if TYPE_CHECKING:
@@ -295,7 +296,7 @@ class RunStore:
     async def import_evidence(self, evidence: dict[str, Any], filename: str) -> dict[str, Any]:
         await self.initialize()
         created_at = utc_now()
-        target = _normalize_target(str(evidence['target']))
+        target = normalize_target(str(evidence['target']))
         source_run_id = str(evidence['run_id'])
         run_id = str(uuid4())
         try:

--- a/theHarvester/lib/api/schedule_models.py
+++ b/theHarvester/lib/api/schedule_models.py
@@ -7,7 +7,9 @@ from typing import Literal, Self
 from dateutil.tz import datetime_exists, gettz, resolve_imaginary
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from .run_models import RunRequest, _normalize_target
+from theHarvester.lib.target_identity import normalize_target
+
+from .run_models import RunRequest
 
 MAX_SCHEDULE_TARGETS = 10_000
 ScheduleFrequency = Literal['once', 'hourly', 'daily', 'weekly', 'monthly']
@@ -215,7 +217,7 @@ class ScheduleCreate(BaseModel):
     @field_validator('targets')
     @classmethod
     def normalize_targets(cls, values: list[str]) -> list[str]:
-        normalized = [_normalize_target(value) for value in values]
+        normalized = [normalize_target(value) for value in values]
         if len(normalized) != len(set(normalized)):
             raise ValueError('targets must not contain duplicates')
         return normalized

--- a/theHarvester/lib/api/schedule_models.py
+++ b/theHarvester/lib/api/schedule_models.py
@@ -7,7 +7,7 @@ from typing import Literal, Self
 from dateutil.tz import datetime_exists, gettz, resolve_imaginary
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from theHarvester.lib.target_identity import normalize_target
+from theHarvester.lib.target_identity import normalize_enumeration_target
 
 from .run_models import RunRequest
 
@@ -217,7 +217,7 @@ class ScheduleCreate(BaseModel):
     @field_validator('targets')
     @classmethod
     def normalize_targets(cls, values: list[str]) -> list[str]:
-        normalized = [normalize_target(value) for value in values]
+        normalized = [normalize_enumeration_target(value) for value in values]
         if len(normalized) != len(set(normalized)):
             raise ValueError('targets must not contain duplicates')
         return normalized

--- a/theHarvester/lib/hostname_tracking.py
+++ b/theHarvester/lib/hostname_tracking.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 from uuid import UUID
 
-from theHarvester.lib.target_identity import canonical_target
+from theHarvester.lib.target_identity import normalize_saved_target
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -107,19 +107,19 @@ async def hostname_tracking_projection(
     summaries = await store.list_runs(limit=None)
     if run_id is not None:
         current = await store.load_hostname_tracking_run(run_id)
-        selected_target = canonical_target(current.target)
+        selected_target = normalize_saved_target(current.target)
         selected_ids = {run_id}
     elif target is not None:
-        selected_target = canonical_target(target)
+        selected_target = normalize_saved_target(target)
         selected_ids = {
-            UUID(str(summary['run_id'])) for summary in summaries if canonical_target(summary['target']) == selected_target
+            UUID(str(summary['run_id'])) for summary in summaries if normalize_saved_target(summary['target']) == selected_target
         }
     else:
         raise ValueError('target or run_id is required')
     target_runs = [
         await store.load_hostname_tracking_run(UUID(str(summary['run_id'])))
         for summary in summaries
-        if canonical_target(summary['target']) == selected_target
+        if normalize_saved_target(summary['target']) == selected_target
     ]
     target_runs.sort(key=lambda run: (run.completed_at, str(run.run_id)))
     previous_by_cohort: dict[tuple[str, ...], TrackingRunEvidence] = {}

--- a/theHarvester/lib/hostname_tracking.py
+++ b/theHarvester/lib/hostname_tracking.py
@@ -4,8 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 from uuid import UUID
 
-from theHarvester.lib.hostnames import normalize_hostname
-from theHarvester.lib.result_values import normalize_asn, normalize_ip, normalize_prefix
+from theHarvester.lib.target_identity import canonical_target
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -16,26 +15,6 @@ if TYPE_CHECKING:
 
 ChangeStatus = Literal['new', 'persisting', 'missing', 'inconclusive']
 ResolutionEvidence = Literal['positive', 'not-retained', 'not-checked']
-
-
-def canonical_target(value: object) -> str:
-    target = str(value).strip()
-    if target[:2].casefold() == 'as' and target[2:].isascii() and target[2:].isdecimal():
-        return normalize_asn(target)
-    if '/' in target:
-        try:
-            return normalize_prefix(target)
-        except ValueError:
-            pass
-    try:
-        return normalize_ip(target, label='target')
-    except ValueError:
-        pass
-    try:
-        hostname = normalize_hostname(target)
-    except ValueError:
-        return target
-    return hostname if '.' in hostname else target
 
 
 @dataclass(frozen=True, slots=True)

--- a/theHarvester/lib/target_identity.py
+++ b/theHarvester/lib/target_identity.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import ipaddress
+
+from theHarvester.lib.hostnames import normalize_hostname
+from theHarvester.lib.result_values import normalize_asn, normalize_ip, normalize_prefix
+
+
+def normalize_target(value: str) -> str:
+    """Preserve the target forms currently accepted by run intake."""
+    target = value.strip().rstrip('.')
+    if target[:2].casefold() == 'as' and target[2:].isascii() and target[2:].isdecimal():
+        return normalize_asn(target)
+    target = target.lower()
+    if not target or len(target) > 253 or any(character in target for character in '/?#@'):
+        raise ValueError('Target must be a hostname or IP address')
+    try:
+        return str(ipaddress.ip_address(target))
+    except ValueError:
+        try:
+            return normalize_hostname(target)
+        except ValueError as error:
+            raise ValueError('Target must be a valid hostname') from error
+
+
+def canonical_target(value: object) -> str:
+    """Canonicalize persisted target identity without rejecting legacy free text."""
+    target = str(value).strip()
+    if target[:2].casefold() == 'as' and target[2:].isascii() and target[2:].isdecimal():
+        return normalize_asn(target)
+    if '/' in target:
+        try:
+            return normalize_prefix(target)
+        except ValueError:
+            pass
+    try:
+        return normalize_ip(target, label='target')
+    except ValueError:
+        pass
+    try:
+        hostname = normalize_hostname(target)
+    except ValueError:
+        return target
+    return hostname if '.' in hostname else target

--- a/theHarvester/lib/target_identity.py
+++ b/theHarvester/lib/target_identity.py
@@ -6,8 +6,8 @@ from theHarvester.lib.hostnames import normalize_hostname
 from theHarvester.lib.result_values import normalize_asn, normalize_ip, normalize_prefix
 
 
-def normalize_target(value: str) -> str:
-    """Preserve the target forms currently accepted by run intake."""
+def normalize_enumeration_target(value: str) -> str:
+    """Normalize a target accepted for a new enumeration run."""
     target = value.strip().rstrip('.')
     if target[:2].casefold() == 'as' and target[2:].isascii() and target[2:].isdecimal():
         return normalize_asn(target)
@@ -23,8 +23,8 @@ def normalize_target(value: str) -> str:
             raise ValueError('Target must be a valid hostname') from error
 
 
-def canonical_target(value: object) -> str:
-    """Canonicalize persisted target identity without rejecting legacy free text."""
+def normalize_saved_target(value: object) -> str:
+    """Normalize a saved target without rejecting legacy free text."""
     target = str(value).strip()
     if target[:2].casefold() == 'as' and target[2:].isascii() and target[2:].isdecimal():
         return normalize_asn(target)

--- a/theHarvester/source_yields.py
+++ b/theHarvester/source_yields.py
@@ -12,7 +12,7 @@ from uuid import UUID
 from theHarvester.lib.database import ResultStore
 from theHarvester.lib.evidence_types import RESULT_KINDS, ResultKind
 from theHarvester.lib.hostname_tracking import hostname_tracking_projection
-from theHarvester.lib.target_identity import canonical_target
+from theHarvester.lib.target_identity import normalize_saved_target
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -60,7 +60,7 @@ Change reports read finalized local evidence only and never run discovery or DNS
 async def _list_targets(database: Path) -> list[dict[str, str | int]]:
     store = ResultStore(database)
     try:
-        counts = Counter(canonical_target(run['target']) for run in await store.list_runs(limit=None))
+        counts = Counter(normalize_saved_target(run['target']) for run in await store.list_runs(limit=None))
         return [{'target': target, 'run_count': counts[target]} for target in sorted(counts)]
     finally:
         await store.dispose()
@@ -96,20 +96,20 @@ async def _collect(
     try:
         target_rows: list[dict[str, str | int]] = []
         if run_id is not None:
-            selected_target = canonical_target((await store.load_run(run_id)).target)
+            selected_target = normalize_saved_target((await store.load_run(run_id)).target)
             run_ids = [run_id]
         else:
             summaries = await store.list_runs(limit=None)
-            selected_target = canonical_target(target) if target is not None else None
+            selected_target = normalize_saved_target(target) if target is not None else None
             if all_targets:
-                counts = Counter(canonical_target(run['target']) for run in summaries)
+                counts = Counter(normalize_saved_target(run['target']) for run in summaries)
                 target_rows = [{'target': value, 'run_count': counts[value]} for value in sorted(counts)]
             elif selected_target is not None:
-                summaries = [run for run in summaries if canonical_target(run['target']) == selected_target]
+                summaries = [run for run in summaries if normalize_saved_target(run['target']) == selected_target]
                 if not summaries:
                     raise LookupError(f'target not found: {selected_target}; use --list-targets')
             else:
-                targets = {canonical_target(run['target']) for run in summaries}
+                targets = {normalize_saved_target(run['target']) for run in summaries}
                 if len(targets) > 1:
                     raise LookupError(f'database contains {len(targets)} canonical targets; use --list-targets')
                 selected_target = next(iter(targets), None)

--- a/theHarvester/source_yields.py
+++ b/theHarvester/source_yields.py
@@ -11,7 +11,8 @@ from uuid import UUID
 
 from theHarvester.lib.database import ResultStore
 from theHarvester.lib.evidence_types import RESULT_KINDS, ResultKind
-from theHarvester.lib.hostname_tracking import canonical_target, hostname_tracking_projection
+from theHarvester.lib.hostname_tracking import hostname_tracking_projection
+from theHarvester.lib.target_identity import canonical_target
 
 if TYPE_CHECKING:
     from collections.abc import Sequence


### PR DESCRIPTION
## Problem

Enumeration targets and saved targets follow different rules, but the shared helpers did not make that distinction obvious. New runs must reject invalid targets. Historical records still need to load legacy free text.

## Change

- centralize both policies in `target_identity`
- name the strict helper `normalize_enumeration_target`
- name the permissive helper `normalize_saved_target`
- route API models, imported run evidence, schedules, hostname comparison, and saved-run reporting through those helpers
- remove the duplicate private normalization code

This is behavior-preserving. It does not change the CLI, REST API, persistence format, schema, or discovery-source identifiers.

## Validation

- affected target, schedule, reporting, REST, and persistence tests: 228 passed
- full configured non-browser suite: 2,033 passed, 6 skipped, 37 browser tests deselected
- `uv run ruff check .`: passed
- `uv run ruff format --check .`: passed
- `uv run ty check`: passed
- `git diff --check`: passed

This PR remains a separate draft so the target-identity seam can be reviewed independently from the 5.0 release work.