### PR TITLE
fix: validate HarvestView log levels before starting Uvicorn

### DIFF
--- a/tests/test_harvestview_log_level.py
+++ b/tests/test_harvestview_log_level.py
@@ -1,0 +1,48 @@
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+from theHarvester import harvestview
+
+
+@pytest.mark.parametrize('option', ['-l', '--log-level'])
+@pytest.mark.parametrize('value', ['nonsense', ''])
+def test_invalid_log_level_is_rejected_before_server_start(monkeypatch, capsys, option, value):
+    run = Mock()
+    monkeypatch.setattr(harvestview.uvicorn, 'run', run)
+    monkeypatch.setattr(sys, 'argv', ['harvestview', option, value])
+
+    with pytest.raises(SystemExit) as exit_info:
+        harvestview.main()
+
+    assert exit_info.value.code == 2
+    run.assert_not_called()
+    error = capsys.readouterr().err
+    assert 'invalid choice' in error
+    assert 'warning' in error
+    assert 'Traceback' not in error
+
+
+@pytest.mark.parametrize('level', ['critical', 'error', 'warning', 'info', 'debug', 'trace'])
+@pytest.mark.parametrize('uppercase', [False, True])
+def test_valid_log_levels_remain_case_insensitive(monkeypatch, level, uppercase):
+    run = Mock()
+    monkeypatch.setattr(harvestview.uvicorn, 'run', run)
+    monkeypatch.setattr(sys, 'argv', ['harvestview', '--log-level', level.upper() if uppercase else level])
+
+    harvestview.main()
+
+    run.assert_called_once()
+    assert run.call_args.kwargs['log_level'] == level
+
+
+def test_log_level_defaults_to_info(monkeypatch):
+    run = Mock()
+    monkeypatch.setattr(harvestview.uvicorn, 'run', run)
+    monkeypatch.setattr(sys, 'argv', ['harvestview'])
+
+    harvestview.main()
+
+    run.assert_called_once()
+    assert run.call_args.kwargs['log_level'] == 'info'

--- a/theHarvester/harvestview.py
+++ b/theHarvester/harvestview.py
@@ -1,6 +1,7 @@
 import argparse
 
 import uvicorn
+from uvicorn.config import LOG_LEVELS
 
 
 def main():
@@ -22,6 +23,8 @@ def main():
         '-l',
         '--log-level',
         default='info',
+        type=str.lower,
+        choices=tuple(LOG_LEVELS),
         help='Set logging level, default is info but [critical|error|warning|info|debug|trace] can be set',
     )
     parser.add_argument(


### PR DESCRIPTION
`uv run harvestview --log-level nonsense` currently raises an uncaught `KeyError` in Uvicorn. Validate the value in argparse so unsupported or empty levels produce a usage error with the accepted choices and exit with status 2 before the server starts.

Reuse Uvicorn's `LOG_LEVELS` and lowercase the input before validation, preserving valid uppercase inputs such as `INFO` and the default `info` level. Add focused coverage for both flag spellings, invalid inputs, every supported level in lower/uppercase, and the default.

Fixes #2601.

### Validation

- Confirmed the four invalid-input regression cases fail before the fix.
- `uv run pytest tests/test_harvestview_log_level.py tests/test_harvestview_launcher.py -q`: 19 passed.
- `uv run pytest -q`: 2,053 passed, 6 skipped, 41 deselected (default non-browser suite).
- `uv run ruff check . tests/test_harvestview_log_level.py`
- `uv run ruff format --check . tests/test_harvestview_log_level.py`
- `uv run ty check`
- `git diff --check`

Verified on Ubuntu under WSL 2 with Python 3.14.4. The new tests mock server startup and require no credentials or network access.
