### PR TITLE
fix: preserve provider outcomes and session state for 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the nonfunctional ThreatCrowd source because its service hostnames terminate at deleted AWS load balancers and return NXDOMAIN; OTX remains available through its separate adapter.
 
 ### Fixed
+- Preserved provider HTTP, transport, and malformed-response failures in saved source outcomes so incomplete collection remains uncertain in hostname comparisons; restored JSON response decoding for DeHashed and Leak-Lookup.
 - Made explicit proxy mode fail closed with a sanitized `proxy-unavailable` source outcome, and kept one proxy identity and session across the CriminalIP scan, poll, and report conversation.
 - Reused one connection pool, proxy identity, and cookie jar across Censys and GitHub Code pagination while keeping provider sessions isolated and cancellation-safe.
 - Sent a stable, versioned theHarvester identity with provider and API requests while preserving explicit browser identities for sources that require them.

--- a/docs/wiki/Moving-from-4.11-to-5.0.md
+++ b/docs/wiki/Moving-from-4.11-to-5.0.md
@@ -1,6 +1,6 @@
 # Moving from 4.11 to 5.0
 
-Version 5.0 is still under development on `dev`. This guide covers the changes from 4.11 so you can prepare before the release.
+Version 5.0 is still under development on `dev`. This guide compares the released [4.11.1 tag](https://github.com/laramies/theHarvester/tree/4.11.1) with the current development interfaces so you can update existing commands and REST automation before the release.
 
 ## Update the runtime first
 
@@ -12,6 +12,103 @@ uv run theHarvester --help
 ```
 
 See [Installation](Installation) for platform steps and browser dependencies.
+
+## Replace the REST launcher
+
+Replace `uv run restfulHarvest` with `uv run harvestview` in service definitions and startup scripts. The installed `restfulHarvest` command and `python -m theHarvester.restfulHarvest` module are gone. For a module invocation, use `uv run python -m theHarvester.harvestview`.
+
+```bash
+export THEHARVESTER_API_KEY="$(openssl rand -hex 32)"
+uv run harvestview --host 127.0.0.1 --port 5000
+```
+
+Configure the same operator key in the service and its clients. Every `/api/v1/*` request requires `X-API-Key`; provider credentials belong in server-side configuration, not the request body. See [Configuration and API Keys](Configuration-and-API-Keys).
+
+`--host`, `--port`, `--log-level`, and `--reload` remain launcher options. Remove `--rate-limit` and `API_RATE_LIMIT`: the built-in request limiter has no replacement in HarvestView. If your deployment relied on it, enforce request limits outside the application. The default address remains `127.0.0.1:5000`; `/` now opens HarvestView, and `/docs`, `/redoc`, and `/openapi.json` describe the current API.
+
+## Migrate REST requests and response parsing
+
+The unversioned enumeration routes and `/additional/*` provider routes from 4.11.1 are removed. Use these replacements:
+
+| Released 4.11.1 request | Current replacement |
+| --- | --- |
+| `GET /sources` | `GET /api/v1/sources`; source entries are objects, so read `.sources[].name` instead of `.sources[]`. Entries also describe capabilities, activity, and credentials. |
+| `GET /query?domain=example.test&source=crtsh` | `POST /api/v1/runs` with `{"target":"example.test","sources":["crtsh"]}`. |
+| `GET /dnsbrute?domain=example.test` | `POST /api/v1/runs` with `{"target":"example.test","sources":[],"dns_brute":true}`. This enables P1 DNS interaction. |
+| `POST /additional/breaches` | Submit a run with `"sources":["haveibeenpwned"]`. For verified-domain email data, review `hibpverified` and its separate credential requirements. |
+| `POST /additional/leaks` | Submit a run with `"sources":["leaklookup"]`. |
+| `POST /additional/security-score` | `"sources":["securityscorecard"]` returns hostname/IP evidence. The old score, grades, issues, and recommendations payload has no current API equivalent. |
+| `POST /additional/tech-stack` | Use `"sources":["builtwith"]`. Replace the grouped `tech_stack` parser with `.results[]` types `framework`, `language`, `server`, `cms`, and `analytics`; `interesting_urls` becomes `url`, alongside `hostname` findings. |
+| `POST /additional/all` | No exact replacement. Select `haveibeenpwned`, `leaklookup`, `securityscorecard`, and `builtwith` for their current findings. The old route also resolved hosts and queried Shodan; review the separate `dns_resolve` and `shodan` actions if needed. Their results do not reproduce `shodan_data`. `"sources":["all"]` selects all P0 sources, a much broader request. |
+
+For every provider replacement, include `target` and consume the current source's normalized findings. The old `{status, data}` provider response and its provider-specific fields are not preserved.
+
+Move query parameters into the JSON body. Rename `domain` to `target` and `source` to the `sources` array. `limit`, `start`, `proxies`, `shodan`, `dns_brute`, `dns_lookup`, and `api_scan` keep their names. Other request changes are:
+
+| Released request field | Current request field or action |
+| --- | --- |
+| `dns_server` or a resolver string in `dns_resolve` | `dns_resolvers`, an array of literal resolver IPs. `dns_resolve` is now a Boolean that enables hostname resolution. Server-side file paths are not accepted as resolver values. |
+| `take_over` | `takeover`, a Boolean. |
+| `wordlist` | `api_scan_paths`, an array of endpoint paths such as `["/api", "/health"]`; enable `api_scan` to use it. The API does not read a client-supplied wordlist file. |
+| `filename` | Download `GET /api/v1/runs/{run_id}/export` and choose the local output filename. |
+| `api_keys` in `/additional/*` bodies | Configure provider keys on the server; authenticate the request with the operator's `X-API-Key`. |
+
+Unknown body fields are rejected. Use the [REST API guide](Rest-API) and the running service's OpenAPI document for exact request and response schemas.
+
+For example, this replaces a `/query` call. `example.test` is a reserved placeholder; substitute an authorized target before executing. The local POST queues a run that contacts `crtsh`.
+
+```bash
+run_id="$(curl --fail-with-body -sS http://127.0.0.1:5000/api/v1/runs \
+  -H "X-API-Key: $THEHARVESTER_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"target":"example.test","sources":["crtsh"],"limit":100}' \
+  | jq -er '.run_id')"
+
+curl --fail-with-body -sS "http://127.0.0.1:5000/api/v1/runs/$run_id" \
+  -H "X-API-Key: $THEHARVESTER_API_KEY" \
+  | jq '{status, evidence_status, results, source_executions}'
+```
+
+A successful POST returns HTTP 201 and a durable `run_id`, not completed findings. Poll the run's GET endpoint until `status` is `completed`, `failed`, or `cancelled`; `queued`, `running`, and `cancelling` are intermediate states. Read `evidence_status` and producer outcomes separately: a terminal run may retain partial evidence.
+
+Replace old grouped response parsing such as `.hosts[]`, `.ips[]`, and `.emails[]` with normalized `.results[]` records. After the run is terminal, extract hostnames and download JSONL like this:
+
+```bash
+curl --fail-with-body -sS "http://127.0.0.1:5000/api/v1/runs/$run_id" \
+  -H "X-API-Key: $THEHARVESTER_API_KEY" \
+  | jq -r '.results[] | select(.type == "hostname") | .value'
+
+curl --fail-with-body -sS "http://127.0.0.1:5000/api/v1/runs/$run_id/export" \
+  -H "X-API-Key: $THEHARVESTER_API_KEY" \
+  -o report.jsonl
+```
+
+Use result types `ip`, `email`, `asn`, `url`, or `person` for the corresponding records. Old social/provider-specific arrays have no guaranteed one-to-one replacement; consult each source's capabilities and the [result format](Results-and-Local-Data).
+
+## Update CLI options and source selections
+
+`-e` / `--dns-server` is removed. It was unused in 4.11.1. Use `--dns-resolvers IPS_OR_FILE` to select resolvers for enabled DNS actions without also enabling hostname resolution. Pass comma-separated literal IPs or a text file with one IP per line. `-r` / `--dns-resolve [IPS_OR_FILE]` still enables hostname resolution and can select resolvers; do not supply resolver values through both options.
+
+This replacement for `-e` selects a resolver for DNS brute force. Both the target and resolver below are reserved placeholders; substitute your authorized domain and resolver before running this P1 command:
+
+```console
+uv run theHarvester -d example.test --dns-brute --dns-resolvers 192.0.2.53
+```
+
+Update explicit `-b` / `--source` lists and REST `sources` arrays against the [current source catalog](https://github.com/laramies/theHarvester/blob/dev/README.md#discovery-sources), also available through authenticated `GET /api/v1/sources`:
+
+| Released identifier | Migration |
+| --- | --- |
+| `chaos` | Use `projectdiscovery`, the same dataset and credential. `chaos` is no longer an alias. |
+| `zoomeyeapi` | Use the supported `zoomeye` source; the old identifier had no working dispatch. |
+| `bitbucket` | Removed from domain discovery with no equivalent provider. Choose an appropriate current source, or use Bitbucket separately with an explicit workspace/repository scope. |
+| `threatcrowd` | Removed. `otx` is a supported alternative with its own data and behavior, not an alias or identical dataset. |
+| `venacus` | Removed with no direct replacement; choose current providers by the capabilities your workflow needs. |
+| `linkedin`, `linkedin_links`, `netcraft`, `omnisint`, `sublist3r` | Removed legacy identifiers with no direct replacement. Select supported sources by capability; old names are not compatibility aliases. |
+
+For example, change `-b chaos` to `-b projectdiscovery`, or `"sources":["chaos"]` to `"sources":["projectdiscovery"]`. Case-insensitive spellings of retained names still work; the catalog preserves canonical names such as `securityTrails` and `shodanInternetDB` in results.
+
+Review `-b all` and capability selections before reuse. `all` now selects every P0 source and excludes P1/P2 sources; explicitly select other sources only when their activity is authorized. Capability selectors such as `emails` choose sources and retain all result types those sources return. For a fixed provider set, enumerate its names.
 
 ## Use the right result format
 
@@ -75,6 +172,9 @@ These labels do not express importance or confidence. Check [Responsible Use and
 ## Migration checklist
 
 - Install Python 3.14 and refresh the `uv` environment.
+- Replace `restfulHarvest` with `harvestview`, configure the operator key, and remove obsolete rate-limit settings.
+- Replace legacy REST routes and fields, then poll runs and parse normalized results.
+- Replace `-e` / `--dns-server` and removed source names; review what `all` selects.
 - Move new automation to JSONL, SQLite, or the authenticated API.
 - Use `hostname`, `ip`, and `url` to filter JSONL findings.
 - Use `harvest-report` for saved-run contributions and hostname comparisons.

--- a/tests/discovery/test_hudsonrock.py
+++ b/tests/discovery/test_hudsonrock.py
@@ -1,15 +1,22 @@
+from __future__ import annotations
+
+import asyncio
 import json
 import logging
 import sys
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from theHarvester import __main__ as theharvester_main
 from theHarvester.discovery import hudsonrocksearch
-from theHarvester.lib.completed_result import CompletedResult
 from theHarvester.lib.core import FetcherResponse
+from theHarvester.lib.source_execution import SourceExecutionReport
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from theHarvester.lib.completed_result import CompletedResult
 
 
 @pytest.mark.asyncio
@@ -39,11 +46,12 @@ async def test_rate_limited_domain_search_recovers_without_trailing_delay(monkey
     monkeypatch.setattr(hudsonrocksearch.asyncio, 'sleep', fake_sleep)
     search = hudsonrocksearch.SearchHudsonRock('example.com')
 
-    await search.process()
+    report = await search.process()
 
     assert await search.get_hostnames() == {'portal.example.com'}
     assert calls == 2
     assert sleeps == [0]
+    assert report is None
 
 
 @pytest.mark.asyncio
@@ -78,13 +86,14 @@ async def test_email_search_preserves_normalized_getters(monkeypatch: pytest.Mon
     monkeypatch.setattr(hudsonrocksearch.asyncio, 'sleep', fake_sleep)
     search = hudsonrocksearch.SearchHudsonRock('analyst@example.com')
 
-    await search.process()
+    report = await search.process()
 
     assert await search.get_hostnames() == {'portal.example.com'}
     assert await search.get_ips() == {'192.0.2.4'}
     assert await search.get_emails() == {'analyst@example.com'}
     assert len(await search.get_infostealers()) == 1
     assert sleeps == [1.0]
+    assert report is None
 
 
 @pytest.mark.asyncio
@@ -109,9 +118,10 @@ async def test_domain_search_ignores_malformed_url_items(monkeypatch: pytest.Mon
     monkeypatch.setattr(hudsonrocksearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
     search = hudsonrocksearch.SearchHudsonRock('example.com')
 
-    await search.process()
+    report = await search.process()
 
     assert await search.get_hostnames() == {'portal.example.com'}
+    assert report == SourceExecutionReport('partial', 'invalid-response')
 
 
 @pytest.mark.asyncio
@@ -137,10 +147,11 @@ async def test_email_search_ignores_malformed_stealer_items(monkeypatch: pytest.
     monkeypatch.setattr(hudsonrocksearch.asyncio, 'sleep', no_sleep)
     search = hudsonrocksearch.SearchHudsonRock('analyst@example.com')
 
-    await search.process()
+    report = await search.process()
 
     assert await search.get_ips() == {'192.0.2.5'}
     assert len(await search.get_infostealers()) == 1
+    assert report == SourceExecutionReport('partial', 'invalid-response')
 
 
 @pytest.mark.asyncio
@@ -156,20 +167,70 @@ async def test_empty_email_search_does_not_invent_a_result(monkeypatch: pytest.M
     monkeypatch.setattr(hudsonrocksearch.asyncio, 'sleep', no_sleep)
     search = hudsonrocksearch.SearchHudsonRock('analyst@example.com')
 
-    await search.process()
+    report = await search.process()
 
     assert await search.get_hostnames() == set()
     assert await search.get_ips() == set()
     assert await search.get_emails() == set()
     assert await search.get_infostealers() == []
+    assert report is None
+
+
+@pytest.mark.asyncio
+async def test_email_search_retains_domain_results_when_email_request_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch_all(urls: list[str], **_kwargs: Any) -> list[FetcherResponse]:
+        assert _kwargs['proxy'] is True
+        if 'search-by-domain' in urls[0]:
+            return [FetcherResponse({'data': {'employees_urls': [{'url': 'https://portal.example.com/login'}]}}, 200, {})]
+        return [FetcherResponse({}, 503, {})]
+
+    async def no_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(hudsonrocksearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(hudsonrocksearch.asyncio, 'sleep', no_sleep)
+    search = hudsonrocksearch.SearchHudsonRock('analyst@example.com')
+
+    report = await search.process(proxy=True)
+
+    assert await search.get_hostnames() == {'portal.example.com'}
+    assert report == SourceExecutionReport('partial', 'http-503')
+
+
+@pytest.mark.asyncio
+async def test_search_transport_failure_and_cancellation_are_distinct(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def failed(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        raise OSError('provider-secret')
+
+    async def no_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(hudsonrocksearch.AsyncFetcher, 'fetch_all', failed)
+    monkeypatch.setattr(hudsonrocksearch.asyncio, 'sleep', no_sleep)
+    assert await hudsonrocksearch.SearchHudsonRock('example.com').process() == SourceExecutionReport('failed', 'transport-error')
+
+    async def cancelled(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        raise asyncio.CancelledError('operator-stop')
+
+    monkeypatch.setattr(hudsonrocksearch.AsyncFetcher, 'fetch_all', cancelled)
+    with pytest.raises(asyncio.CancelledError, match='operator-stop'):
+        await hudsonrocksearch.SearchHudsonRock('analyst@example.com').process()
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ('response', 'expected_log'),
+    ('response', 'expected_log', 'expected_report'),
     [
-        (FetcherResponse(body={'error': 'forbidden'}, status=403, headers={}), 'failed with HTTP 403'),
-        (FetcherResponse(body=['not-an-object'], status=200, headers={}), 'Invalid response format'),
+        (
+            FetcherResponse(body={'error': 'forbidden'}, status=403, headers={}),
+            'failed with HTTP 403',
+            SourceExecutionReport('failed', 'access-denied'),
+        ),
+        (
+            FetcherResponse(body=['not-an-object'], status=200, headers={}),
+            'Invalid response format',
+            SourceExecutionReport('failed', 'invalid-response'),
+        ),
     ],
 )
 async def test_terminal_domain_responses_are_attributed_without_retry(
@@ -177,6 +238,7 @@ async def test_terminal_domain_responses_are_attributed_without_retry(
     caplog: pytest.LogCaptureFixture,
     response: FetcherResponse,
     expected_log: str,
+    expected_report: SourceExecutionReport,
 ) -> None:
     calls = 0
 
@@ -189,11 +251,12 @@ async def test_terminal_domain_responses_are_attributed_without_retry(
     search = hudsonrocksearch.SearchHudsonRock('example.com')
 
     with caplog.at_level(logging.INFO, logger=hudsonrocksearch.__name__):
-        await search.process()
+        report = await search.process()
 
     assert await search.get_hostnames() == set()
     assert calls == 1
     assert expected_log in caplog.text
+    assert report == expected_report
 
 
 @pytest.mark.asyncio

--- a/tests/discovery/test_hudsonrock.py
+++ b/tests/discovery/test_hudsonrock.py
@@ -5,6 +5,7 @@ import json
 import logging
 import sys
 from typing import TYPE_CHECKING, Any
+from unittest.mock import ANY, AsyncMock
 
 import pytest
 
@@ -36,7 +37,7 @@ async def test_rate_limited_domain_search_recovers_without_trailing_delay(monkey
         nonlocal calls
         calls += 1
         assert urls == ['https://cavalier.hudsonrock.com/api/json/v2/osint-tools/search-by-domain?domain=example.com']
-        assert kwargs == {'json': True, 'proxy': False, 'include_metadata': True}
+        assert kwargs == {'json': True, 'session': ANY, 'include_metadata': True}
         return [responses.pop(0)]
 
     async def fake_sleep(delay: float) -> None:
@@ -59,7 +60,7 @@ async def test_email_search_preserves_normalized_getters(monkeypatch: pytest.Mon
     sleeps: list[float] = []
 
     async def fake_fetch_all(urls: list[str], **kwargs: Any) -> list[FetcherResponse]:
-        assert kwargs == {'json': True, 'proxy': False, 'include_metadata': True}
+        assert kwargs == {'json': True, 'session': ANY, 'include_metadata': True}
         if urls[0].endswith('search-by-domain?domain=example.com'):
             return [FetcherResponse(body={'data': {'employees_urls': []}}, status=200, headers={})]
         assert urls[0].endswith('search-by-email?email=analyst@example.com')
@@ -178,8 +179,13 @@ async def test_empty_email_search_does_not_invent_a_result(monkeypatch: pytest.M
 
 @pytest.mark.asyncio
 async def test_email_search_retains_domain_results_when_email_request_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = AsyncMock()
+    build_session = AsyncMock(return_value=session)
+    monkeypatch.setattr(hudsonrocksearch.AsyncFetcher, '_build_session', build_session)
+    monkeypatch.setattr(hudsonrocksearch.AsyncFetcher, '_resolve_proxy', lambda proxy: ('http://proxy.example:8080', 'http'))
+
     async def fake_fetch_all(urls: list[str], **_kwargs: Any) -> list[FetcherResponse]:
-        assert _kwargs['proxy'] is True
+        assert _kwargs['session'] is session and 'proxy' not in _kwargs
         if 'search-by-domain' in urls[0]:
             return [FetcherResponse({'data': {'employees_urls': [{'url': 'https://portal.example.com/login'}]}}, 200, {})]
         return [FetcherResponse({}, 503, {})]
@@ -195,6 +201,9 @@ async def test_email_search_retains_domain_results_when_email_request_fails(monk
 
     assert await search.get_hostnames() == {'portal.example.com'}
     assert report == SourceExecutionReport('partial', 'http-503')
+    build_session.assert_awaited_once_with(ANY, ANY, 'http://proxy.example:8080', 'http', ANY, None)
+    assert build_session.call_args.args[1].total == 60
+    session.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/discovery/test_leakix.py
+++ b/tests/discovery/test_leakix.py
@@ -1,4 +1,5 @@
 import logging
+from unittest.mock import ANY, AsyncMock
 
 import pytest
 
@@ -38,6 +39,10 @@ async def test_process_uses_documented_endpoint_and_normalizes_only_scoped_subdo
         ]
 
     monkeypatch.setattr(leakix.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    session = AsyncMock()
+    build_session = AsyncMock(return_value=session)
+    monkeypatch.setattr(leakix.AsyncFetcher, '_build_session', build_session)
+    monkeypatch.setattr(leakix.AsyncFetcher, '_resolve_proxy', lambda proxy: ('http://proxy.example:8080', 'http'))
     search = leakix.SearchLeakix('example.com')
 
     await search.process(proxy=True)
@@ -46,13 +51,22 @@ async def test_process_uses_documented_endpoint_and_normalizes_only_scoped_subdo
         (
             ['https://leakix.net/api/subdomains/example.com'],
             {
-                'headers': {'User-Agent': 'test-agent', 'accept': 'application/json', 'api-key': 'test-key'},
+                'session': session,
                 'json': True,
-                'proxy': True,
                 'include_metadata': True,
             },
         )
     ]
+    build_session.assert_awaited_once_with(
+        {'User-Agent': 'test-agent', 'accept': 'application/json', 'api-key': 'test-key'},
+        ANY,
+        'http://proxy.example:8080',
+        'http',
+        ANY,
+        None,
+    )
+    assert build_session.call_args.args[1].total == 60
+    session.close.assert_awaited_once()
     assert await search.get_hostnames() == {'api.example.com', 'www.example.com'}
     assert await search.get_emails() == set()
 

--- a/tests/discovery/test_post_provider_outcomes.py
+++ b/tests/discovery/test_post_provider_outcomes.py
@@ -26,7 +26,7 @@ def mock_transport(monkeypatch, responses):
 
     monkeypatch.setattr(
         AsyncFetcher,
-        'create_session',
+        '_build_session',
         AsyncMock(return_value=SimpleNamespace(request=request, close=AsyncMock())),
     )
     monkeypatch.setattr(Core, 'dehashed_key', lambda: 'test-key')

--- a/tests/discovery/test_post_provider_outcomes.py
+++ b/tests/discovery/test_post_provider_outcomes.py
@@ -1,0 +1,135 @@
+import json
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from theHarvester.lib.core import AsyncFetcher, Core
+from theHarvester.lib.source_runner import SourceRequest, run_source
+
+
+def mock_transport(monkeypatch, responses):
+    responses = iter(responses)
+
+    @asynccontextmanager
+    async def request(*args, **kwargs):
+        body, status, headers = next(responses)
+        if isinstance(body, BaseException):
+            raise body
+        yield SimpleNamespace(
+            status=status,
+            headers=headers,
+            text=AsyncMock(return_value=json.dumps(body)),
+            json=AsyncMock(return_value=body),
+        )
+
+    monkeypatch.setattr(
+        AsyncFetcher,
+        'create_session',
+        AsyncMock(return_value=SimpleNamespace(request=request, close=AsyncMock())),
+    )
+    monkeypatch.setattr(Core, 'dehashed_key', lambda: 'test-key')
+    monkeypatch.setattr(Core, 'leaklookup_key', lambda: 'test-key')
+    monkeypatch.setattr(Core, 'rocketreach_key', lambda: 'test-key')
+
+
+@pytest.mark.parametrize('source', ['dehashed', 'leaklookup', 'rocketreach'])
+@pytest.mark.parametrize(
+    ('body', 'status', 'expected'),
+    [
+        ({}, 401, ('failed', 'access-denied')),
+        ({}, 403, ('failed', 'access-denied')),
+        ({}, 429, ('rate-limited', 'http-429')),
+        ({}, 503, ('failed', 'http-503')),
+        (OSError('transport fixture'), 0, ('failed', 'transport-error')),
+        ('malformed response', 200, ('failed', 'invalid-response')),
+        ({}, 200, ('failed', 'invalid-response')),
+    ],
+)
+@pytest.mark.asyncio
+async def test_post_provider_failure_reaches_source_outcome(monkeypatch, source, body, status, expected):
+    mock_transport(monkeypatch, [(body, status, {})])
+
+    outcome = await run_source(SourceRequest(source, 'example.test', 10, 0, False, True))
+
+    assert (outcome.execution.status, outcome.execution.stop_reason) == expected
+
+
+@pytest.mark.parametrize(
+    ('source', 'body'),
+    [
+        ('dehashed', {'entries': [{'email': 'user@example.test'}]}),
+        ('leaklookup', {'error': 'false', 'message': {'Example Breach': [{'email': 'user@example.test'}]}}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_post_provider_decodes_http_json_before_collecting_evidence(monkeypatch, source, body):
+    mock_transport(monkeypatch, [(body, 200, {})])
+
+    outcome = await run_source(SourceRequest(source, 'example.test', 10, 0, False, True))
+
+    assert outcome.execution.status == 'completed'
+    assert [observation.value for observation in outcome.observations if observation.kind == 'email'] == ['user@example.test']
+
+
+@pytest.mark.parametrize(
+    ('source', 'body'),
+    [('dehashed', {'entries': []}), ('leaklookup', {'error': 'false', 'message': {}})],
+)
+@pytest.mark.asyncio
+async def test_post_provider_valid_empty_response_stays_complete(monkeypatch, source, body):
+    mock_transport(monkeypatch, [(body, 200, {})])
+
+    outcome = await run_source(SourceRequest(source, 'example.test', 10, 0, False, True))
+
+    assert (outcome.execution.status, outcome.execution.stop_reason) == ('completed', 'no-results')
+
+
+@pytest.mark.asyncio
+async def test_dehashed_retains_earlier_evidence_when_later_page_fails(monkeypatch):
+    mock_transport(monkeypatch, [({'entries': [{'email': 'user@example.test'}] * 100}, 200, {}), ({}, 401, {})])
+
+    outcome = await run_source(SourceRequest('dehashed', 'example.test', 200, 0, False, True))
+
+    assert (outcome.execution.status, outcome.execution.stop_reason) == ('partial', 'access-denied')
+    assert [observation.value for observation in outcome.observations] == ['user@example.test']
+
+
+@pytest.mark.asyncio
+async def test_dehashed_decodes_the_bounded_retry_response(monkeypatch):
+    mock_transport(monkeypatch, [({}, 429, {'retry-after': '0'}), ({'entries': [{'email': 'user@example.test'}]}, 200, {})])
+
+    outcome = await run_source(SourceRequest('dehashed', 'example.test', 10, 0, False, True))
+
+    assert outcome.execution.status == 'completed'
+    assert [observation.value for observation in outcome.observations] == ['user@example.test']
+
+
+@pytest.mark.asyncio
+async def test_leaklookup_provider_error_is_not_successful_absence(monkeypatch):
+    mock_transport(monkeypatch, [({'error': 'true', 'message': 'provider detail'}, 200, {})])
+
+    outcome = await run_source(SourceRequest('leaklookup', 'example.test', 10, 0, False, True))
+
+    assert (outcome.execution.status, outcome.execution.stop_reason) == ('failed', 'provider-error')
+
+
+@pytest.mark.parametrize(
+    ('source', 'body', 'status'),
+    [
+        ('dehashed', {'entries': [None]}, 'failed'),
+        ('dehashed', {'entries': [None, {'email': 'user@example.test'}]}, 'partial'),
+        ('leaklookup', {'message': {'Example Breach': None}}, 'failed'),
+        ('leaklookup', {'message': {'Example Breach': [None, {'email': 'user@example.test'}]}}, 'partial'),
+    ],
+)
+@pytest.mark.asyncio
+async def test_post_provider_malformed_records_do_not_complete_successfully(monkeypatch, source, body, status):
+    mock_transport(monkeypatch, [(body, 200, {})])
+
+    outcome = await run_source(SourceRequest(source, 'example.test', 10, 0, False, True))
+
+    assert (outcome.execution.status, outcome.execution.stop_reason) == (status, 'invalid-response')
+    emails = [observation.value for observation in outcome.observations if observation.kind == 'email']
+    assert emails == (['user@example.test'] if status == 'partial' else [])

--- a/tests/discovery/test_provider_failure_outcomes.py
+++ b/tests/discovery/test_provider_failure_outcomes.py
@@ -1,0 +1,214 @@
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from theHarvester.discovery import shodan_internetdb
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
+from theHarvester.lib.source_runner import SourceOutcome, SourceRequest, run_source
+
+
+async def _run_with_response(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+    response: FetcherResponse | None,
+) -> SourceOutcome:
+    async def fake_fetch_all(*_args: Any, **_kwargs: Any) -> list[FetcherResponse | None]:
+        return [response]
+
+    monkeypatch.setattr(Core, 'leakix_key', lambda: 'test-key')
+    monkeypatch.setattr(Core, 'hibpverified_key', lambda: 'test-key')
+    monkeypatch.setattr(AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(shodan_internetdb, 'resolve_ip_addresses', AsyncMock(return_value=['192.0.2.1']))
+    return await run_source(SourceRequest(source, 'example.test', 10, 0, False, True))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'source', ['leakix', 'rapiddns', 'shodanct', 'hibpverified', 'hudsonrock', 'subdomaincenter', 'shodanInternetDB']
+)
+async def test_http_429_is_a_rate_limited_source_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+) -> None:
+    outcome = await _run_with_response(monkeypatch, source, FetcherResponse(body={}, status=429, headers={'retry-after': '0'}))
+
+    assert outcome.execution.status == 'rate-limited'
+    assert outcome.execution.stop_reason == 'http-429'
+    assert outcome.execution.result_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('source', ['leakix', 'rapiddns', 'shodanct', 'hibpverified'])
+async def test_http_401_is_an_access_denied_source_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+) -> None:
+    outcome = await _run_with_response(monkeypatch, source, FetcherResponse(body={}, status=401, headers={}))
+
+    assert (outcome.execution.status, outcome.execution.stop_reason) == ('failed', 'access-denied')
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('source', ['leakix', 'rapiddns', 'shodanct', 'hibpverified'])
+async def test_http_503_is_a_failed_source_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+) -> None:
+    outcome = await _run_with_response(monkeypatch, source, FetcherResponse(body={}, status=503, headers={}))
+
+    assert (outcome.execution.status, outcome.execution.stop_reason) == ('failed', 'http-503')
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('source', ['leakix', 'rapiddns', 'shodanct', 'hibpverified'])
+async def test_missing_response_is_a_transport_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+) -> None:
+    outcome = await _run_with_response(monkeypatch, source, None)
+
+    assert (outcome.execution.status, outcome.execution.stop_reason) == ('failed', 'transport-error')
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('source', ['leakix', 'rapiddns', 'shodanct', 'hibpverified'])
+async def test_transport_exception_is_a_transport_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    source: str,
+) -> None:
+    async def failed_fetch(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        raise OSError('private provider detail')
+
+    monkeypatch.setattr(Core, 'leakix_key', lambda: 'test-key')
+    monkeypatch.setattr(Core, 'hibpverified_key', lambda: 'test-key')
+    monkeypatch.setattr(AsyncFetcher, 'fetch_all', failed_fetch)
+
+    outcome = await run_source(SourceRequest(source, 'example.test', 10, 0, False, True))
+
+    assert (outcome.execution.status, outcome.execution.stop_reason) == ('failed', 'transport-error')
+    assert 'private provider detail' not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('source', 'body'),
+    [('leakix', {}), ('rapiddns', ''), ('shodanct', {}), ('hibpverified', [])],
+)
+async def test_malformed_success_envelope_is_a_failed_source_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+    body: object,
+) -> None:
+    outcome = await _run_with_response(monkeypatch, source, FetcherResponse(body=body, status=200, headers={}))
+
+    assert (outcome.execution.status, outcome.execution.stop_reason) == ('failed', 'invalid-response')
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('source', 'body'),
+    [
+        ('leakix', []),
+        ('rapiddns', '<table><tbody></tbody></table>'),
+        ('shodanct', []),
+        ('hibpverified', {}),
+    ],
+)
+async def test_valid_empty_response_completes_with_no_results(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+    body: object,
+) -> None:
+    outcome = await _run_with_response(monkeypatch, source, FetcherResponse(body=body, status=200, headers={}))
+
+    assert (outcome.execution.status, outcome.execution.stop_reason) == ('completed', 'no-results')
+
+
+@pytest.mark.asyncio
+async def test_hibp_404_completes_with_no_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    outcome = await _run_with_response(
+        monkeypatch,
+        'hibpverified',
+        FetcherResponse(body={}, status=404, headers={}),
+    )
+
+    assert (outcome.execution.status, outcome.execution.stop_reason) == ('completed', 'no-results')
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('source', 'body', 'value'),
+    [
+        ('subdomaincenter', ['api.example.test', 'api.example.test'], 'api.example.test'),
+        ('hudsonrock', {'data': {'emails': ['user@example.test', 'user@example.test']}}, 'user@example.test'),
+    ],
+)
+async def test_duplicate_records_remain_successful_evidence(monkeypatch, source, body, value):
+    outcome = await _run_with_response(monkeypatch, source, FetcherResponse(body, 200, {}))
+
+    assert outcome.execution.status == 'completed'
+    assert [observation.value for observation in outcome.observations] == [value]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('body', 'reason'),
+    [({'error': 'provider unavailable'}, 'provider-error'), ({}, 'invalid-response')],
+)
+async def test_hudsonrock_rejects_incomplete_domain_envelopes(monkeypatch, body, reason):
+    outcome = await _run_with_response(monkeypatch, 'hudsonrock', FetcherResponse(body, 200, {}))
+
+    assert (outcome.execution.status, outcome.execution.stop_reason) == ('failed', reason)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('source', 'body', 'result_count'),
+    [
+        ('leakix', [{'subdomain': 'api.example.test'}, None], 1),
+        (
+            'rapiddns',
+            '<table><tbody><tr><td>api.example.test</td><td>192.0.2.1</td><td>A</td></tr><tr><td></td></tr></tbody></table>',
+            2,
+        ),
+        ('shodanct', ['api.example.test', None], 1),
+        ('hibpverified', {'alice': ['ExampleBreach'], '': ['Malformed']}, 2),
+    ],
+)
+async def test_parsing_failure_preserves_partial_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+    body: object,
+    result_count: int,
+) -> None:
+    outcome = await _run_with_response(monkeypatch, source, FetcherResponse(body=body, status=200, headers={}))
+
+    assert (outcome.execution.status, outcome.execution.stop_reason) == ('partial', 'invalid-response')
+    assert outcome.execution.result_count == result_count
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('source', ['leakix', 'rapiddns', 'shodanct', 'hibpverified'])
+async def test_cancellation_propagates_and_commits_cancelled_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+) -> None:
+    async def cancelled_fetch(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        raise asyncio.CancelledError
+
+    committed = []
+    monkeypatch.setattr(Core, 'leakix_key', lambda: 'test-key')
+    monkeypatch.setattr(Core, 'hibpverified_key', lambda: 'test-key')
+    monkeypatch.setattr(AsyncFetcher, 'fetch_all', cancelled_fetch)
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_source(
+            SourceRequest(source, 'example.test', 10, 0, False, True),
+            commit_cancelled=committed.append,
+        )
+
+    assert len(committed) == 1
+    assert (committed[0].execution.status, committed[0].execution.stop_reason) == ('failed', 'cancelled')

--- a/tests/discovery/test_provider_session_lifecycle.py
+++ b/tests/discovery/test_provider_session_lifecycle.py
@@ -1,9 +1,14 @@
-import pytest
-from aiohttp import ClientSession, web
+import asyncio
+import ssl
 
-from theHarvester.discovery import bravesearch, censysearch, githubcode
+import pytest
+from aiohttp import ClientError, ClientSession, web
+
+from theHarvester.discovery import bravesearch, censysearch, githubcode, hudsonrocksearch, leakix, search_dehashed
 from theHarvester.lib.configuration import InMemoryCredentialAdapter
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse, ResponseStreamError
 from theHarvester.lib.source_execution import SourceExecutionReport
+from theHarvester.lib.source_runner import SOURCE_FACTORIES, SourceRequest, run_source
 
 
 @pytest.mark.asyncio
@@ -183,3 +188,230 @@ async def test_github_code_pagination_preserves_provider_cookies(
     assert requests == [('1', None), ('2', 'ready')]
     assert source.counter == 2
     assert await source.get_emails() == {'first@example.com', 'second@example.com'}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('provider', ['dehashed', 'leakix', 'hudsonrock'])
+@pytest.mark.parametrize('later_failure', [False, True])
+async def test_repaired_provider_conversation_preserves_cookies_and_evidence(
+    monkeypatch, unused_tcp_port, provider, later_failure
+) -> None:
+    monkeypatch.setattr(Core, 'dehashed_key', lambda: 'test-key')
+    monkeypatch.setattr(Core, 'leakix_key', lambda: 'test-key')
+    monkeypatch.setattr(Core, 'get_user_agent', lambda: 'test-agent')
+    sessions = []
+    original_build_session = AsyncFetcher._build_session
+
+    async def tracked_build_session(*args, **kwargs):
+        session = await original_build_session(*args, **kwargs)
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(AsyncFetcher, '_build_session', tracked_build_session)
+    cookies = []
+    pages = []
+
+    async def search(request):
+        cookie = request.cookies.get('provider-session')
+        cookies.append(cookie)
+        assert request.headers['User-Agent'] == 'test-agent'
+        if provider == 'dehashed':
+            assert request.headers['Dehashed-Api-Key'] == 'test-key'
+            payload = await request.json()
+            pages.append(payload['page'])
+            assert payload == {
+                'query': 'example.test',
+                'page': payload['page'],
+                'size': 100,
+                'wildcard': False,
+                'regex': False,
+                'de_dupe': False,
+            }
+            if len(cookies) == 1:
+                response = web.json_response({'entries': [{'email': 'first@example.test'}] * 100})
+                response.set_cookie('provider-session', 'ready')
+                return response
+        elif provider == 'leakix':
+            assert request.headers['api-key'] == 'test-key'
+            assert request.headers['accept'] == 'application/json'
+        if len(cookies) == (2 if provider == 'dehashed' else 1):
+            response = web.json_response({}, status=429, headers={'retry-after': '0', 'x-limited-for': '0ms'})
+            response.set_cookie('provider-session', 'ready')
+            return response
+        if cookie != 'ready':
+            return web.json_response({}, status=403)
+        if later_failure and (provider != 'hudsonrock' or 'search-by-email' in request.path):
+            return web.json_response({}, status=503)
+        body = {
+            'dehashed': {'entries': [{'email': 'second@example.test'}]},
+            'leakix': [{'subdomain': 'portal.example.test'}],
+            'hudsonrock': (
+                {'stealers': []}
+                if 'search-by-email' in request.path
+                else {'data': {'employees_urls': [{'url': 'https://portal.example.test'}], 'emails': ['analyst@example.test']}}
+            ),
+        }[provider]
+        return web.json_response(body)
+
+    app = web.Application()
+    app.router.add_route('*', '/{path:.*}', search)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    await web.TCPSite(runner, '127.0.0.1', unused_tcp_port).start()
+    base_url = f'http://localhost:{unused_tcp_port}'
+    try:
+        for _ in range(2):
+            cookies.clear()
+            pages.clear()
+            if provider == 'dehashed':
+                source = search_dehashed.SearchDehashed('example.test', limit=200)
+                source.api = base_url
+            elif provider == 'leakix':
+                source = leakix.SearchLeakix('example.test')
+                source.url = base_url
+            else:
+                source = hudsonrocksearch.SearchHudsonRock('analyst@example.test')
+                source.base_url = base_url
+                source.request_delay = 0
+            monkeypatch.setitem(SOURCE_FACTORIES, provider, lambda _request: source)
+            outcome = await run_source(SourceRequest(provider, source.word, 200, 0, False, True))
+            expected_status = ('failed' if provider == 'leakix' else 'partial') if later_failure else 'completed'
+            assert outcome.execution.status == expected_status
+            assert outcome.execution.stop_reason == ('http-503' if later_failure else None)
+            assert outcome.execution.result_count == (
+                0 if later_failure and provider == 'leakix' else 2 if provider == 'dehashed' and not later_failure else 1
+            )
+            assert cookies == ([None, 'ready'] if provider == 'leakix' else [None, 'ready', 'ready'])
+            if provider == 'dehashed':
+                assert pages == [1, 2, 2]
+                assert await source.get_emails() == (
+                    {'first@example.test'} if later_failure else {'first@example.test', 'second@example.test'}
+                )
+            else:
+                assert await source.get_hostnames() == (
+                    set() if later_failure and provider == 'leakix' else {'portal.example.test'}
+                )
+            assert sessions[-1].closed
+            assert sessions[-1].timeout.total == (720 if provider == 'dehashed' else 60)
+        assert len(sessions) == 2
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('provider', ['dehashed', 'leakix', 'hudsonrock'])
+@pytest.mark.parametrize('stage', ['opening', 'request', 'closing'])
+@pytest.mark.parametrize(
+    'error_type', [OSError, ClientError, ResponseStreamError, ValueError, RuntimeError, asyncio.CancelledError]
+)
+async def test_repaired_provider_session_failure_and_cancellation(monkeypatch, provider, stage, error_type) -> None:
+    monkeypatch.setattr(Core, 'dehashed_key', lambda: 'test-key')
+    monkeypatch.setattr(Core, 'leakix_key', lambda: 'test-key')
+    source = {
+        'dehashed': lambda: search_dehashed.SearchDehashed('example.test', limit=1),
+        'leakix': lambda: leakix.SearchLeakix('example.test'),
+        'hudsonrock': lambda: hudsonrocksearch.SearchHudsonRock('example.test'),
+    }[provider]()
+    source.max_retries = 1
+    opened = []
+    closed = []
+    owner = asyncio.current_task()
+    error = error_type('response-limit' if error_type is ResponseStreamError else 'test interruption')
+
+    class Session:
+        async def close(self):
+            closed.append(True)
+            if stage == 'closing':
+                if error_type is asyncio.CancelledError:
+                    owner.cancel()
+                    await asyncio.sleep(0)
+                    return
+                raise error
+
+    session = Session()
+
+    async def build_session(headers, client_timeout, proxy_url, proxy_type, ssl_context, cookie_jar):
+        opened.append((client_timeout, proxy_url, proxy_type, ssl_context, cookie_jar))
+        if stage == 'opening':
+            raise error
+        return session
+
+    def resolve_proxy(required):
+        assert required is True
+        return 'http://127.0.0.1:9', 'http'
+
+    async def fetch(*_args, **kwargs):
+        assert kwargs['session'] is session
+        assert not kwargs.get('proxy')
+        if stage == 'request':
+            raise error
+        response = FetcherResponse(
+            {
+                'dehashed': {'entries': [{'email': 'first@example.test'}]},
+                'leakix': [{'subdomain': 'portal.example.test'}],
+                'hudsonrock': {'data': {'employees_urls': [{'url': 'https://portal.example.test'}]}},
+            }[provider],
+            200,
+            {},
+        )
+        return response if provider == 'dehashed' else [response]
+
+    monkeypatch.setattr(AsyncFetcher, '_build_session', build_session)
+    monkeypatch.setattr(AsyncFetcher, '_resolve_proxy', resolve_proxy)
+    monkeypatch.setattr(AsyncFetcher, 'post_fetch', fetch)
+    monkeypatch.setattr(AsyncFetcher, 'fetch_all', fetch)
+    if error_type is asyncio.CancelledError or (stage != 'request' and error_type in (ValueError, RuntimeError)):
+        with pytest.raises(error_type):
+            await source.process(proxy=True)
+    else:
+        reason = 'response-limit' if error_type is ResponseStreamError else 'transport-error'
+        assert await source.process(proxy=True) == SourceExecutionReport('failed', reason)
+    assert len(opened) == 1
+    timeout, proxy_url, proxy_type, ssl_context, cookie_jar = opened[0]
+    assert (proxy_url, proxy_type) == ('http://127.0.0.1:9', 'http')
+    assert timeout.total == (720 if provider == 'dehashed' else 60)
+    assert ssl_context.verify_mode == ssl.CERT_REQUIRED
+    assert cookie_jar is None
+    assert closed == ([] if stage == 'opening' else [True])
+    evidence = await source.get_emails() if provider == 'dehashed' else await source.get_hostnames()
+    assert bool(evidence) is (stage == 'closing')
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('provider', ['dehashed', 'hudsonrock'])
+async def test_provider_cancellation_checkpoints_earlier_evidence(monkeypatch, provider) -> None:
+    monkeypatch.setattr(Core, 'dehashed_key', lambda: 'test-key')
+    if provider == 'dehashed':
+        source = search_dehashed.SearchDehashed('example.test', limit=200)
+    else:
+        source = hudsonrocksearch.SearchHudsonRock('analyst@example.test')
+        source.request_delay = 0
+    monkeypatch.setitem(SOURCE_FACTORIES, provider, lambda _request: source)
+    sessions = []
+
+    async def fetch(*_args, **kwargs):
+        sessions.append(kwargs['session'])
+        if len(sessions) == 2:
+            raise asyncio.CancelledError
+        response = FetcherResponse(
+            {'entries': [{'email': 'first@example.test'}] * 100}
+            if provider == 'dehashed'
+            else {'data': {'emails': ['first@example.test']}},
+            200,
+            {},
+        )
+        return response if provider == 'dehashed' else [response]
+
+    monkeypatch.setattr(AsyncFetcher, 'post_fetch', fetch)
+    monkeypatch.setattr(AsyncFetcher, 'fetch_all', fetch)
+    checkpoints = []
+    with pytest.raises(asyncio.CancelledError):
+        await run_source(SourceRequest(provider, source.word, 200, 0, False, True), commit_cancelled=checkpoints.append)
+
+    assert len(sessions) == 2
+    assert sessions[0] is sessions[1]
+    assert sessions[0].closed
+    assert len(checkpoints) == 1
+    outcome = checkpoints[0]
+    assert (outcome.execution.status, outcome.execution.stop_reason) == ('partial', 'cancelled')
+    assert [(observation.kind, observation.value) for observation in outcome.observations] == [('email', 'first@example.test')]

--- a/tests/discovery/test_rocketreach.py
+++ b/tests/discovery/test_rocketreach.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 import types
 from contextlib import asynccontextmanager
@@ -18,6 +19,8 @@ if 'aiohttp_socks' not in sys.modules:
 
 from theHarvester.discovery import rocketreach
 from theHarvester.discovery.constants import MissingKey
+from theHarvester.lib.core import FetcherResponse
+from theHarvester.lib.source_execution import SourceExecutionReport
 
 
 @pytest.fixture(autouse=True)
@@ -27,10 +30,14 @@ def proxy_aware_session(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]
     @asynccontextmanager
     async def open_session(**kwargs: Any):
         session_options.append(kwargs)
-        yield object()
+        try:
+            yield object()
+        finally:
+            kwargs['closed'] = True
 
     monkeypatch.setattr(rocketreach.AsyncFetcher, 'open_session', open_session)
-    return session_options
+    yield session_options
+    assert all(options.get('closed') for options in session_options)
 
 
 @pytest.mark.asyncio
@@ -67,10 +74,7 @@ async def test_do_search_uses_people_data_endpoint_and_start_pagination(
                         'emails': [{'email': f'user{index}@example.com'}],
                     }
                 )
-            return {
-                'profiles': first_page_profiles,
-                'pagination': {'page': 1, 'total': 150},
-            }
+            return FetcherResponse({'profiles': first_page_profiles, 'pagination': {'page': 1, 'total': 150}}, 200, {})
 
         second_page_profiles = []
         for index in range(100, 150):
@@ -80,10 +84,7 @@ async def test_do_search_uses_people_data_endpoint_and_start_pagination(
                     'emails': [{'email': f'user{index}@example.com'}],
                 }
             )
-        return {
-            'profiles': second_page_profiles,
-            'pagination': {'page': 2, 'total': 150},
-        }
+        return FetcherResponse({'profiles': second_page_profiles, 'pagination': {'page': 2, 'total': 150}}, 200, {})
 
     monkeypatch.setattr(rocketreach.AsyncFetcher, 'post_fetch', fake_post_fetch)
 
@@ -99,6 +100,7 @@ async def test_do_search_uses_people_data_endpoint_and_start_pagination(
     assert first_headers['Api-Key'] == 'test-key'
     assert first_headers['User-Agent'] == 'test-agent'
     assert first_json is True
+    assert first_kwargs['include_metadata'] is True
     assert first_data == {'query': {'current_employer_domain': ['example.com']}, 'start': 0, 'page_size': 100}
     assert second_data == {'query': {'current_employer_domain': ['example.com']}, 'start': 100, 'page_size': 50}
     assert first_kwargs['session'] is second_kwargs['session']
@@ -130,14 +132,83 @@ async def test_do_search_stops_on_throttling_message(monkeypatch) -> None:
 
     async def fake_post_fetch(url, headers=None, data=None, json=False, **kwargs):
         calls.append((url, data))
-        return {'detail': 'Request was throttled. Credits will become available in 10 seconds.'}
+        return FetcherResponse({'detail': 'Request was throttled. Credits will become available in 10 seconds.'}, 200, {})
 
     monkeypatch.setattr(rocketreach.AsyncFetcher, 'post_fetch', fake_post_fetch)
 
     search = rocketreach.SearchRocketReach('example.com', 10)
-    await search.process()
+    report = await search.process()
 
     assert len(calls) == 1
+    assert report == SourceExecutionReport('rate-limited', 'provider-rate-limit')
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('response', 'expected'),
+    [
+        (None, SourceExecutionReport('failed', 'transport-error')),
+        (FetcherResponse({}, 403, {}), SourceExecutionReport('failed', 'access-denied')),
+        (FetcherResponse({}, 429, {}), SourceExecutionReport('rate-limited', 'http-429')),
+        (FetcherResponse('not-json', 200, {}), SourceExecutionReport('failed', 'invalid-response')),
+        (FetcherResponse({'profiles': []}, 200, {}), None),
+    ],
+)
+async def test_search_reports_terminal_outcomes(monkeypatch, response, expected) -> None:
+    monkeypatch.setattr(rocketreach.Core, 'rocketreach_key', lambda: 'test-key')
+    monkeypatch.setattr(rocketreach.Core, 'get_user_agent', lambda: 'test-agent')
+    monkeypatch.setattr(rocketreach, 'get_delay', lambda: -5)
+
+    async def fake_post_fetch(*_args, **kwargs):
+        assert kwargs['include_metadata'] is True
+        return response
+
+    async def no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(rocketreach.AsyncFetcher, 'post_fetch', fake_post_fetch)
+    monkeypatch.setattr(rocketreach.asyncio, 'sleep', no_sleep)
+
+    assert await rocketreach.SearchRocketReach('example.com', 10).process() == expected
+
+
+@pytest.mark.asyncio
+async def test_search_retains_first_page_when_later_page_is_rate_limited(monkeypatch) -> None:
+    monkeypatch.setattr(rocketreach.Core, 'rocketreach_key', lambda: 'test-key')
+    monkeypatch.setattr(rocketreach.Core, 'get_user_agent', lambda: 'test-agent')
+    profiles = [
+        {'linkedin_url': f'https://linkedin.com/in/user{index}', 'emails': [{'email': f'user{index}@example.com'}]}
+        for index in range(100)
+    ]
+    responses = [
+        FetcherResponse({'profiles': profiles, 'pagination': {'total': 150}}, 200, {}),
+        FetcherResponse({}, 429, {}),
+    ]
+
+    async def fake_post_fetch(*_args, **_kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr(rocketreach.AsyncFetcher, 'post_fetch', fake_post_fetch)
+    search = rocketreach.SearchRocketReach('example.com', 150)
+
+    report = await search.process()
+
+    assert report == SourceExecutionReport('partial', 'http-429')
+    assert len(await search.get_emails()) == 100
+    assert len(await search.get_urls()) == 100
+
+
+@pytest.mark.asyncio
+async def test_search_cancellation_propagates(monkeypatch) -> None:
+    monkeypatch.setattr(rocketreach.Core, 'rocketreach_key', lambda: 'test-key')
+
+    async def cancelled(*_args, **_kwargs):
+        raise asyncio.CancelledError('operator-stop')
+
+    monkeypatch.setattr(rocketreach.AsyncFetcher, 'post_fetch', cancelled)
+
+    with pytest.raises(asyncio.CancelledError, match='operator-stop'):
+        await rocketreach.SearchRocketReach('example.com', 10).process(proxy=True)
 
 
 pytestmark = pytest.mark.provider_contract('rocketreach')

--- a/tests/discovery/test_search_dehashed.py
+++ b/tests/discovery/test_search_dehashed.py
@@ -1,4 +1,5 @@
 import logging
+from unittest.mock import ANY, AsyncMock
 
 import pytest
 
@@ -45,12 +46,20 @@ async def test_process_honors_limit_and_retains_only_normalized_evidence(monkeyp
         return next(responses)
 
     monkeypatch.setattr(search_dehashed.AsyncFetcher, 'post_fetch', fake_post_fetch)
+    session = AsyncMock()
+    build_session = AsyncMock(return_value=session)
+    monkeypatch.setattr(search_dehashed.AsyncFetcher, '_build_session', build_session)
     search = SearchDehashed('example.com', limit=120)
 
     await search.process(proxy='http://proxy.example:8080')
 
     assert [request['json_body']['size'] for _, request in payloads] == [100, 20]
-    assert all(request['proxy'] == 'http://proxy.example:8080' for _, request in payloads)
+    assert all(request['session'] is session and 'proxy' not in request for _, request in payloads)
+    build_session.assert_awaited_once_with(
+        search.headers, ANY, 'http://proxy.example:8080', 'http', ANY, None
+    )
+    assert build_session.call_args.args[1].total == 720
+    session.close.assert_awaited_once()
     assert all(request['include_metadata'] is True for _, request in payloads)
     assert await search.get_emails() == {'user@example.com', 'admin@example.com'}
     assert await search.get_ips() == {'192.0.2.1', '2001:db8::1'}

--- a/tests/discovery/test_shodan_engine.py
+++ b/tests/discovery/test_shodan_engine.py
@@ -9,6 +9,9 @@ from uuid import UUID
 
 import pytest
 
+from theHarvester.lib.core import FetcherResponse
+from theHarvester.lib.source_execution import SourceExecutionReport
+
 
 def patch_resolution(monkeypatch, module, addresses=('203.0.113.10',)):
     requested_targets = []
@@ -663,24 +666,31 @@ class TestShodanEngine:
 
         targets = patch_resolution(monkeypatch, shodan_internetdb, ('203.0.113.1',))
 
-        async def fake_fetch_all(urls, json=False, proxy=False):
+        async def fake_fetch_all(urls, json=False, proxy=False, include_metadata=False):
             assert urls == ['https://internetdb.shodan.io/203.0.113.1']
+            assert include_metadata is True
+            assert proxy is True
             return [
-                {
-                    'ip': '203.0.113.1',
-                    'hostnames': ['API.Example.TEST.', 'www.notexample.test', None],
-                    'ports': [443],
-                }
+                FetcherResponse(
+                    {
+                        'ip': '203.0.113.1',
+                        'hostnames': ['API.Example.TEST.', 'www.notexample.test', None],
+                        'ports': [443],
+                    },
+                    200,
+                    {},
+                )
             ]
 
         monkeypatch.setattr(shodan_internetdb.AsyncFetcher, 'fetch_all', fake_fetch_all, raising=True)
 
         search = shodan_internetdb.SearchShodanInternetDB(' Example.TEST. ')
-        await search.process()
+        report = await search.process(proxy=True)
 
         assert targets == [('example.test', socket.AF_UNSPEC)]
         assert await search.get_hostnames() == {'api.example.test'}
         assert await search.get_ips() == {'203.0.113.1'}
+        assert report is None
 
     @pytest.mark.asyncio
     async def test_shodan_internetdb_rejects_evidence_for_an_unrequested_ip(self, monkeypatch):
@@ -688,22 +698,27 @@ class TestShodanEngine:
 
         patch_resolution(monkeypatch, shodan_internetdb, ('203.0.113.1',))
 
-        async def fake_fetch_all(_urls, json=False, proxy=False):
+        async def fake_fetch_all(_urls, json=False, proxy=False, include_metadata=False):
+            assert include_metadata is True
             return [
-                {
-                    'ip': '198.51.100.2',
-                    'hostnames': ['injected.example.test'],
-                    'ports': [443],
-                    'vulns': ['CVE-2026-0001'],
-                    'tags': ['injected'],
-                    'cpes': ['cpe:/a:injected'],
-                }
+                FetcherResponse(
+                    {
+                        'ip': '198.51.100.2',
+                        'hostnames': ['injected.example.test'],
+                        'ports': [443],
+                        'vulns': ['CVE-2026-0001'],
+                        'tags': ['injected'],
+                        'cpes': ['cpe:/a:injected'],
+                    },
+                    200,
+                    {},
+                )
             ]
 
         monkeypatch.setattr(shodan_internetdb.AsyncFetcher, 'fetch_all', fake_fetch_all, raising=True)
 
         search = shodan_internetdb.SearchShodanInternetDB('example.test')
-        await search.process()
+        report = await search.process()
 
         assert not await search.get_hostnames()
         assert not await search.get_ips()
@@ -711,6 +726,7 @@ class TestShodanEngine:
         assert not await search.get_vulns()
         assert not await search.get_tags()
         assert not await search.get_cpes()
+        assert report == SourceExecutionReport('failed', 'invalid-response')
 
     @pytest.mark.asyncio
     async def test_shodan_internetdb_resolution_failure_skips_provider_request(self, monkeypatch):
@@ -726,13 +742,14 @@ class TestShodanEngine:
         monkeypatch.setattr(shodan_internetdb.AsyncFetcher, 'fetch_all', fail_fetch, raising=True)
 
         search = shodan_internetdb.SearchShodanInternetDB('example.test')
-        await search.process()
+        report = await search.process()
 
         assert not await search.get_hostnames()
         assert not await search.get_ips()
+        assert report == SourceExecutionReport('failed', 'dns-resolution-failed')
 
     @pytest.mark.asyncio
-    async def test_shodan_internetdb_provider_failure_completes_without_evidence(self, monkeypatch, caplog):
+    async def test_shodan_internetdb_provider_failure_reports_transport_error(self, monkeypatch, caplog):
         from theHarvester.discovery import shodan_internetdb
 
         patch_resolution(monkeypatch, shodan_internetdb, ('203.0.113.1',))
@@ -744,12 +761,91 @@ class TestShodanEngine:
         caplog.set_level(logging.INFO, logger=shodan_internetdb.__name__)
 
         search = shodan_internetdb.SearchShodanInternetDB('example.test')
-        await search.process()
+        report = await search.process()
 
         assert not await search.get_hostnames()
         assert not await search.get_ips()
         assert 'Shodan InternetDB request failed' in caplog.text
         assert 'provider-secret-payload' not in caplog.text
+        assert report.status == 'failed'
+        assert report.stop_reason == 'transport-error'
+
+    @pytest.mark.asyncio
+    async def test_shodan_internetdb_no_resolved_ips_is_valid_empty(self, monkeypatch):
+        from theHarvester.discovery import shodan_internetdb
+
+        patch_resolution(monkeypatch, shodan_internetdb, ())
+
+        async def fail_fetch(*_args, **_kwargs):
+            raise AssertionError('provider request must not run')
+
+        monkeypatch.setattr(shodan_internetdb.AsyncFetcher, 'fetch_all', fail_fetch)
+
+        search = shodan_internetdb.SearchShodanInternetDB('example.test')
+
+        assert await search.process() is None
+        assert not await search.get_hostnames()
+        assert not await search.get_ips()
+
+    @pytest.mark.asyncio
+    async def test_shodan_internetdb_404_is_valid_empty(self, monkeypatch):
+        from theHarvester.discovery import shodan_internetdb
+
+        patch_resolution(monkeypatch, shodan_internetdb, ('203.0.113.1',))
+
+        async def fake_fetch_all(*_args, **kwargs):
+            assert kwargs['include_metadata'] is True
+            return [FetcherResponse({'detail': 'provider detail'}, 404, {})]
+
+        monkeypatch.setattr(shodan_internetdb.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        search = shodan_internetdb.SearchShodanInternetDB('example.test')
+
+        assert await search.process() is None
+        assert not await search.get_hostnames()
+        assert not await search.get_ips()
+
+    @pytest.mark.asyncio
+    async def test_shodan_internetdb_retains_one_ip_when_another_request_fails(self, monkeypatch):
+        from theHarvester.discovery import shodan_internetdb
+
+        patch_resolution(monkeypatch, shodan_internetdb, ('203.0.113.1', '203.0.113.2'))
+
+        async def fake_fetch_all(*_args, **kwargs):
+            assert kwargs['include_metadata'] is True
+            return [
+                FetcherResponse({'ip': '203.0.113.1', 'hostnames': ['API.Example.TEST.']}, 200, {}),
+                FetcherResponse({}, 503, {}),
+            ]
+
+        monkeypatch.setattr(shodan_internetdb.AsyncFetcher, 'fetch_all', fake_fetch_all)
+        search = shodan_internetdb.SearchShodanInternetDB('example.test')
+
+        report = await search.process()
+
+        assert await search.get_hostnames() == {'api.example.test'}
+        assert await search.get_ips() == {'203.0.113.1'}
+        assert report == SourceExecutionReport('partial', 'http-503')
+
+    @pytest.mark.asyncio
+    async def test_shodan_internetdb_malformed_response_and_cancellation_are_distinct(self, monkeypatch):
+        from theHarvester.discovery import shodan_internetdb
+
+        patch_resolution(monkeypatch, shodan_internetdb, ('203.0.113.1',))
+
+        async def malformed(*_args, **_kwargs):
+            return [FetcherResponse('not-json', 200, {})]
+
+        monkeypatch.setattr(shodan_internetdb.AsyncFetcher, 'fetch_all', malformed)
+        assert await shodan_internetdb.SearchShodanInternetDB('example.test').process() == SourceExecutionReport(
+            'failed', 'invalid-response'
+        )
+
+        async def cancelled(*_args, **_kwargs):
+            raise asyncio.CancelledError('operator-stop')
+
+        monkeypatch.setattr(shodan_internetdb.AsyncFetcher, 'fetch_all', cancelled)
+        with pytest.raises(asyncio.CancelledError, match='operator-stop'):
+            await shodan_internetdb.SearchShodanInternetDB('example.test').process()
 
 
 pytestmark = [

--- a/tests/discovery/test_subdomaincenter.py
+++ b/tests/discovery/test_subdomaincenter.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Any
 
@@ -5,6 +6,7 @@ import pytest
 
 from theHarvester.discovery import subdomaincenter
 from theHarvester.lib.core import FetcherResponse
+from theHarvester.lib.source_execution import SourceExecutionReport
 
 
 @pytest.mark.asyncio
@@ -15,25 +17,28 @@ async def test_process_preserves_www_hostname(monkeypatch):
     monkeypatch.setattr(subdomaincenter.AsyncFetcher, 'fetch_all', staticmethod(fake_fetch_all))
     search = subdomaincenter.SubdomainCenter('example.com')
 
-    await search.process()
+    report = await search.process()
 
     assert await search.get_hostnames() == {'www.example.com'}
+    assert report is None
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ('payload', 'expected'),
+    ('payload', 'expected', 'expected_report'),
     [
-        (None, set()),
-        ({'unexpected': 'shape'}, set()),
-        ('api.example.com', set()),
-        (['api.example.com', None], {'api.example.com'}),
+        (None, set(), SourceExecutionReport('failed', 'invalid-response')),
+        ({'unexpected': 'shape'}, set(), SourceExecutionReport('failed', 'invalid-response')),
+        ('api.example.com', set(), SourceExecutionReport('failed', 'invalid-response')),
+        (['api.example.com', None], {'api.example.com'}, SourceExecutionReport('partial', 'invalid-response')),
+        ([], set(), None),
     ],
 )
 async def test_process_rejects_malformed_results(
     monkeypatch: pytest.MonkeyPatch,
     payload: Any,
     expected: set[str],
+    expected_report: SourceExecutionReport | None,
 ) -> None:
     async def fake_fetch_all(urls: list[str], **_kwargs: Any) -> list[FetcherResponse]:
         assert urls == ['https://api.subdomain.center/?domain=example.com']
@@ -42,9 +47,10 @@ async def test_process_rejects_malformed_results(
     monkeypatch.setattr(subdomaincenter.AsyncFetcher, 'fetch_all', fake_fetch_all)
     search = subdomaincenter.SubdomainCenter('example.com')
 
-    await search.process()
+    report = await search.process()
 
     assert await search.get_hostnames() == expected
+    assert report == expected_report
 
 
 @pytest.mark.asyncio
@@ -59,10 +65,11 @@ async def test_process_attributes_provider_failures(
     search = subdomaincenter.SubdomainCenter('example.com')
 
     with caplog.at_level(logging.INFO, logger=subdomaincenter.__name__):
-        await search.process()
+        report = await search.process()
 
     assert await search.get_hostnames() == set()
     assert 'SubdomainCenter' in caplog.text
+    assert report == SourceExecutionReport('failed', 'transport-error')
 
 
 @pytest.mark.asyncio
@@ -78,10 +85,22 @@ async def test_process_attributes_http_failures(
     search = subdomaincenter.SubdomainCenter('example.com')
 
     with caplog.at_level(logging.INFO, logger=subdomaincenter.__name__):
-        await search.process()
+        report = await search.process()
 
     assert await search.get_hostnames() == set()
     assert 'SubdomainCenter request failed with HTTP 429' in caplog.text
+    assert report == SourceExecutionReport('rate-limited', 'http-429')
+
+
+@pytest.mark.asyncio
+async def test_process_cancellation_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def cancelled(*_args: Any, **_kwargs: Any) -> list[FetcherResponse]:
+        raise asyncio.CancelledError('operator-stop')
+
+    monkeypatch.setattr(subdomaincenter.AsyncFetcher, 'fetch_all', cancelled)
+
+    with pytest.raises(asyncio.CancelledError, match='operator-stop'):
+        await subdomaincenter.SubdomainCenter('example.com').process(proxy=True)
 
 
 pytestmark = pytest.mark.provider_contract('subdomaincenter')

--- a/tests/test_saved_run_report_cli.py
+++ b/tests/test_saved_run_report_cli.py
@@ -11,8 +11,10 @@ from theHarvester import saved_run_report
 from theHarvester.lib import database as database_module
 from theHarvester.lib.active_evidence import ActionExecution, ActiveEvidence
 from theHarvester.lib.completed_result import CompletedResult, ResultObservation, SourceExecution
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
 from theHarvester.lib.database import ResultStore
 from theHarvester.lib.evidence_types import RESULT_KINDS, ExecutionStatus
+from theHarvester.lib.source_runner import SourceRequest, run_source
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -585,6 +587,56 @@ def test_hostname_changes_distinguish_no_longer_reported_from_uncertain_using_pe
             'status': 'partial',
             'stop_reason': 'previous-run-errors',
         }
+    ]
+
+
+def test_real_provider_rate_limit_stays_uncertain_in_saved_hostname_report(monkeypatch, tmp_path: Path, capsys):
+    responses = iter(
+        [
+            FetcherResponse([{'subdomain': 'api.example.test'}], 200, {}),
+            FetcherResponse({}, 429, {}),
+        ]
+    )
+
+    async def fetch_all(*args, **kwargs):
+        return [next(responses)]
+
+    monkeypatch.setattr(Core, 'leakix_key', lambda: 'test-key')
+    monkeypatch.setattr(AsyncFetcher, 'fetch_all', fetch_all)
+    database = tmp_path / 'runs.sqlite'
+
+    async def collect_and_save():
+        store = ResultStore(database)
+        try:
+            await store.initialize()
+            for index, run_id in enumerate((RUN_ONE, RUN_TWO)):
+                outcome = await run_source(SourceRequest('leakix', 'example.test', 10, 0, False, True))
+                instant = datetime(2026, 9, 7, 12, index, tzinfo=UTC)
+                await store.save_run(
+                    CompletedResult.finish(
+                        run_id=run_id,
+                        target='example.test',
+                        started_at=instant,
+                        completed_at=instant + timedelta(seconds=1),
+                        groups={'hostname': [observation.value for observation in outcome.observations]},
+                        observations=outcome.observations,
+                        source_executions=(outcome.execution,),
+                    )
+                )
+        finally:
+            await store.dispose()
+
+    asyncio.run(collect_and_save())
+    assert (
+        saved_run_report.main(['hostname-changes', '--database', str(database), '--run-id', str(RUN_TWO), '--format', 'json'])
+        == 0
+    )
+
+    (difference,) = json.loads(capsys.readouterr().out)['hostname_differences']
+    assert difference['hostname'] == 'api.example.test'
+    assert difference['change_type'] == 'uncertain'
+    assert difference['incomplete_source_outcomes'] == [
+        {'source': 'leakix', 'status': 'rate-limited', 'stop_reason': 'http-429', 'error_type': None},
     ]
 
 

--- a/theHarvester/discovery/hibpverified.py
+++ b/theHarvester/discovery/hibpverified.py
@@ -1,7 +1,9 @@
 import logging
 
 from theHarvester.discovery.constants import MissingKey
+from theHarvester.discovery.provider_response import provider_http_error
 from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
+from theHarvester.lib.source_execution import SourceExecutionReport
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +19,7 @@ class SearchHibpVerified:
         self.emails: set[str] = set()
         self.breach_names: set[str] = set()
 
-    async def process(self, proxy: bool = False) -> None:
+    async def process(self, proxy: bool = False) -> SourceExecutionReport | None:
         try:
             responses = await AsyncFetcher.fetch_all(
                 [f'{self.base_url}/breachedDomain/{self.word}'],
@@ -28,40 +30,47 @@ class SearchHibpVerified:
             )
         except OSError, RuntimeError, ValueError:
             logger.info('HIBP verified-domain request failed')
-            return
+            return SourceExecutionReport('failed', 'transport-error')
 
         response = responses[0] if responses and isinstance(responses[0], FetcherResponse) else None
         if response is None:
             logger.info('HIBP verified-domain request failed')
-            return
+            return SourceExecutionReport('failed', 'transport-error')
         if response.status == 403:
             logger.info('HIBP verified-domain target is not verified for this API key (HTTP 403)')
-            return
+            return SourceExecutionReport('failed', 'access-denied')
         if response.status == 404:
-            return
-        if response.status == 429:
-            logger.info('HIBP verified-domain request was rate limited (HTTP 429)')
-            return
+            return None
+        if failure := provider_http_error(response):
+            if response.status == 429:
+                logger.info('HIBP verified-domain request was rate limited (HTTP 429)')
+            else:
+                logger.info(f'HIBP verified-domain request failed with HTTP {response.status}')
+            return SourceExecutionReport(*failure)
         if response.status != 200:
             logger.info(f'HIBP verified-domain request failed with HTTP {response.status}')
-            return
+            return SourceExecutionReport('failed', f'http-{response.status}')
         if not isinstance(response.body, dict):
             logger.info('HIBP verified-domain returned malformed account data')
-            return
-        if not all(
-            isinstance(alias, str)
-            and alias.strip()
-            and '@' not in alias
-            and not any(character.isspace() for character in alias)
-            and isinstance(breaches, list)
-            and all(isinstance(breach, str) and breach.strip() for breach in breaches)
-            for alias, breaches in response.body.items()
-        ):
-            logger.info('HIBP verified-domain returned malformed account data')
-            return
+            return SourceExecutionReport('failed', 'invalid-response')
+        malformed = False
         for alias, breaches in response.body.items():
+            if not (
+                isinstance(alias, str)
+                and alias.strip()
+                and '@' not in alias
+                and not any(character.isspace() for character in alias)
+                and isinstance(breaches, list)
+                and all(isinstance(breach, str) and breach.strip() for breach in breaches)
+            ):
+                malformed = True
+                continue
             self.emails.add(f'{alias.strip()}@{self.word}')
             self.breach_names.update(breach.strip() for breach in breaches)
+        if malformed:
+            logger.info('HIBP verified-domain returned malformed account data')
+            return SourceExecutionReport('failed', 'invalid-response')
+        return None
 
     async def get_emails(self) -> set[str]:
         return self.emails

--- a/theHarvester/discovery/hudsonrocksearch.py
+++ b/theHarvester/discovery/hudsonrocksearch.py
@@ -2,7 +2,9 @@ import asyncio
 import logging
 from urllib.parse import urlparse
 
+from theHarvester.discovery.provider_response import provider_http_error
 from theHarvester.lib.core import AsyncFetcher, FetcherResponse
+from theHarvester.lib.source_execution import SourceExecutionReport
 
 
 class SearchHudsonRock:
@@ -33,37 +35,47 @@ class SearchHudsonRock:
         self.request_delay = 1.0  # Delay between requests in seconds
         self.max_retries = 3
 
-    async def do_search(self) -> None:
+    def _has_results(self) -> bool:
+        return bool(self.totalhosts or self.totalips or self.emails or self.infostealers)
+
+    async def do_search(self) -> SourceExecutionReport | None:
         """Query by domain and, for email targets, by email address.
 
         Requests are retried when the provider rate limits them.
         """
         self.logger.info(f'Starting Hudson Rock search for: {self.word}')
 
-        search_tasks = []
+        searches = []
 
         # Always search by domain (even for emails, to find related domains)
         domain_to_search = self.word if '@' not in self.word else self.word.split('@')[1]
-        search_tasks.append(self._search_domain(domain_to_search))
+        searches.append((self._search_domain, domain_to_search))
 
         # Search by email if the word looks like an email
         if '@' in self.word and self._is_valid_email(self.word):
-            search_tasks.append(self._search_email(self.word))
+            searches.append((self._search_email, self.word))
 
         # Execute searches with rate limiting
-        for index, task in enumerate(search_tasks):
+        reports: list[SourceExecutionReport] = []
+        for index, (search, target) in enumerate(searches):
             try:
-                await task
-                if index < len(search_tasks) - 1:
+                if report := await search(target):
+                    reports.append(report)
+                if index < len(searches) - 1:
                     await asyncio.sleep(self.request_delay)
-            except Exception as e:
-                self.logger.error(f'Search task failed: {e}')
-                continue
+            except OSError, RuntimeError, ValueError:
+                self.logger.error('Hudson Rock search task failed')
+                reports.append(SourceExecutionReport('failed', 'transport-error'))
 
         self.logger.info(
             f'Hudson Rock search completed. Found {len(self.totalhosts)} hosts, '
             f'{len(self.totalips)} IPs, {len(self.emails)} emails'
         )
+        if not reports:
+            return None
+        if len(reports) < len(searches) or self._has_results():
+            return SourceExecutionReport('partial', reports[0].stop_reason)
+        return reports[0]
 
     def _is_valid_email(self, email: str) -> bool:
         """Validate email format.
@@ -80,7 +92,7 @@ class SearchHudsonRock:
         pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
         return bool(re.match(pattern, email))
 
-    async def _search_domain(self, domain: str) -> None:
+    async def _search_domain(self, domain: str) -> SourceExecutionReport | None:
         """Search Hudson Rock by domain with retry logic.
 
         Args:
@@ -88,11 +100,15 @@ class SearchHudsonRock:
 
         """
         url = f'{self.base_url}/search-by-domain?domain={domain}'
-        response = await self._fetch_response(url, 'domain', domain)
-        if response is not None:
-            self._process_domain_response(response)
+        response, report = await self._fetch_response(url, 'domain', domain)
+        if report is not None:
+            return report
+        assert response is not None
+        if self._process_domain_response(response):
+            return SourceExecutionReport('partial' if self._has_results() else 'failed', 'invalid-response')
+        return None
 
-    async def _search_email(self, email: str) -> None:
+    async def _search_email(self, email: str) -> SourceExecutionReport | None:
         """Search Hudson Rock by email with retry logic.
 
         Args:
@@ -100,11 +116,15 @@ class SearchHudsonRock:
 
         """
         url = f'{self.base_url}/search-by-email?email={email}'
-        response = await self._fetch_response(url, 'email', email)
-        if response is not None:
-            self._process_email_response(response)
+        response, report = await self._fetch_response(url, 'email', email)
+        if report is not None:
+            return report
+        assert response is not None
+        if self._process_email_response(response):
+            return SourceExecutionReport('partial' if self._has_results() else 'failed', 'invalid-response')
+        return None
 
-    async def _fetch_response(self, url: str, search_type: str, target: str) -> dict | None:
+    async def _fetch_response(self, url: str, search_type: str, target: str) -> tuple[dict | None, SourceExecutionReport | None]:
         for attempt in range(self.max_retries):
             try:
                 self.logger.debug(f'Searching {search_type}: {target} (attempt {attempt + 1})')
@@ -112,11 +132,11 @@ class SearchHudsonRock:
                 response = responses[0] if responses and isinstance(responses[0], FetcherResponse) else None
                 if response is None:
                     self.logger.warning(f'Invalid response format for {search_type} search: {target}')
-                    return None
-                if response.status == 429:
+                    return None, SourceExecutionReport('failed', 'transport-error')
+                if isinstance(response, FetcherResponse) and response.status == 429:
                     if attempt == self.max_retries - 1:
                         self.logger.info(f'Hudson Rock {search_type} search returned HTTP 429 after {self.max_retries} attempts')
-                        return None
+                        return None, SourceExecutionReport('rate-limited', 'http-429')
                     retry_after = response.headers.get('retry-after')
                     try:
                         delay = int(retry_after) if retry_after is not None else 2**attempt
@@ -124,23 +144,26 @@ class SearchHudsonRock:
                         delay = 2**attempt
                     await asyncio.sleep(max(0, min(delay, 60)))
                     continue
-                if not 200 <= response.status < 300:
+                if error := provider_http_error(response):
                     self.logger.info(f'Hudson Rock {search_type} search failed with HTTP {response.status}')
-                    return None
+                    return None, SourceExecutionReport(*error)
                 if not isinstance(response.body, dict):
                     self.logger.warning(f'Invalid response format for {search_type} search: {target}')
-                    return None
-                return response.body
+                    return None, SourceExecutionReport('failed', 'invalid-response')
+                if response.body.get('error'):
+                    self.logger.info(f'Hudson Rock {search_type} search returned a provider error')
+                    return None, SourceExecutionReport('failed', 'provider-error')
+                return response.body, None
 
-            except Exception as e:
-                self.logger.error(f'{search_type.title()} search attempt {attempt + 1} failed for {target}: {e}')
+            except OSError, RuntimeError, ValueError:
+                self.logger.error(f'Hudson Rock {search_type} search attempt {attempt + 1} failed')
                 if attempt < self.max_retries - 1:
                     await asyncio.sleep(2**attempt)
                 else:
-                    raise
-        return None
+                    return None, SourceExecutionReport('failed', 'transport-error')
+        return None, SourceExecutionReport('failed', 'transport-error')
 
-    def _process_domain_response(self, response: dict) -> None:
+    def _process_domain_response(self, response: dict) -> bool:
         """Process domain search response from Hudson Rock API.
 
         Args:
@@ -164,27 +187,31 @@ class SearchHudsonRock:
             )
 
             # Extract URLs and hosts from response data
-            data = response.get('data', {})
+            data = response.get('data')
+            if not isinstance(data, dict):
+                return True
 
             # Process employee URLs
             employees_urls = data.get('employees_urls', [])
-            self._extract_hosts_from_urls(employees_urls, 'employee')
+            malformed = self._extract_hosts_from_urls(employees_urls, 'employee')
 
             # Process user URLs
             users_urls = data.get('users_urls', [])
-            self._extract_hosts_from_urls(users_urls, 'user')
+            malformed |= self._extract_hosts_from_urls(users_urls, 'user')
 
             # Process third party URLs if available
             third_party_urls = data.get('third_parties_urls', [])
-            self._extract_hosts_from_urls(third_party_urls, 'third_party')
+            malformed |= self._extract_hosts_from_urls(third_party_urls, 'third_party')
 
             # Extract emails from the data
-            self._extract_emails_from_data(data)
+            malformed |= self._extract_emails_from_data(data)
+            return malformed
 
-        except Exception as e:
-            self.logger.error(f'Error processing Hudson Rock domain response: {e}', exc_info=True)
+        except TypeError, ValueError:
+            self.logger.error('Error processing Hudson Rock domain response')
+            return True
 
-    def _extract_hosts_from_urls(self, urls_data: list[dict], source_type: str) -> None:
+    def _extract_hosts_from_urls(self, urls_data: list[dict], source_type: str) -> bool:
         """Extract hostnames from URL data.
 
         Args:
@@ -192,13 +219,20 @@ class SearchHudsonRock:
             source_type: Source category: employee, user, or third party.
 
         """
+        if not isinstance(urls_data, list):
+            return True
         extracted_count = 0
+        malformed = False
 
         for url_data in urls_data:
             if not isinstance(url_data, dict):
+                malformed = True
                 continue
             url = url_data.get('url', '')
-            if not isinstance(url, str) or not url or url.startswith('https://•••') or url.startswith('http://•••'):
+            if not isinstance(url, str) or not url:
+                malformed = True
+                continue
+            if url.startswith('https://•••') or url.startswith('http://•••'):
                 continue
 
             try:
@@ -208,13 +242,15 @@ class SearchHudsonRock:
                     extracted_count += 1
                     self.logger.debug(f'Extracted {source_type} host: {parsed.hostname}')
 
-            except Exception as e:
-                self.logger.warning(f'Failed to parse URL {url}: {e}')
+            except ValueError:
+                malformed = True
+                self.logger.warning('Failed to parse Hudson Rock URL')
 
         if extracted_count > 0:
             self.logger.info(f'Extracted {extracted_count} hosts from {source_type} URLs')
+        return malformed
 
-    def _extract_emails_from_data(self, data: dict) -> None:
+    def _extract_emails_from_data(self, data: dict) -> bool:
         """Extract email addresses from response data.
 
         Args:
@@ -224,6 +260,7 @@ class SearchHudsonRock:
         # Look for emails in various data fields
         email_fields = ['employees_emails', 'users_emails', 'emails']
 
+        malformed = False
         for field in email_fields:
             if field in data:
                 emails_data = data[field]
@@ -234,11 +271,16 @@ class SearchHudsonRock:
                         else:
                             email = str(email_data)
 
-                        if email and self._is_valid_email(email) and email not in self.emails:
+                        if email and self._is_valid_email(email):
                             self.emails.add(email)
                             self.logger.debug(f'Extracted email: {email}')
+                        elif email:
+                            malformed = True
+                else:
+                    malformed = True
+        return malformed
 
-    def _process_email_response(self, response: dict) -> None:
+    def _process_email_response(self, response: dict) -> bool:
         """Process email search response from Hudson Rock API.
 
         Args:
@@ -247,15 +289,20 @@ class SearchHudsonRock:
         """
         try:
             # Process stealer data with enhanced information extraction
-            stealers = response.get('stealers', [])
+            stealers = response.get('stealers')
+            if not isinstance(stealers, list):
+                return True
             self.logger.info(f'Processing {len(stealers)} stealer records for email: {self.word}')
 
+            malformed = False
             for stealer in stealers:
                 if not isinstance(stealer, dict):
+                    malformed = True
                     continue
                 corporate_services = stealer.get('top_corporate_services', [])
                 user_services = stealer.get('top_user_services', [])
                 if not isinstance(corporate_services, list) or not isinstance(user_services, list):
+                    malformed = True
                     continue
                 self.emails.add(self.word)
                 stealer_info = {
@@ -285,9 +332,11 @@ class SearchHudsonRock:
                 self.infostealers.append(stealer_info)
 
             self.logger.info(f'Processed {len(stealers)} stealer records, extracted {len(self.totalips)} IPs')
+            return malformed
 
-        except Exception as e:
-            self.logger.error(f'Error processing Hudson Rock email response: {e}', exc_info=True)
+        except TypeError, ValueError:
+            self.logger.error('Error processing Hudson Rock email response')
+            return True
 
     def _is_valid_ip(self, ip: str) -> bool:
         """Validate IP address format.
@@ -334,8 +383,8 @@ class SearchHudsonRock:
                                     self.totalhosts.add(parsed.hostname)
                                     self.logger.debug(f'Extracted service host: {parsed.hostname}')
 
-                            except Exception as e:
-                                self.logger.warning(f'Failed to parse service URL {url}: {e}')
+                            except TypeError, ValueError:
+                                self.logger.warning('Failed to parse Hudson Rock service URL')
 
     async def get_hostnames(self) -> set[str]:
         """Return discovered hostnames.
@@ -401,7 +450,7 @@ class SearchHudsonRock:
             'emails': sorted(list(self.emails)),
         }
 
-    async def process(self, proxy: bool = False) -> None:
+    async def process(self, proxy: bool = False) -> SourceExecutionReport | None:
         """Run the Hudson Rock search.
 
         Args:
@@ -412,13 +461,14 @@ class SearchHudsonRock:
         self.logger.info(f'Starting Hudson Rock processing for: {self.word}')
 
         try:
-            await self.do_search()
+            report = await self.do_search()
             summary = self.get_summary()
             self.logger.info(
                 f'Hudson Rock processing completed successfully: '
                 f'{summary["total_hosts"]} hosts, {summary["total_ips"]} IPs, '
                 f'{summary["total_emails"]} emails, {summary["total_stealers"]} stealers'
             )
-        except Exception as e:
-            self.logger.error(f'Hudson Rock processing failed: {e}', exc_info=True)
-            raise
+            return report
+        except OSError, RuntimeError, ValueError:
+            self.logger.error('Hudson Rock processing failed')
+            return SourceExecutionReport('failed', 'transport-error')

--- a/theHarvester/discovery/hudsonrocksearch.py
+++ b/theHarvester/discovery/hudsonrocksearch.py
@@ -1,10 +1,16 @@
 import asyncio
 import logging
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
+from aiohttp import ClientError
+
 from theHarvester.discovery.provider_response import provider_http_error
-from theHarvester.lib.core import AsyncFetcher, FetcherResponse
+from theHarvester.lib.core import AsyncFetcher, FetcherResponse, ResponseStreamError
 from theHarvester.lib.source_execution import SourceExecutionReport
+
+if TYPE_CHECKING:
+    from aiohttp import ClientSession
 
 
 class SearchHudsonRock:
@@ -38,7 +44,7 @@ class SearchHudsonRock:
     def _has_results(self) -> bool:
         return bool(self.totalhosts or self.totalips or self.emails or self.infostealers)
 
-    async def do_search(self) -> SourceExecutionReport | None:
+    async def do_search(self, session: ClientSession) -> SourceExecutionReport | None:
         """Query by domain and, for email targets, by email address.
 
         Requests are retried when the provider rate limits them.
@@ -59,7 +65,7 @@ class SearchHudsonRock:
         reports: list[SourceExecutionReport] = []
         for index, (search, target) in enumerate(searches):
             try:
-                if report := await search(target):
+                if report := await search(target, session):
                     reports.append(report)
                 if index < len(searches) - 1:
                     await asyncio.sleep(self.request_delay)
@@ -92,7 +98,7 @@ class SearchHudsonRock:
         pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
         return bool(re.match(pattern, email))
 
-    async def _search_domain(self, domain: str) -> SourceExecutionReport | None:
+    async def _search_domain(self, domain: str, session: ClientSession) -> SourceExecutionReport | None:
         """Search Hudson Rock by domain with retry logic.
 
         Args:
@@ -100,7 +106,7 @@ class SearchHudsonRock:
 
         """
         url = f'{self.base_url}/search-by-domain?domain={domain}'
-        response, report = await self._fetch_response(url, 'domain', domain)
+        response, report = await self._fetch_response(url, 'domain', domain, session)
         if report is not None:
             return report
         assert response is not None
@@ -108,7 +114,7 @@ class SearchHudsonRock:
             return SourceExecutionReport('partial' if self._has_results() else 'failed', 'invalid-response')
         return None
 
-    async def _search_email(self, email: str) -> SourceExecutionReport | None:
+    async def _search_email(self, email: str, session: ClientSession) -> SourceExecutionReport | None:
         """Search Hudson Rock by email with retry logic.
 
         Args:
@@ -116,7 +122,7 @@ class SearchHudsonRock:
 
         """
         url = f'{self.base_url}/search-by-email?email={email}'
-        response, report = await self._fetch_response(url, 'email', email)
+        response, report = await self._fetch_response(url, 'email', email, session)
         if report is not None:
             return report
         assert response is not None
@@ -124,11 +130,13 @@ class SearchHudsonRock:
             return SourceExecutionReport('partial' if self._has_results() else 'failed', 'invalid-response')
         return None
 
-    async def _fetch_response(self, url: str, search_type: str, target: str) -> tuple[dict | None, SourceExecutionReport | None]:
+    async def _fetch_response(
+        self, url: str, search_type: str, target: str, session: ClientSession
+    ) -> tuple[dict | None, SourceExecutionReport | None]:
         for attempt in range(self.max_retries):
             try:
                 self.logger.debug(f'Searching {search_type}: {target} (attempt {attempt + 1})')
-                responses = await AsyncFetcher.fetch_all([url], json=True, proxy=self.proxy, include_metadata=True)
+                responses = await AsyncFetcher.fetch_all([url], session=session, json=True, include_metadata=True)
                 response = responses[0] if responses and isinstance(responses[0], FetcherResponse) else None
                 if response is None:
                     self.logger.warning(f'Invalid response format for {search_type} search: {target}')
@@ -461,7 +469,8 @@ class SearchHudsonRock:
         self.logger.info(f'Starting Hudson Rock processing for: {self.word}')
 
         try:
-            report = await self.do_search()
+            async with AsyncFetcher.open_session(proxy=self.proxy, request_timeout=60) as session:
+                report = await self.do_search(session)
             summary = self.get_summary()
             self.logger.info(
                 f'Hudson Rock processing completed successfully: '
@@ -469,6 +478,8 @@ class SearchHudsonRock:
                 f'{summary["total_emails"]} emails, {summary["total_stealers"]} stealers'
             )
             return report
-        except OSError, RuntimeError, ValueError:
+        except ResponseStreamError as error:
+            return SourceExecutionReport('failed', error.reason)
+        except ClientError, OSError:
             self.logger.error('Hudson Rock processing failed')
             return SourceExecutionReport('failed', 'transport-error')

--- a/theHarvester/discovery/leakix.py
+++ b/theHarvester/discovery/leakix.py
@@ -2,8 +2,10 @@ import asyncio
 import logging
 
 from theHarvester.discovery.constants import MissingKey
+from theHarvester.discovery.provider_response import provider_http_error
 from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
 from theHarvester.lib.hostnames import normalize_scoped_hostname
+from theHarvester.lib.source_execution import SourceExecutionReport
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +47,7 @@ class SearchLeakix:
             return None
         return delay if 0 <= delay <= 60 else None
 
-    async def do_search(self) -> None:
+    async def do_search(self) -> SourceExecutionReport | None:
         try:
             response = await self._fetch()
             if response is not None and response.status == 429:
@@ -56,24 +58,31 @@ class SearchLeakix:
                     response = await self._fetch()
         except OSError, RuntimeError, ValueError:
             logger.info('LeakIX request failed')
-            return
+            return SourceExecutionReport('failed', 'transport-error')
 
         if response is None:
             logger.info('LeakIX request failed')
-            return
-        if not 200 <= response.status < 300:
+            return SourceExecutionReport('failed', 'transport-error')
+        if error := provider_http_error(response):
             logger.info(f'LeakIX request failed with HTTP {response.status}')
-            return
+            return SourceExecutionReport(*error)
         if not isinstance(response.body, list):
             logger.info('LeakIX returned a malformed response')
-            return
+            return SourceExecutionReport('failed', 'invalid-response')
 
+        malformed = False
         for item in response.body:
             if not isinstance(item, dict):
+                malformed = True
                 continue
-            normalized = normalize_scoped_hostname(item.get('subdomain'), self.word)
+            candidate = item.get('subdomain')
+            if candidate is not None and not isinstance(candidate, str):
+                malformed = True
+                continue
+            normalized = normalize_scoped_hostname(candidate, self.word)
             if normalized:
                 self.totalhosts.add(normalized)
+        return SourceExecutionReport('failed', 'invalid-response') if malformed else None
 
     async def get_hostnames(self) -> set[str]:
         return self.totalhosts
@@ -81,6 +90,6 @@ class SearchLeakix:
     async def get_emails(self) -> set[str]:
         return set()
 
-    async def process(self, proxy: bool = False) -> None:
+    async def process(self, proxy: bool = False) -> SourceExecutionReport | None:
         self.proxy = proxy
-        await self.do_search()
+        return await self.do_search()

--- a/theHarvester/discovery/leakix.py
+++ b/theHarvester/discovery/leakix.py
@@ -1,11 +1,17 @@
 import asyncio
 import logging
+from typing import TYPE_CHECKING
+
+from aiohttp import ClientError
 
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.discovery.provider_response import provider_http_error
-from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse, ResponseStreamError
 from theHarvester.lib.hostnames import normalize_scoped_hostname
 from theHarvester.lib.source_execution import SourceExecutionReport
+
+if TYPE_CHECKING:
+    from aiohttp import ClientSession
 
 logger = logging.getLogger(__name__)
 
@@ -22,16 +28,11 @@ class SearchLeakix:
         self.proxy = False
         self.url = f'https://leakix.net/api/subdomains/{word}'
 
-    async def _fetch(self) -> FetcherResponse | None:
+    async def _fetch(self, session: ClientSession) -> FetcherResponse | None:
         responses = await AsyncFetcher.fetch_all(
             [self.url],
-            headers={
-                'User-Agent': Core.get_user_agent(),
-                'accept': 'application/json',
-                'api-key': self.api_key,
-            },
+            session=session,
             json=True,
-            proxy=self.proxy,
             include_metadata=True,
         )
         response = responses[0] if responses else None
@@ -47,15 +48,26 @@ class SearchLeakix:
             return None
         return delay if 0 <= delay <= 60 else None
 
-    async def do_search(self) -> SourceExecutionReport | None:
+    async def do_search(self, session: ClientSession | None = None) -> SourceExecutionReport | None:
+        if session is None:
+            headers = {'User-Agent': Core.get_user_agent(), 'accept': 'application/json', 'api-key': self.api_key}
+            try:
+                async with AsyncFetcher.open_session(headers=headers, proxy=self.proxy, request_timeout=60) as owned_session:
+                    return await self.do_search(owned_session)
+            except ResponseStreamError as error:
+                return SourceExecutionReport('failed', error.reason)
+            except ClientError, OSError:
+                logger.info('LeakIX session failed')
+                return SourceExecutionReport('failed', 'transport-error')
+
         try:
-            response = await self._fetch()
+            response = await self._fetch(session)
             if response is not None and response.status == 429:
                 delay = self._limited_for_seconds(response.headers.get('x-limited-for'))
                 if delay is not None:
                     logger.info(f'LeakIX rate limited; retrying once in {delay:g} seconds')
                     await asyncio.sleep(delay)
-                    response = await self._fetch()
+                    response = await self._fetch(session)
         except OSError, RuntimeError, ValueError:
             logger.info('LeakIX request failed')
             return SourceExecutionReport('failed', 'transport-error')

--- a/theHarvester/discovery/leaklookup.py
+++ b/theHarvester/discovery/leaklookup.py
@@ -1,7 +1,9 @@
 import logging
 
 from theHarvester.discovery.constants import MissingKey
+from theHarvester.discovery.provider_response import provider_http_error
 from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
+from theHarvester.lib.source_execution import SourceExecutionReport
 
 logger = logging.getLogger(__name__)
 
@@ -22,38 +24,41 @@ class SearchLeakLookup:
         self.leak_dates: set[str] = set()
         self.breach_names: set[str] = set()
 
-    async def process(self, proxy: bool = False) -> None:
+    async def process(self, proxy: bool = False) -> SourceExecutionReport | None:
         response = await AsyncFetcher.post_fetch(
             self.url,
             headers={'User-Agent': Core.get_user_agent()},
             data={'key': self.api_key, 'type': 'domain', 'query': self.word},
+            json=True,
             proxy=proxy,
             include_metadata=True,
         )
         if not isinstance(response, FetcherResponse):
             logger.info('Leak-Lookup request failed without a response')
-            return
-        if not 200 <= response.status < 300:
+            return SourceExecutionReport('failed', 'transport-error')
+        if failure := provider_http_error(response):
             logger.info(f'Leak-Lookup request failed with HTTP {response.status}')
-            return
+            return SourceExecutionReport(*failure)
         if not isinstance(response.body, dict):
             logger.info('Leak-Lookup returned malformed data')
-            return
+            return SourceExecutionReport('failed', 'invalid-response')
         if response.body.get('error') in (True, 'true', 1, '1'):
             logger.info('Leak-Lookup request failed')
-            return
+            return SourceExecutionReport('failed', 'provider-error')
 
-        self._extract_data(response.body.get('message'))
+        return self._extract_data(response.body.get('message'))
 
-    def _extract_data(self, message: object) -> None:
+    def _extract_data(self, message: object) -> SourceExecutionReport | None:
         if not isinstance(message, dict):
             logger.info('Leak-Lookup returned malformed data')
-            return
+            return SourceExecutionReport('failed', 'invalid-response')
 
         normalized_leaks: set[tuple[str, str | None]] = set()
         email_fields = ('email', 'email_address', 'emailaddress', 'email2', 'email_address2', 'emailaddress2')
+        malformed = False
         for breach, records in message.items():
-            if not isinstance(breach, str) or not breach.strip():
+            if not isinstance(breach, str) or not breach.strip() or not isinstance(records, (list, dict)):
+                malformed = True
                 continue
             breach_name = breach.strip()
             self.breach_names.add(breach_name)
@@ -62,6 +67,7 @@ class SearchLeakLookup:
             if isinstance(records, list):
                 for record in records:
                     if not isinstance(record, dict):
+                        malformed = True
                         continue
                     breach_emails.update(
                         value.strip() for field in email_fields if isinstance((value := record.get(field)), str) and value.strip()
@@ -75,6 +81,7 @@ class SearchLeakLookup:
             {'breach': breach, **({'email': email} if email else {})}
             for breach, email in sorted(normalized_leaks, key=lambda item: (item[0], item[1] or ''))
         ]
+        return SourceExecutionReport('failed', 'invalid-response') if malformed else None
 
     async def get_hostnames(self) -> set[str]:
         return self.hosts

--- a/theHarvester/discovery/rapiddns.py
+++ b/theHarvester/discovery/rapiddns.py
@@ -4,7 +4,9 @@ import logging
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 
+from theHarvester.discovery.provider_response import provider_http_error
 from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
+from theHarvester.lib.source_execution import SourceExecutionReport
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +19,7 @@ class SearchRapidDns:
         self.host_ip_pairs: set[tuple[str, str]] = set()
         self.proxy = False
 
-    async def do_search(self):
+    async def do_search(self) -> SourceExecutionReport | None:
         try:
             headers = {'User-Agent': Core.get_browser_user_agent()}
             # TODO see if it's worth adding sameip searches
@@ -30,22 +32,31 @@ class SearchRapidDns:
                 include_metadata=True,
             )
             response = responses[0] if responses else None
-            if response is None:
-                logger.info('RapidDNS request failed')
-                return
-            if not 200 <= response.status < 300:
+        except Exception as error:
+            logger.info(f'RapidDNS error: {type(error).__name__}')
+            return SourceExecutionReport('failed', 'transport-error')
+
+        if failure := provider_http_error(response):
+            if isinstance(response, FetcherResponse):
                 logger.info(f'RapidDNS request failed with HTTP {response.status}')
-                return
-            if not isinstance(response.body, str) or len(response.body) <= 1:
-                return
+            else:
+                logger.info('RapidDNS request failed')
+            return SourceExecutionReport(*failure)
+        if not isinstance(response, FetcherResponse) or not isinstance(response.body, str):
+            logger.info('RapidDNS returned a malformed response')
+            return SourceExecutionReport('failed', 'invalid-response')
+        try:
             soup = BeautifulSoup(response.body, 'html.parser')
             table_el = soup.find('table')
             if not isinstance(table_el, Tag):
-                return
+                logger.info('RapidDNS returned a malformed response')
+                return SourceExecutionReport('failed', 'invalid-response')
             tbody_el = table_el.find('tbody')
             if not isinstance(tbody_el, Tag):
-                return
+                logger.info('RapidDNS returned a malformed response')
+                return SourceExecutionReport('failed', 'invalid-response')
             rows = tbody_el.find_all('tr')
+            malformed = False
             if rows:
                 # Validation check
                 for row in rows:
@@ -53,9 +64,11 @@ class SearchRapidDns:
                         continue
                     cells = row.find_all('td')
                     if len(cells) < 2:
+                        malformed = True
                         continue
                     subdomain = cells[0].get_text(strip=True)
                     if not subdomain:
+                        malformed = True
                         continue
                     self.totalhosts.add(subdomain)
                     if cells[-1].get_text(strip=True).upper() not in {'A', 'AAAA'}:
@@ -63,15 +76,18 @@ class SearchRapidDns:
                     try:
                         address = str(ipaddress.ip_address(cells[1].get_text(strip=True)))
                     except ValueError:
+                        malformed = True
                         continue
                     self.totalips.add(address)
                     self.host_ip_pairs.add((subdomain, address))
-        except Exception as e:
-            logger.info(f'RapidDNS error: {e!s}')
+            return SourceExecutionReport('failed', 'invalid-response') if malformed else None
+        except Exception:
+            logger.info('RapidDNS returned a malformed response')
+            return SourceExecutionReport('failed', 'invalid-response')
 
-    async def process(self, proxy: bool = False) -> None:
+    async def process(self, proxy: bool = False) -> SourceExecutionReport | None:
         self.proxy = proxy
-        await self.do_search()
+        return await self.do_search()
 
     async def get_hostnames(self) -> list[str]:
         return list(self.totalhosts)

--- a/theHarvester/discovery/rocketreach.py
+++ b/theHarvester/discovery/rocketreach.py
@@ -2,7 +2,9 @@ import asyncio
 import logging
 
 from theHarvester.discovery.constants import MissingKey, get_delay
-from theHarvester.lib.core import AsyncFetcher, Core
+from theHarvester.discovery.provider_response import provider_http_error
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
+from theHarvester.lib.source_execution import SourceExecutionReport, SourceReportStatus
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +23,10 @@ class SearchRocketReach:
         self.emails: set = set()
         self.limit = limit
 
-    async def do_search(self) -> None:
+    def _report(self, status: SourceReportStatus, reason: str) -> SourceExecutionReport:
+        return SourceExecutionReport('partial' if self.urls or self.emails else status, reason)
+
+    async def do_search(self) -> SourceExecutionReport | None:
         try:
             if self.limit is not None and self.limit <= 0:
                 return
@@ -42,40 +47,64 @@ class SearchRocketReach:
                         'start': start,
                         'page_size': page_size,
                     }
-                    result = await AsyncFetcher.post_fetch(
+                    response = await AsyncFetcher.post_fetch(
                         self.baseurl,
                         session=session,
                         headers=headers,
                         data=data,
                         json=True,
+                        include_metadata=True,
                     )
+                    if failure := provider_http_error(response):
+                        logger.info('RocketReach request failed')
+                        return self._report(*failure)
+                    assert isinstance(response, FetcherResponse)
+                    result = response.body
                     if not isinstance(result, dict):
-                        break
+                        logger.info('RocketReach returned malformed data')
+                        return self._report('failed', 'invalid-response')
 
                     detail = result.get('detail', '')
                     if detail and 'Subscribe to a plan to access' in str(detail):
-                        # No more results can be fetched
-                        break
+                        logger.info('RocketReach requires additional provider access')
+                        return self._report('failed', 'quota-exhausted')
 
                     if detail and 'Request was throttled.' in str(detail):
                         # Rate limit has been triggered need to sleep extra
-                        logger.info(
-                            f'RocketReach requests have been throttled; '
-                            f'{str(detail).split(" ", 3)[-1].replace("available", "availability")}'
-                        )
-                        break
+                        logger.info('RocketReach request was throttled')
+                        return self._report('rate-limited', 'provider-rate-limit')
 
-                    profiles = result.get('profiles', [])
+                    profiles = result.get('profiles')
+                    if not isinstance(profiles, list):
+                        logger.info('RocketReach returned malformed data')
+                        return self._report('failed', 'invalid-response')
                     if not profiles:
                         break
 
+                    malformed = False
                     for profile in profiles:
-                        if 'linkedin_url' in profile:
-                            self.urls.add(profile['linkedin_url'])
-                        if profile.get('emails'):
-                            for email in profile['emails']:
-                                if email.get('email'):
-                                    self.emails.add(email['email'])
+                        if not isinstance(profile, dict):
+                            malformed = True
+                            continue
+                        linkedin_url = profile.get('linkedin_url')
+                        if linkedin_url is not None:
+                            if isinstance(linkedin_url, str) and linkedin_url.strip():
+                                self.urls.add(linkedin_url)
+                            else:
+                                malformed = True
+                        emails = profile.get('emails', [])
+                        if not isinstance(emails, list):
+                            malformed = True
+                            continue
+                        for email in emails:
+                            if not isinstance(email, dict) or not isinstance(email.get('email'), str):
+                                malformed = True
+                                continue
+                            if email['email'].strip():
+                                self.emails.add(email['email'])
+                    if malformed:
+                        logger.info('RocketReach ignored malformed profile data')
+                        return self._report('failed', 'invalid-response')
 
                     found = len(profiles)
                     if remaining is not None:
@@ -83,6 +112,8 @@ class SearchRocketReach:
                     start += found
 
                     pagination = result.get('pagination', {})
+                    if not isinstance(pagination, dict):
+                        return self._report('failed', 'invalid-response')
                     total = pagination.get('total')
                     if isinstance(total, int) and start >= total:
                         break
@@ -90,9 +121,11 @@ class SearchRocketReach:
                         break
 
             await asyncio.sleep(get_delay() + 5)
+            return None
 
-        except Exception as e:
-            logger.info(f'An exception has occurred rocketreach: {e}')
+        except OSError, RuntimeError, ValueError:
+            logger.info('RocketReach request failed')
+            return self._report('failed', 'transport-error')
 
     async def get_urls(self):
         return self.urls
@@ -100,6 +133,6 @@ class SearchRocketReach:
     async def get_emails(self):
         return self.emails
 
-    async def process(self, proxy: bool = False) -> None:
+    async def process(self, proxy: bool = False) -> SourceExecutionReport | None:
         self.proxy = proxy
-        await self.do_search()
+        return await self.do_search()

--- a/theHarvester/discovery/search_dehashed.py
+++ b/theHarvester/discovery/search_dehashed.py
@@ -1,12 +1,17 @@
 import asyncio
 import logging
 from ipaddress import ip_address
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from aiohttp import ClientError
 
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.discovery.provider_response import provider_http_error
-from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
+from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse, ResponseStreamError
 from theHarvester.lib.source_execution import SourceExecutionReport
+
+if TYPE_CHECKING:
+    from aiohttp import ClientSession
 
 logger = logging.getLogger(__name__)
 
@@ -27,13 +32,12 @@ class SearchDehashed:
         self.ips: set[str] = set()
         self.proxy: bool = False
 
-    async def _fetch_page(self, payload: dict[str, Any]) -> Any:
+    async def _fetch_page(self, payload: dict[str, Any], session: ClientSession) -> Any:
         response = await AsyncFetcher.post_fetch(
             self.api,
-            headers=self.headers,
+            session=session,
             json_body=payload,
             json=True,
-            proxy=self.proxy,
             include_metadata=True,
         )
         if isinstance(response, FetcherResponse) and response.status == 429:
@@ -47,10 +51,9 @@ class SearchDehashed:
                 await asyncio.sleep(delay)
                 response = await AsyncFetcher.post_fetch(
                     self.api,
-                    headers=self.headers,
+                    session=session,
                     json_body=payload,
                     json=True,
-                    proxy=self.proxy,
                     include_metadata=True,
                 )
         return response
@@ -72,7 +75,19 @@ class SearchDehashed:
                 except ValueError:
                     continue
 
-    async def do_search(self) -> SourceExecutionReport | None:
+    async def do_search(self, session: ClientSession | None = None) -> SourceExecutionReport | None:
+        if session is None:
+            try:
+                async with AsyncFetcher.open_session(
+                    headers=self.headers, proxy=self.proxy, request_timeout=720
+                ) as owned_session:
+                    return await self.do_search(owned_session)
+            except ResponseStreamError as error:
+                return SourceExecutionReport('failed', error.reason)
+            except ClientError, OSError:
+                logger.info('\t[!] Dehashed session failed')
+                return SourceExecutionReport('failed', 'transport-error')
+
         logger.info(f'\t[+] Performing Dehashed search for: {self.word}')
         page = 1
         remaining = self.limit
@@ -80,7 +95,7 @@ class SearchDehashed:
             size = min(100, remaining) if remaining is not None else 100
             payload = {'query': self.word, 'page': page, 'size': size, 'wildcard': False, 'regex': False, 'de_dupe': False}
             try:
-                response = await self._fetch_page(payload)
+                response = await self._fetch_page(payload, session)
                 if not isinstance(response, FetcherResponse):
                     logger.info('\t[!] Dehashed request failed')
                     return SourceExecutionReport('failed', 'transport-error')

--- a/theHarvester/discovery/search_dehashed.py
+++ b/theHarvester/discovery/search_dehashed.py
@@ -4,7 +4,9 @@ from ipaddress import ip_address
 from typing import Any
 
 from theHarvester.discovery.constants import MissingKey
+from theHarvester.discovery.provider_response import provider_http_error
 from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
+from theHarvester.lib.source_execution import SourceExecutionReport
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +32,7 @@ class SearchDehashed:
             self.api,
             headers=self.headers,
             json_body=payload,
+            json=True,
             proxy=self.proxy,
             include_metadata=True,
         )
@@ -46,6 +49,7 @@ class SearchDehashed:
                     self.api,
                     headers=self.headers,
                     json_body=payload,
+                    json=True,
                     proxy=self.proxy,
                     include_metadata=True,
                 )
@@ -68,7 +72,7 @@ class SearchDehashed:
                 except ValueError:
                     continue
 
-    async def do_search(self) -> None:
+    async def do_search(self) -> SourceExecutionReport | None:
         logger.info(f'\t[+] Performing Dehashed search for: {self.word}')
         page = 1
         remaining = self.limit
@@ -79,18 +83,20 @@ class SearchDehashed:
                 response = await self._fetch_page(payload)
                 if not isinstance(response, FetcherResponse):
                     logger.info('\t[!] Dehashed request failed')
-                    break
-                if not 200 <= response.status < 300:
+                    return SourceExecutionReport('failed', 'transport-error')
+                if failure := provider_http_error(response):
                     logger.info(f'\t[!] Dehashed request failed with HTTP {response.status}')
-                    break
+                    return SourceExecutionReport(*failure)
                 data = response.body
                 if not isinstance(data, dict) or not isinstance(entries := data.get('entries'), list):
                     logger.info('\t[!] Dehashed returned a malformed response')
-                    break
+                    return SourceExecutionReport('failed', 'invalid-response')
                 if not entries:
                     break
                 retained_entries = entries[:remaining] if remaining is not None else entries
                 self._retain_evidence(retained_entries)
+                if any(not isinstance(entry, dict) for entry in retained_entries):
+                    return SourceExecutionReport('failed', 'invalid-response')
                 if remaining is not None:
                     remaining -= len(retained_entries)
                 logger.info(f'\t[+] Page {page} - Retrieved {len(retained_entries)} entries.')
@@ -99,11 +105,11 @@ class SearchDehashed:
                 page += 1
             except OSError, RuntimeError, ValueError:
                 logger.info('\t[!] Dehashed request failed')
-                break
+                return SourceExecutionReport('failed', 'transport-error')
 
-    async def process(self, proxy: bool = False) -> None:
+    async def process(self, proxy: bool = False) -> SourceExecutionReport | None:
         self.proxy = proxy
-        await self.do_search()
+        return await self.do_search()
 
     async def get_emails(self) -> set[str]:
         return self.emails

--- a/theHarvester/discovery/shodan_internetdb.py
+++ b/theHarvester/discovery/shodan_internetdb.py
@@ -3,9 +3,11 @@ from ipaddress import ip_address
 
 import aiodns
 
-from theHarvester.lib.core import AsyncFetcher
+from theHarvester.discovery.provider_response import provider_http_error
+from theHarvester.lib.core import AsyncFetcher, FetcherResponse
 from theHarvester.lib.hostchecker import resolve_ip_addresses
 from theHarvester.lib.hostnames import normalize_scoped_hostname
+from theHarvester.lib.source_execution import SourceExecutionReport
 
 logger = logging.getLogger(__name__)
 
@@ -32,68 +34,90 @@ class SearchShodanInternetDB:
         self.cpes: set = set()
         self.proxy = False
 
-    async def do_search(self) -> None:
+    def _has_results(self) -> bool:
+        return bool(self.totalhosts or self.totalips or self.ports or self.vulns or self.tags or self.cpes)
+
+    async def do_search(self) -> SourceExecutionReport | None:
         # Resolve the domain to IP addresses first
         try:
             resolved_ips = await resolve_ip_addresses(self.word)
         except aiodns.error.DNSError:
             logger.info(f'Shodan InternetDB: Could not resolve domain {self.word}')
-            return
+            return SourceExecutionReport('failed', 'dns-resolution-failed')
 
         if not resolved_ips:
             logger.info(f'Shodan InternetDB: No IPs resolved for {self.word}')
-            return
+            return None
 
         # Query InternetDB for each resolved IP
         requested_ips = list(resolved_ips)
         urls = [f'https://internetdb.shodan.io/{ip}' for ip in requested_ips]
         try:
-            responses = await AsyncFetcher.fetch_all(urls, json=True, proxy=self.proxy)
-        except Exception:
+            responses = await AsyncFetcher.fetch_all(urls, json=True, proxy=self.proxy, include_metadata=True)
+        except OSError, RuntimeError, ValueError:
             logger.info('Shodan InternetDB request failed')
-            return
+            return SourceExecutionReport('failed', 'transport-error')
 
-        for requested_ip, response in zip(requested_ips, responses, strict=False):
-            if not isinstance(response, dict):
+        report = None
+        for index, requested_ip in enumerate(requested_ips):
+            response = responses[index] if index < len(responses) else None
+            if isinstance(response, FetcherResponse) and response.status == 404:
+                continue
+            if failure := provider_http_error(response):
+                report = SourceExecutionReport(*failure)
+                continue
+            assert isinstance(response, FetcherResponse)
+            payload = response.body
+            if not isinstance(payload, dict):
+                report = SourceExecutionReport('failed', 'invalid-response')
                 continue
 
-            # InternetDB returns a 404 as an empty JSON object or with a "detail" key
-            # when no data is found for an IP. Skip those.
-            if 'detail' in response:
+            # Older InternetDB responses represented missing data with a detail object.
+            if 'detail' in payload:
                 continue
 
             try:
-                response_ip = str(ip_address(response.get('ip', '')))
+                response_ip = str(ip_address(payload.get('ip', '')))
             except ValueError:
+                report = SourceExecutionReport('failed', 'invalid-response')
                 continue
             if response_ip != requested_ip:
+                report = SourceExecutionReport('failed', 'invalid-response')
                 continue
             self.totalips.add(response_ip)
 
+            fields = {name: payload.get(name, []) for name in ('hostnames', 'ports', 'vulns', 'tags', 'cpes')}
+            if any(not isinstance(values, list) for values in fields.values()):
+                report = SourceExecutionReport('failed', 'invalid-response')
+                continue
+
             # Collect hostnames that match our target domain
-            for hostname in response.get('hostnames', []):
+            for hostname in fields['hostnames']:
                 if normalized := normalize_scoped_hostname(hostname, self.word):
                     self.totalhosts.add(normalized)
 
             # Collect ports
-            for port in response.get('ports', []):
+            for port in fields['ports']:
                 if isinstance(port, int):
                     self.ports.add(port)
 
             # Collect CVEs / vulnerabilities
-            for vuln in response.get('vulns', []):
+            for vuln in fields['vulns']:
                 if isinstance(vuln, str):
                     self.vulns.add(vuln)
 
             # Collect tags
-            for tag in response.get('tags', []):
+            for tag in fields['tags']:
                 if isinstance(tag, str):
                     self.tags.add(tag)
 
             # Collect CPEs
-            for cpe in response.get('cpes', []):
+            for cpe in fields['cpes']:
                 if isinstance(cpe, str):
                     self.cpes.add(cpe)
+        if report is not None and self._has_results():
+            return SourceExecutionReport('partial', report.stop_reason)
+        return report
 
     async def get_hostnames(self) -> set:
         return self.totalhosts
@@ -113,6 +137,6 @@ class SearchShodanInternetDB:
     async def get_cpes(self) -> set:
         return self.cpes
 
-    async def process(self, proxy: bool = False) -> None:
+    async def process(self, proxy: bool = False) -> SourceExecutionReport | None:
         self.proxy = proxy
-        await self.do_search()
+        return await self.do_search()

--- a/theHarvester/discovery/shodanct.py
+++ b/theHarvester/discovery/shodanct.py
@@ -1,7 +1,9 @@
 import logging
 
+from theHarvester.discovery.provider_response import provider_http_error
 from theHarvester.lib.core import AsyncFetcher, FetcherResponse
 from theHarvester.lib.hostnames import normalize_scoped_hostname
+from theHarvester.lib.source_execution import SourceExecutionReport
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +19,7 @@ class SearchShodanCt:
         self.hostnames: set[str] = set()
         self.proxy = False
 
-    async def process(self, proxy: bool = False) -> None:
+    async def process(self, proxy: bool = False) -> SourceExecutionReport | None:
         self.proxy = proxy
         try:
             responses: list[FetcherResponse | None] = await AsyncFetcher.fetch_all(
@@ -27,19 +29,19 @@ class SearchShodanCt:
                 include_metadata=True,
             )
         except Exception as error:
-            logger.info(f'Shodan CT request failed: {error}')
-            return
+            logger.info(f'Shodan CT request failed: {type(error).__name__}')
+            return SourceExecutionReport('failed', 'transport-error')
 
         response = responses[0] if responses else None
         if response is None:
             logger.info('Shodan CT request failed')
-            return
-        if not 200 <= response.status < 300:
+            return SourceExecutionReport('failed', 'transport-error')
+        if failure := provider_http_error(response):
             logger.info(f'Shodan CT request failed with HTTP {response.status}')
-            return
+            return SourceExecutionReport(*failure)
         if not isinstance(response.body, list):
             logger.info('Shodan CT returned malformed data')
-            return
+            return SourceExecutionReport('failed', 'invalid-response')
 
         malformed = False
         for candidate in response.body:
@@ -68,6 +70,8 @@ class SearchShodanCt:
 
         if malformed:
             logger.info('Shodan CT ignored malformed hostname data')
+            return SourceExecutionReport('failed', 'invalid-response')
+        return None
 
     async def get_hostnames(self) -> set[str]:
         return self.hostnames

--- a/theHarvester/discovery/subdomaincenter.py
+++ b/theHarvester/discovery/subdomaincenter.py
@@ -1,6 +1,8 @@
 import logging
 
+from theHarvester.discovery.provider_response import provider_http_error
 from theHarvester.lib.core import AsyncFetcher, Core, FetcherResponse
+from theHarvester.lib.source_execution import SourceExecutionReport
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +14,7 @@ class SubdomainCenter:
         self.server = 'https://api.subdomain.center/?domain='
         self.proxy = False
 
-    async def do_search(self):
+    async def do_search(self) -> SourceExecutionReport | None:
         headers = {'User-Agent': Core.get_user_agent()}
         try:
             current_url = f'{self.server}{self.word}'
@@ -24,24 +26,29 @@ class SubdomainCenter:
                 include_metadata=True,
             )
             response = responses[0] if responses else None
-            if response is None:
-                logger.info('SubdomainCenter request failed')
-                return
-            if not 200 <= response.status < 300:
-                logger.info(f'SubdomainCenter request failed with HTTP {response.status}')
-                return
+            if failure := provider_http_error(response):
+                logger.info(
+                    f'SubdomainCenter request failed with HTTP {response.status}'
+                    if isinstance(response, FetcherResponse)
+                    else 'SubdomainCenter request failed'
+                )
+                return SourceExecutionReport(*failure)
+            assert isinstance(response, FetcherResponse)
             payload = response.body
-            self.results = (
-                {hostname for hostname in payload if isinstance(hostname, str) and hostname.strip()}
-                if isinstance(payload, list)
-                else set()
-            )
-        except Exception as e:
-            logger.info(f'An exception has occurred in SubdomainCenter on : {e}')
+            if not isinstance(payload, list):
+                logger.info('SubdomainCenter returned malformed data')
+                return SourceExecutionReport('failed', 'invalid-response')
+            self.results = {hostname for hostname in payload if isinstance(hostname, str) and hostname.strip()}
+            if any(not isinstance(hostname, str) or not hostname.strip() for hostname in payload):
+                return SourceExecutionReport('partial' if self.results else 'failed', 'invalid-response')
+            return None
+        except OSError, RuntimeError, ValueError:
+            logger.info('SubdomainCenter request failed')
+            return SourceExecutionReport('failed', 'transport-error')
 
     async def get_hostnames(self):
         return self.results
 
-    async def process(self, proxy=False):
+    async def process(self, proxy: bool = False) -> SourceExecutionReport | None:
         self.proxy = proxy
-        await self.do_search()
+        return await self.do_search()


### PR DESCRIPTION
Provider HTTP errors, rate limits, malformed responses, and interrupted collection could be recorded as successful empty results, making saved hostname comparisons overstate disappearance. DeHashed and Leak-Lookup also received undecoded JSON responses, and related requests in DeHashed, LeakIX, and Hudson Rock did not retain one provider session.

This change preserves failed and partial outcomes across ten adapters, decodes POST responses before collecting evidence, and keeps one session across each provider conversation. Earlier evidence survives later failures; valid empty and duplicate results remain successful. The existing transport, source identifiers, CLI, and persistence contracts are preserved.

The 4.11-to-5.0 migration guide also documents the released launcher, API, source, and resolver changes so existing automation can upgrade correctly.

### Validation

- Final publication head: `7d683b8ea2c0dbd39ec0a9e3c7565437f2e7bf97`, based directly on current upstream `dev` (`3b01d7f1`).
- `uv run pytest -q`: **2207 passed, 6 skipped, 41 deselected**. The run used the existing Python 3.14 development environment with `--no-sync --offline`; packaging regression included.
- Ruff lint, Ruff formatting, ty, and `git diff --check`: passed.
- Offline and loopback regressions cover provider outcomes, decoded JSON, pagination, cookies, retry/session ownership, cancellation, cleanup, and a persisted saved-run comparison.
- Independent Standards and Spec reviews: no remaining actionable findings.
- Bounded passive Shodan CT and SubdomainCenter smoke checks completed successfully. Collected data is excluded from the PR.

The 41 browser tests were not rerun locally because UI/API, browser tests, and dependencies are unchanged from upstream. Container and release validation workflows were not dispatched for this repair; full release validation remains necessary at the final release candidate. One existing Starlette/httpx deprecation warning remains. Authenticated providers were covered by deterministic tests, not live account checks.

Related tracking issues: NotoriousRebel/theHarvester#358, NotoriousRebel/theHarvester#359, NotoriousRebel/theHarvester#361, NotoriousRebel/theHarvester#365.
